### PR TITLE
Fix Motor Scaling on Blackbox Log when D-Shot is used

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -51,7 +51,7 @@
         <li>Fix Issue #36; viewer was not parsing version number correctly for filter scaling. Refactored functions to use library semver.</li>
         <li>UI Overhall; improved handling for smaller screens.</li>
         <li>Changelog added to Welcome screen</li>
-        <li>Add DShot to header dialog</li>
+        <li>Add DShot to header dialog and scale motors independently to rcCommand[Throttle]</li>
         <li>Update to gyro scale for BF 3.1.0; logged data is now scaled in the flight controller.</li>
     </ul>
 

--- a/index.html
+++ b/index.html
@@ -1041,7 +1041,16 @@
 												</tr>
 											</tbody>
 										</table>
-									</div>
+                                        <table class="parameter cf">
+                                            <tbody>
+                                            <tr>
+                                                <td name="digitalIdleOffset"><label>D-Shot Offset (%)</label><input type="number" step="0.01" min="0" max="1" /></td>
+                                                <td name="motorOutputLow"><label>D-Shot Motor Low</label><input type="number" step="10" min="0" max="2047" /></td>
+                                                <td name="motorOutputHigh"><label>D-Shot Motor High</label><input type="number" step="10" min="0" max="2047" /></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
 								</div>
 								<div class="gui_box grey voltagecurrent">
 									<div class="gui_box_titlebar">

--- a/js/craft_2d.js
+++ b/js/craft_2d.js
@@ -227,7 +227,7 @@ function Craft2D(flightLog, canvas, propColors) {
     
                 canvasContext.moveTo(0, 0);
                 canvasContext.arc(0, 0, bladeRadius, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 
-                        * Math.max(motorValue - sysConfig.minthrottle, 0) / (sysConfig.maxthrottle - sysConfig.minthrottle), false);
+                        * Math.max(motorValue - sysConfig.motorOutput[0], 0) / (sysConfig.motorOutput[1] - sysConfig.motorOutput[0]), false);
                 
                 canvasContext.fill();
     

--- a/js/craft_3d.js
+++ b/js/craft_3d.js
@@ -287,7 +287,7 @@ function Craft3D(flightLog, canvas, propColors) {
                 propShells[i].remove(props[i]);
             
             var 
-                throttlePos = Math.min(Math.max(frame[frameFieldIndexes["motor[" + motorOrder[i] + "]"]] - sysInfo.minthrottle, 0) / (sysInfo.maxthrottle - sysInfo.minthrottle), 1.0),
+                throttlePos = Math.min(Math.max(frame[frameFieldIndexes["motor[" + motorOrder[i] + "]"]] - sysInfo.motorOutput[0], 0) / (sysInfo.motorOutput[1] - sysInfo.motorOutput[0]), 1.0),
                 propLevel = Math.round(throttlePos * (NUM_PROP_LEVELS - 1)),
                 geometry = propGeometry[propLevel],
                 prop = new THREE.Mesh(geometry, propMaterials[motorOrder[i]]);

--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -1080,6 +1080,11 @@ FlightLog.prototype.rcCommandRawToThrottle = function(value) {
     return Math.min(Math.max(((value - this.getSysConfig().minthrottle) / (this.getSysConfig().maxthrottle - this.getSysConfig().minthrottle)) * 100.0, 0.0),100.0);
 };
 
+FlightLog.prototype.rcMotorRawToPct = function(value) {
+    // Motor displayed as percentage
+    return Math.min(Math.max(((value - this.getSysConfig().motorOutput[0]) / (this.getSysConfig().motorOutput[1] - this.getSysConfig().motorOutput[0])) * 100.0, 0.0),100.0);
+};
+
 FlightLog.prototype.getPIDPercentage = function(value) {
     // PID components and outputs are displayed as percentage (raw value is 0-1000)
     return (value / 10.0);

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -257,7 +257,8 @@ function FlightLogFieldPresenter() {
                 return Math.round(flightLog.rcCommandRawToDegreesPerSecond(value,2), currentFlightMode) + " deg/s";
 
             case 'rcCommand[3]':
-            case 'motor[0]':            
+                return Math.round(flightLog.rcCommandRawToThrottle(value)) + " %";
+            case 'motor[0]':
             case 'motor[1]':            
             case 'motor[2]':            
             case 'motor[3]':            
@@ -265,7 +266,7 @@ function FlightLogFieldPresenter() {
             case 'motor[5]':            
             case 'motor[6]':            
             case 'motor[7]':            
-                return Math.round(flightLog.rcCommandRawToThrottle(value)) + " %";
+                return Math.round(flightLog.rcMotorRawToPct(value)) + " %";
 
             case 'rcCommands[0]':
             case 'rcCommands[1]':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -233,9 +233,9 @@ GraphConfig.load = function(config) {
         try {
             if (fieldName.match(/^motor\[/)) {
                 return {
-                    offset: -(sysConfig.maxthrottle + sysConfig.minthrottle) / 2,
+                    offset: -(sysConfig.motorOutput[1] + sysConfig.motorOutput[0]) / 2,
                     power: 1.0,
-                    inputRange: (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
+                    inputRange: (sysConfig.motorOutput[1] - sysConfig.motorOutput[0]) / 2,
                     outputRange: 1.0
                 };
             } else if (fieldName.match(/^servo\[/)) {
@@ -362,9 +362,9 @@ GraphConfig.load = function(config) {
                         };
                     case 'MIXER':
                         return {
-                            offset: -(sysConfig.maxthrottle + sysConfig.minthrottle) / 2,
+                            offset: -(sysConfig.motorOutput[1] + sysConfig.motorOutput[0]) / 2,
                             power: 1.0,
-                            inputRange: (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
+                            inputRange: (sysConfig.motorOutput[1] - sysConfig.motorOutput[0]) / 2,
                             outputRange: 1.0
                         };
                     case 'BATTERY':

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -51,7 +51,10 @@ function HeaderDialog(dialog, onSave) {
             {name:'debug_mode'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
 			{name:'gyro_notch_hz_2'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'},
 			{name:'gyro_notch_cutoff_2'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'},
-			{name:'pidController'		    	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'0.0.0', max:'3.0.1'}
+			{name:'pidController'		    	, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'0.0.0', max:'3.0.1'},
+			{name:'motorOutputLow'		        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.1.0', max:'999.9.9'},
+			{name:'motorOutputHigh'		        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.1.0', max:'999.9.9'},
+			{name:'digitalIdleOffset'	        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.1.0', max:'999.9.9'}
 
 	];
 
@@ -460,6 +463,10 @@ function HeaderDialog(dialog, onSave) {
         setParameter('rateAccelLimit'		    ,sysConfig.rateAccelLimit,0);
         renderSelect('gyro_soft_type'			,sysConfig.gyro_soft_type, FILTER_TYPE);
         renderSelect('debug_mode'				,sysConfig.debug_mode, DEBUG_MODE);
+		setParameter('motorOutputLow'			,sysConfig.motorOutput[0],0);
+		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1],0);
+		setParameter('digitalIdleOffset'		,sysConfig.digitalIdleOffset,2);
+
 		/* Packed Flags */
 
         builtFeaturesList(sysConfig);


### PR DESCRIPTION
This modification should allow blackbox logging of motor outputs based on the range of the ESC signals (originally this matched minthrottle to maxthrottle, but with the release of D-Shot, this has been separated to handle the 0048 to 2047 digital range. I have also added the 'digitalIdleOffset' parameter to the header.

This is to resolve issue #39 and requires separate modification to the flight controller pull request #1876 in betaflight.
