### PR TITLE
Fix chromeapp not starting (title not supported)

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,8 +7,7 @@ function startApplication() {
         innerBounds : {
             'width' : 1340,
             'height' : 920
-        },
-        title: 'Betaflight - Blackbox Explorer'
+        }
     });
 }
 


### PR DESCRIPTION
The chromeapps does not start when the title is defined.

The nw apps use the `<title>` tag of the html by default, that in this case is correct, or the `name` in the `package.json` if the tag is empty.