### PR TITLE
Fix taskbar icon in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "gulp": "gulp"
   },
   "window": {
-    "show": true
+    "show": true,
+    "icon": "images/bf_icon_128.png"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In windows, the icon in the taskbar is the default one. This PR solves it in the same manner as it was done in the betaflight configurator