### PR TITLE
Adjust ID flight modes

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -42,6 +42,7 @@ var
             'ANGLE',
             'HORIZON',
             'BARO',
+            'VARIO',
             'MAG',
             'HEADFREE',
             'HEADADJ',
@@ -66,8 +67,7 @@ var
             'BLACKBOX',
             'FAILSAFE',
             'AIRMODE',
-            'SUPEREXPO',
-            '3DDISABLESWITCH',
+            'VTX',
             'CHECKBOX_ITEM_COUNT'
     ]),
 


### PR DESCRIPTION
This solves https://github.com/betaflight/blackbox-log-viewer/issues/60

This is a first approach to the solution of the issue. The Flight Modes in BetaFlight now have a fixed number:
```
static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
    { "ARM",       BOXARM,        0 },
    { "ANGLE",     BOXANGLE,      1 },
    { "HORIZON",   BOXHORIZON,    2 },
    { "BARO",      BOXBARO,       3 },
  //{ "VARIO",     BOXVARIO,      4 },
    { "MAG",       BOXMAG,        5 },
    { "HEADFREE",  BOXHEADFREE,   6 },
    { "HEADADJ",   BOXHEADADJ,    7 },
    { "CAMSTAB",   BOXCAMSTAB,    8 },
    { "CAMTRIG",   BOXCAMTRIG,    9 },
    { "GPS HOME",  BOXGPSHOME,   10 },
    { "GPS HOLD",  BOXGPSHOLD,   11 },
    { "PASSTHRU",  BOXPASSTHRU,  12 },
    { "BEEPER",    BOXBEEPERON,  13 },
    { "LEDMAX",    BOXLEDMAX,    14 },
    { "LEDLOW",    BOXLEDLOW,    15 },
    { "LLIGHTS",   BOXLLIGHTS,   16 },
    { "CALIB",     BOXCALIB,     17 },
    { "GOVERNOR",  BOXGOV,       18 },
    { "OSD SW",    BOXOSD,       19 },
    { "TELEMETRY", BOXTELEMETRY, 20 },
    { "GTUNE",     BOXGTUNE,     21 },
    { "SONAR",     BOXSONAR,     22 },
    { "SERVO1",    BOXSERVO1,    23 },
    { "SERVO2",    BOXSERVO2,    24 },
    { "SERVO3",    BOXSERVO3,    25 },
    { "BLACKBOX",  BOXBLACKBOX,  26 },
    { "FAILSAFE",  BOXFAILSAFE,  27 },
    { "AIR MODE",  BOXAIRMODE,   28 },
    { "VTX",       BOXVTX,       29 },
};
```
so the VARIO mode that disappear must exist or at least the MAG must continue being the number 5 in the list. In the actual blackbox viewer the MAG is number 4 and the others modes since then have a number less.
I open this PR to talk about the solution and look for the best approach.
The actual code of the PR solves the issue but I don't know if it can break older versions or not.