### PR TITLE
Detect correctly some vars for CleanFlight >= 2.x

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -255,7 +255,8 @@ function FlightLog(logData) {
             found = false;
 
         var refVoltage;
-        if(sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(sysConfig.firmwareVersion, '3.1.0')) {
+        if((sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(sysConfig.firmwareVersion, '3.1.0')) || 
+           (sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(sysConfig.firmwareVersion, '2.0.0'))) {
             refVoltage = sysConfig.vbatref;
         } else {
             refVoltage = that.vbatADCToMillivolts(sysConfig.vbatref) / 100;
@@ -967,7 +968,7 @@ FlightLog.prototype.rcCommandRawToDegreesPerSecond = function(value, axis, curre
 
     var sysConfig = this.getSysConfig();
 
-    if(sysConfig.firmware >= 3.0) {
+    if(sysConfig.firmware >= 3.0 || (sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && sysConfig.firmware >= 2.0)) {
 
         const RC_RATE_INCREMENTAL = 14.54;
         const RC_EXPO_POWER = 3;
@@ -1018,7 +1019,7 @@ FlightLog.prototype.rcCommandRawToDegreesPerSecond = function(value, axis, curre
         return calculateSetpointRate(axis, value);
 
     }
-    else if(sysConfig.firmware >= 2.8) {
+    else if(sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && sysConfig.firmware >= 2.8) {
 
             var that = this;
 
@@ -1098,7 +1099,8 @@ FlightLog.prototype.getPIDPercentage = function(value) {
 
 
 FlightLog.prototype.getReferenceVoltageMillivolts = function() {
-    if(this.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(this.getSysConfig().firmwareVersion, '3.1.0')) {
+    if((this.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(this.getSysConfig().firmwareVersion, '3.1.0')) ||
+       (this.getSysConfig().firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(this.getSysConfig().firmwareVersion, '2.0.0'))) {
         return this.getSysConfig().vbatref * 100;
     } else {
         return this.vbatADCToMillivolts(this.getSysConfig().vbatref);

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -314,14 +314,16 @@ function FlightLogFieldPresenter() {
                 return flightLog.accRawToGs(value).toFixed(2) + "g";
             
             case 'vbatLatest':
-                if(flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) {
+                if((flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) ||
+                   (flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '2.0.0'))) {
                     return (value / 10).toFixed(2) + "V" + ", " + (value / 10 / flightLog.getNumCellsEstimate()).toFixed(2) + "V/cell";
                 } else {
                     return (flightLog.vbatADCToMillivolts(value) / 1000).toFixed(2) + "V" + ", " + (flightLog.vbatADCToMillivolts(value) / 1000 / flightLog.getNumCellsEstimate()).toFixed(2) + "V/cell";
                 }
 
             case 'amperageLatest':
-                if(flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) {
+                if((flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) ||
+                   (flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '2.0.0'))) {
                     return (value / 10).toFixed(2) + "A" + ", " + (value / 10 / flightLog.getNumMotors()).toFixed(2) + "A/motor";
                 } else {
                     return (flightLog.amperageADCToMillivolts(value) / 1000).toFixed(2) + "A" + ", " + (flightLog.amperageADCToMillivolts(value) / 1000 / flightLog.getNumMotors()).toFixed(2) + "A/motor";

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -393,7 +393,9 @@ function HeaderDialog(dialog, onSave) {
 				});
 		}
 
-		if(sysConfig.firmware >= 3.0 && sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT) {
+		if((sysConfig.firmware >= 3.0 && sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT) ||
+		   (sysConfig.firmware >= 2.0 && sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT)) {
+		   
 			PID_CONTROLLER_TYPE = ([
 					'LEGACY',
 					'BETAFLIGHT'


### PR DESCRIPTION
This solves this issue: https://github.com/cleanflight/cleanflight/issues/2708

Some vars are not detected correctly for CleanFlight 2.x. They are detected like BetaFlight 2.x and CleanFlight 2.x uses the same as BetaFlight 3.1.x

