### PR TITLE
Parsing of new log header parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,6 +662,12 @@
 												<td name='gyro_notch_hz'><label>Notch (Hz)</label><input type="number" step="0.01" min="0" max="999.00" /></td>
 												<td name="gyro_notch_cutoff"><label>Notch Cutoff (Hz)</label><input type="number" step="0.1" min="0" max="999.00" /></td>
 											</tr>
+                                            <tr>
+                                                <td</td>
+                                                <td</td>
+                                                <td name='gyro_notch_hz_2'><label>Notch (Hz)</label><input type="number" step="0.01" min="0" max="999.00" /></td>
+                                                <td name="gyro_notch_cutoff_2"><label>Notch Cutoff (Hz)</label><input type="number" step="0.1" min="0" max="999.00" /></td>
+                                            </tr>
 										</tbody>
 									</table>
 									<table class="parameter cf">

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -421,13 +421,11 @@ var FlightLogParser = function(logData) {
             case "pid_process_denom":
             case "pidController":
             case "yaw_p_limit":
-            case "yaw_lpf_hz":
             case "dterm_average_count":
             case "rollPitchItermResetRate":
             case "yawItermResetRate": 
             case "rollPitchItermIgnoreRate":
             case "yawItermIgnoreRate":
-            case "dterm_lpf_hz":
             case "dterm_differentiator":
             case "deltaMethod":
             case "dynamic_dterm_threshold":
@@ -436,7 +434,6 @@ var FlightLogParser = function(logData) {
             case "deadband":
             case "yaw_deadband":
             case "gyro_lpf":
-            case "gyro_lowpass_hz":
             case "acc_lpf_hz":
             case "acc_hardware":
             case "baro_hardware":
@@ -447,10 +444,6 @@ var FlightLogParser = function(logData) {
             case "superExpoYawMode":
             case "features":
             case "dynamic_pid":
-            case "gyro_notch_hz":
-            case "gyro_notch_cutoff":
-            case "dterm_notch_hz":
-            case "dterm_notch_cutoff":
             case "rc_interpolation":
             case "rc_interpolation_interval":
             case "unsynced_fast_pwm":
@@ -471,6 +464,28 @@ var FlightLogParser = function(logData) {
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
 
+            case "yaw_lpf_hz":
+            case "gyro_lowpass_hz":
+            case "dterm_notch_hz":
+            case "dterm_notch_cutoff":
+            case "dterm_lpf_hz":
+                if(that.sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && that.sysConfig.firmware == 3.0 && that.sysConfig.firmwarePatch >= 1) {
+                    that.sysConfig[fieldName] = parseInt(fieldValue, 10);
+                } else {
+                    that.sysConfig[fieldName] = parseInt(fieldValue, 10) / 100.0;
+                }
+            break;
+
+            case "gyro_notch_hz":
+            case "gyro_notch_cutoff":
+                if(that.sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && that.sysConfig.firmware == 3.0 && that.sysConfig.firmwarePatch >= 1) {
+                    that.sysConfig[fieldName] = parseCommaSeparatedString(fieldValue);
+                } else {
+                    that.sysConfig[fieldName] = parseInt(fieldValue, 10) / 100.0;
+                }
+            break;
+
+
             /**  Cleanflight Only log headers **/
             case "dterm_cut_hz":
             case "acc_cut_hz":
@@ -480,7 +495,7 @@ var FlightLogParser = function(logData) {
             
             case "superExpoFactor":
                 if(fieldValue.match(/.*,.*/)!=null) {
-                    var expoParams = parseCommaSeparatedIntegers(fieldValue);
+                    var expoParams = parseCommaSeparatedString(fieldValue);
                     that.sysConfig.superExpoFactor    = expoParams[0];
                     that.sysConfig.superExpoFactorYaw = expoParams[1];
 
@@ -500,22 +515,22 @@ var FlightLogParser = function(logData) {
             case "navrPID":
             case "levelPID":
             case "velPID":
-                that.sysConfig[fieldName] = parseCommaSeparatedIntegers(fieldValue);
+                that.sysConfig[fieldName] = parseCommaSeparatedString(fieldValue);
             break;
             case "magPID":
-                that.sysConfig.magPID = [parseInt(fieldValue, 10), null, null];
+                that.sysConfig.magPID = parseCommaSeparatedString(fieldValue,3); //[parseInt(fieldValue, 10), null, null];
             break;
             /* End of CSV packed values */
 
             case "vbatcellvoltage":
-                var vbatcellvoltageParams = parseCommaSeparatedIntegers(fieldValue);
+                var vbatcellvoltageParams = parseCommaSeparatedString(fieldValue);
 
                 that.sysConfig.vbatmincellvoltage = vbatcellvoltageParams[0];
                 that.sysConfig.vbatwarningcellvoltage = vbatcellvoltageParams[1];
                 that.sysConfig.vbatmaxcellvoltage = vbatcellvoltageParams[2];
             break;
             case "currentMeter":
-                var currentMeterParams = parseCommaSeparatedIntegers(fieldValue);
+                var currentMeterParams = parseCommaSeparatedString(fieldValue);
 
                 that.sysConfig.currentMeterOffset = currentMeterParams[0];
                 that.sysConfig.currentMeterScale = currentMeterParams[1];
@@ -603,10 +618,10 @@ var FlightLogParser = function(logData) {
 
                     switch (frameInfo) {
                         case "predictor":
-                            frameDef.predictor = parseCommaSeparatedIntegers(fieldValue);
+                            frameDef.predictor = parseCommaSeparatedString(fieldValue);
                         break;
                         case "encoding":
-                            frameDef.encoding = parseCommaSeparatedIntegers(fieldValue);
+                            frameDef.encoding = parseCommaSeparatedString(fieldValue);
                         break;
                         case "name":
                             frameDef.name = translateLegacyFieldNames(fieldValue.split(","));
@@ -621,7 +636,7 @@ var FlightLogParser = function(logData) {
                             frameDef.signed.length = frameDef.count;
                         break;
                         case "signed":
-                            frameDef.signed = parseCommaSeparatedIntegers(fieldValue);
+                            frameDef.signed = parseCommaSeparatedString(fieldValue);
                         break;
                         default:
                             console.log("Saw unsupported field header \"" + fieldName + "\"");

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -231,30 +231,43 @@ try {
 		var offset = 0;
 		if (mouseFrequency !=null) drawMarkerLine(mouseFrequency,  PLOTTED_BLACKBOX_RATE, '', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(0,255,0,0.50)", 3);
 		offset++; // make some space!
-		if(flightLog.getSysConfig().gyro_lowpass_hz!=null) 		drawMarkerLine(flightLog.getSysConfig().gyro_lowpass_hz/100.0,  PLOTTED_BLACKBOX_RATE, 'GYRO LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+		if(flightLog.getSysConfig().gyro_lowpass_hz!=null) 		drawMarkerLine(flightLog.getSysConfig().gyro_lowpass_hz,  PLOTTED_BLACKBOX_RATE, 'GYRO LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
 		if(flightLog.getSysConfig().gyro_notch_hz!=null && flightLog.getSysConfig().gyro_notch_cutoff!=null ) {
-			if(flightLog.getSysConfig().gyro_notch_hz > 0 && flightLog.getSysConfig().gyro_notch_cutoff > 0) {
+			if(flightLog.getSysConfig().gyro_notch_hz.length > 0) { //there are multiple gyro notch filters
 				var gradient = canvasCtx.createLinearGradient(0,0,0,(HEIGHT));
 				gradient.addColorStop(1,   'rgba(128,255,128,0.10)');
 				gradient.addColorStop(0,   'rgba(128,255,128,0.35)');
-	 			drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz/100.0,  PLOTTED_BLACKBOX_RATE, null, WIDTH, HEIGHT, (15*offset) + MARGIN, gradient, (flightLog.getSysConfig().gyro_notch_hz - flightLog.getSysConfig().gyro_notch_cutoff)/100.0);
-	 			drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz/100.0,  PLOTTED_BLACKBOX_RATE, 'GYRO notch center', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)"); // highlight the center
-				drawMarkerLine(flightLog.getSysConfig().gyro_notch_cutoff/100.0,  PLOTTED_BLACKBOX_RATE, 'GYRO notch cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+				for(var i=0; i<flightLog.getSysConfig().gyro_notch_hz.length; i++) {
+					if(flightLog.getSysConfig().gyro_notch_hz[i] > 0 && flightLog.getSysConfig().gyro_notch_cutoff[i] > 0) {
+						drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz[i],  PLOTTED_BLACKBOX_RATE, null, WIDTH, HEIGHT, (15*offset) + MARGIN, gradient, (flightLog.getSysConfig().gyro_notch_hz[i] - flightLog.getSysConfig().gyro_notch_cutoff[i]));
+						drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz[i],  PLOTTED_BLACKBOX_RATE, 'GYRO notch center', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)"); // highlight the center
+						drawMarkerLine(flightLog.getSysConfig().gyro_notch_cutoff[i],  PLOTTED_BLACKBOX_RATE, 'GYRO notch cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+					}
+				}
+			} else { // only a single gyro notch to display
+				if(flightLog.getSysConfig().gyro_notch_hz > 0 && flightLog.getSysConfig().gyro_notch_cutoff > 0) {
+					var gradient = canvasCtx.createLinearGradient(0,0,0,(HEIGHT));
+					gradient.addColorStop(1,   'rgba(128,255,128,0.10)');
+					gradient.addColorStop(0,   'rgba(128,255,128,0.35)');
+					drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz,  PLOTTED_BLACKBOX_RATE, null, WIDTH, HEIGHT, (15*offset) + MARGIN, gradient, (flightLog.getSysConfig().gyro_notch_hz - flightLog.getSysConfig().gyro_notch_cutoff));
+					drawMarkerLine(flightLog.getSysConfig().gyro_notch_hz,  PLOTTED_BLACKBOX_RATE, 'GYRO notch center', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)"); // highlight the center
+					drawMarkerLine(flightLog.getSysConfig().gyro_notch_cutoff,  PLOTTED_BLACKBOX_RATE, 'GYRO notch cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+				}
 			}
 		}
 		offset++; // make some space!
 		if(dataBuffer.fieldName.match(/(.*yaw.*)/i)!=null) {
-			if(flightLog.getSysConfig().yaw_lpf_hz!=null)      		drawMarkerLine(flightLog.getSysConfig().yaw_lpf_hz/100.0,  PLOTTED_BLACKBOX_RATE, 'YAW LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
+			if(flightLog.getSysConfig().yaw_lpf_hz!=null)      		drawMarkerLine(flightLog.getSysConfig().yaw_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'YAW LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
 		} else {
-			if(flightLog.getSysConfig().dterm_lpf_hz!=null)    		drawMarkerLine(flightLog.getSysConfig().dterm_lpf_hz/100.0,  PLOTTED_BLACKBOX_RATE, 'D-TERM LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
+			if(flightLog.getSysConfig().dterm_lpf_hz!=null)    		drawMarkerLine(flightLog.getSysConfig().dterm_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'D-TERM LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
 			if(flightLog.getSysConfig().dterm_notch_hz!=null && flightLog.getSysConfig().dterm_notch_cutoff!=null ) {
 				if(flightLog.getSysConfig().dterm_notch_hz > 0 && flightLog.getSysConfig().dterm_notch_cutoff > 0) {
 					var gradient = canvasCtx.createLinearGradient(0,0,0,(HEIGHT));
 					gradient.addColorStop(1,   'rgba(128,128,255,0.10)');
 					gradient.addColorStop(0,   'rgba(128,128,255,0.35)');
-					drawMarkerLine(flightLog.getSysConfig().dterm_notch_hz/100.0,  PLOTTED_BLACKBOX_RATE, null, WIDTH, HEIGHT, (15*offset) + MARGIN, gradient, (flightLog.getSysConfig().dterm_notch_hz - flightLog.getSysConfig().dterm_notch_cutoff)/100.0);
-					drawMarkerLine(flightLog.getSysConfig().dterm_notch_hz/100.0,  PLOTTED_BLACKBOX_RATE, 'D-TERM notch center', WIDTH, HEIGHT, (15*offset++) + MARGIN); // highlight the center
-					drawMarkerLine(flightLog.getSysConfig().dterm_notch_cutoff/100.0,  PLOTTED_BLACKBOX_RATE, 'D-TERM notch cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
+					drawMarkerLine(flightLog.getSysConfig().dterm_notch_hz,  PLOTTED_BLACKBOX_RATE, null, WIDTH, HEIGHT, (15*offset) + MARGIN, gradient, (flightLog.getSysConfig().dterm_notch_hz - flightLog.getSysConfig().dterm_notch_cutoff));
+					drawMarkerLine(flightLog.getSysConfig().dterm_notch_hz,  PLOTTED_BLACKBOX_RATE, 'D-TERM notch center', WIDTH, HEIGHT, (15*offset++) + MARGIN); // highlight the center
+					drawMarkerLine(flightLog.getSysConfig().dterm_notch_cutoff,  PLOTTED_BLACKBOX_RATE, 'D-TERM notch cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
 				}
 			}
 		}

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -14,41 +14,43 @@ function HeaderDialog(dialog, onSave) {
 	**/
 
 	var parameterVersion = [
-            {name:'dterm_average_count'	    	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:0.0, max:2.6},
-            {name:'rc_smoothing'			    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:0.0, max:2.8},
-			{name:'dynamic_pterm'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.6, max:2.7},
-			{name:'iterm_reset_offset'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.6, max:2.7},
-			{name:'superExpoFactor'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.6, max:2.7},
-			{name:'superExpoFactorYaw'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.7, max:2.7},
-			{name:'superExpoYawMode'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.7, max:2.7},
-            {name:'rollPitchItermResetRate'		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.7, max:2.7},
-            {name:'yawItermResetRate'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.7, max:2.7},
-			{name:'dynamic_pid'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.8, max:2.9},
-			{name:'rcYawRate'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.8, max:999.9},
-			{name:'airmode_activate_throttle'	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.8, max:999.9},
-            {name:'rollPitchItermIgnoreRate'	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.8, max:999.9},
-            {name:'yawItermIgnoreRate'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:2.8, max:999.9},
-            {name:'gyro_notch_hz'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'gyro_notch_cutoff'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'dterm_notch_hz'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'dterm_notch_cutoff'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'rc_interpolation'   			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'rc_interpolation_interval'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'gyro_sync_denom'			    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'pid_process_denom'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'unsynced_fast_pwm'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'fast_pwm_protocol'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'motor_pwm_rate'    			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-			{name:'serialrx_provider'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'dterm_filter_type'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'pidAtMinThrottle'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'itermThrottleGain'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'ptermSRateWeight'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'dtermSetpointWeight'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'yawRateAccelLimit'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'rateAccelLimit'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'gyro_soft_type'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
-            {name:'debug_mode'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:3.0, max:999.9},
+            {name:'dterm_average_count'	    	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'0.0.0', max:'2.6.9'},
+            {name:'rc_smoothing'			    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'0.0.0', max:'2.8.9'},
+			{name:'dynamic_pterm'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.6.0', max:'2.7.9'},
+			{name:'iterm_reset_offset'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.6.0', max:'2.7.9'},
+			{name:'superExpoFactor'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.6.0', max:'2.7.9'},
+			{name:'superExpoFactorYaw'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.7.0', max:'2.7.9'},
+			{name:'superExpoYawMode'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.7.0', max:'2.7.9'},
+            {name:'rollPitchItermResetRate'		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.7.0', max:'2.7.9'},
+            {name:'yawItermResetRate'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.7.0', max:'2.7.9'},
+			{name:'dynamic_pid'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'2.9.9'},
+			{name:'rcYawRate'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
+			{name:'airmode_activate_throttle'	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
+            {name:'rollPitchItermIgnoreRate'	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
+            {name:'yawItermIgnoreRate'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
+            {name:'gyro_notch_hz'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'gyro_notch_cutoff'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'dterm_notch_hz'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'dterm_notch_cutoff'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'rc_interpolation'   			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'rc_interpolation_interval'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'gyro_sync_denom'			    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'pid_process_denom'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'unsynced_fast_pwm'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'fast_pwm_protocol'    		, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'motor_pwm_rate'    			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+			{name:'serialrx_provider'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'dterm_filter_type'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'pidAtMinThrottle'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'itermThrottleGain'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'ptermSRateWeight'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'dtermSetpointWeight'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'yawRateAccelLimit'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'rateAccelLimit'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'gyro_soft_type'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'debug_mode'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+			{name:'gyro_notch_hz_2'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'},
+			{name:'gyro_notch_cutoff_2'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'}
 
 	];
 
@@ -56,7 +58,12 @@ function HeaderDialog(dialog, onSave) {
 
 		for(var i=0; i<parameterVersion.length; i++) {
 			if (parameterVersion[i].name == name && parameterVersion[i].type == activeSysConfig.firmwareType) {
-				return ((activeSysConfig.firmware >= parameterVersion[i].min) && (activeSysConfig.firmware <= parameterVersion[i].max));
+				var matches = parameterVersion[i].min.match(/(\d+)\.(\d+)(?:\.(\d+))/); // extract the firmware version and patch
+				var min = parseFloat(matches[1] + '.' + matches[2]) + matches[3]/10000;
+				matches = parameterVersion[i].max.match(/(\d+)\.(\d+)(?:\.(\d+))/);
+				var max = parseFloat(matches[1] + '.' + matches[2]) + matches[3]/10000;
+				var current = activeSysConfig.firmware + activeSysConfig.firmwarePatch/10000;
+				return ((current >= min) && (current <= max));
 			}
 		}
 		return true; // default is to show parameter
@@ -409,30 +416,41 @@ function HeaderDialog(dialog, onSave) {
         setParameter('gyro_sync_denom'			,sysConfig.gyro_sync_denom,0);
         setParameter('pid_process_denom'		,sysConfig.pid_process_denom,0);
         setParameter('yaw_p_limit'				,sysConfig.yaw_p_limit,0);
-        setParameter('yaw_lpf_hz'				,sysConfig.yaw_lpf_hz,2);
         setParameter('dterm_average_count'		,sysConfig.dterm_average_count,0);
     	renderSelect('dynamic_pterm'			,sysConfig.dynamic_pterm, OFF_ON);
         setParameter('rollPitchItermResetRate'	,sysConfig.rollPitchItermResetRate,0);
         setParameter('yawItermResetRate'		,sysConfig.yawItermResetRate,0);
         setParameter('rollPitchItermIgnoreRate'	,sysConfig.rollPitchItermIgnoreRate,0);
         setParameter('yawItermIgnoreRate'		,sysConfig.yawItermIgnoreRate,0);
-        setParameter('dterm_lpf_hz'				,sysConfig.dterm_lpf_hz,2);
         setParameter('dterm_cut_hz'				,sysConfig.dterm_cut_hz,2);
         setParameter('iterm_reset_offset'		,sysConfig.iterm_reset_offset,0);
         setParameter('deadband'					,sysConfig.deadband,0);
         setParameter('yaw_deadband'				,sysConfig.yaw_deadband,0);
     	renderSelect('gyro_lpf'			    	,sysConfig.gyro_lpf, GYRO_LPF);
-        setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,2);
         setParameter('acc_lpf_hz'				,sysConfig.acc_lpf_hz,2);
         setParameter('acc_cut_hz'				,sysConfig.acc_cut_hz,2);
 	    setParameter('airmode_activate_throttle',sysConfig.airmode_activate_throttle, 0);
 	    renderSelect('serialrx_provider'		,sysConfig.serialrx_provider, SERIALRX_PROVIDER);
 	    renderSelect('superExpoYawMode'		    ,sysConfig.superExpoYawMode, SUPER_EXPO_YAW);
     	renderSelect('dynamic_pid'				,sysConfig.dynamic_pid, OFF_ON);
-        setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz,2);
-        setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff,2);
-        setParameter('dterm_notch_hz'			,sysConfig.dterm_notch_hz,2);
-        setParameter('dterm_notch_cutoff'		,sysConfig.dterm_notch_cutoff,2);
+
+		if(sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && sysConfig.firmware == 3.0 && sysConfig.firmwarePatch >= 1) {
+			setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz[0],0);
+			setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff[0],0);
+			setParameter('gyro_notch_hz_2'			,sysConfig.gyro_notch_hz[1],0);
+			setParameter('gyro_notch_cutoff_2'		,sysConfig.gyro_notch_cutoff[1],0);
+		} else {
+			setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz, 0);
+			setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff, 0);
+			setParameter('gyro_notch_hz_2'			,0,0); // this parameter does not exist in earlier versions
+			setParameter('gyro_notch_cutoff_2'		,0,0); // this parameter does not exist in earlier versions
+		}
+		setParameter('dterm_notch_hz'			,sysConfig.dterm_notch_hz,0);
+		setParameter('dterm_notch_cutoff'		,sysConfig.dterm_notch_cutoff,0);
+		setParameter('dterm_lpf_hz'				,sysConfig.dterm_lpf_hz,0);
+		setParameter('yaw_lpf_hz'				,sysConfig.yaw_lpf_hz,0);
+		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
+
     	renderSelect('rc_interpolation'		    ,sysConfig.rc_interpolation, RC_INTERPOLATION);
         setParameter('rc_interpolation_interval',sysConfig.rc_interpolation_interval,0);
     	renderSelect('unsynced_fast_pwm'		,sysConfig.unsynced_fast_pwm, MOTOR_SYNC);

--- a/js/tools.js
+++ b/js/tools.js
@@ -92,16 +92,41 @@ function memmem(haystack, needle, startIndex) {
     return -1;
 }
 
-function parseCommaSeparatedIntegers(string) {
-    var 
+function parseCommaSeparatedString(string, length) {
+    /***
+     * Parse a comma separated string for individual values.
+     *
+     * string               is the comma separated string to parse
+     * length (optional)    the returned array will be forced to be this long; extra fields will be discarded,
+     *                      missing fields will be padded. if length is not specified, then array will be auto
+     *                      sized.
+     *
+     * returns              if the string does not contain a comma, then the first integer/float/string is returned
+     *                      else an Array is returned containing all the values up to the length (if specified)
+     ***/
+    var
         parts = string.split(","),
-        result = new Array(parts.length);
-    
-    for (var i = 0; i < parts.length; i++) {
-        result[i] = parseInt(parts[i], 10);
-    }
+        result, value;
 
-    return result;
+    length = length || parts.length; // we can force a length if we like
+
+    if (length < 2) {
+        // this is not actually a list, just return the value
+        value = (parts.indexOf('.'))?parseFloat(parts):parseInt(parts, 10);
+        return (isNaN(value) ? string : value);
+    } else {
+        // this really is a list; build an array
+        result = new Array(length);
+        for (var i = 0; i < length; i++) {
+            if(i<parts.length) {
+                value = (parts[i].indexOf('.'))?parseFloat(parts[i]):parseInt(parts[i], 10);
+                result[i] = isNaN(value) ? parts[i] : value;
+            } else {
+                result[i] = null;
+            }
+        }
+        return result;
+    }
 }
 
 /**


### PR DESCRIPTION
This modification is coordinated with BF Pull request [https://github.com/betaflight/betaflight/pull/1255](url)

Modify log parser to retrieve new second gyro-notch parameter and display it on the Log Header dialog and analyser.

1. Add ability to auto-detect CSV separated values in the header and to
process them properly.
1. Display new parameters for second gyro notch filter.
1. Adjust analyser view to show second gyro notch if present.
1. Modify log parsing to automatically remove the x100 scaling from Hz
values.
