### PR TITLE
Correct spelling on Export Workspaces tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                 <div class="navbar-form navbar-right" role="form">
                     <div class="btn-group">
                         <a class="btn btn-default btn-video-export" data-toggle="tooltip" title="Export your vide and chart setup to file"> Export video...</a>
-                        <a class="btn btn-primary btn-workspaces-export" data-toggle="tooltip" title="Export your workspace confifurations to file"> Export Workspaces...</a>
+                        <a class="btn btn-primary btn-workspaces-export" data-toggle="tooltip" title="Export your workspace configurations to file"> Export Workspaces...</a>
                         <span class="btn btn-primary btn-file" data-toggle="tooltip" title="Open another log file, video file, exported workspace file or configuration dump file"> Open log file/video <input type="file" class="file-open" multiple></span>
                         <button type="button" class="btn btn-default view-zoom-in" data-toggle="tooltip" title="Zoom In Window" style="display: none;">
                             <span class="glyphicon glyphicon-zoom-in"></span>


### PR DESCRIPTION
Update index.html with corrected spelling of "configurations" on the tooltip for the "Export Workspaces" button.