### PR TITLE
Shorter error output if no event log

### DIFF
--- a/js/flightlog_index.js
+++ b/js/flightlog_index.js
@@ -193,9 +193,9 @@ function FlightLogIndex(logData) {
             // Did we not find any events in this log?
             if (intraIndex.minTime === false) {
                 if (sawEndMarker) {
-                    intraIndex.error = "Logging was paused, no data recorded";
+                    intraIndex.error = "Logging paused, no data";
                 } else {
-                    intraIndex.error = "Log is truncated, contains no data";
+                    intraIndex.error = "Log truncated, no data";
                 }
             }
         

--- a/js/main.js
+++ b/js/main.js
@@ -305,7 +305,7 @@ function BlackboxLogViewer() {
             error = flightLog.getLogError(index);
             
             if (error) {
-                logLabel = "Error: " + error;
+                logLabel = error;
             } else {
                 logLabel = formatTime(flightLog.getMinTime(index) / 1000, false) 
                     + " - " + formatTime(flightLog.getMaxTime(index) / 1000 , false)


### PR DESCRIPTION
The legend is unnecessarily widened ... this pr makes an shorter error output if no event logs ... 

before:
![before](https://cloud.githubusercontent.com/assets/20139767/21577569/053097ac-cf60-11e6-875f-cea6099f4c03.jpg)

and after:
![after](https://cloud.githubusercontent.com/assets/20139767/21577572/0ee26820-cf60-11e6-909e-c6fa924e0f18.jpg)
