### PR TITLE
Update graph_spectrum.js

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -62,7 +62,7 @@ try {
     if (sysConfig.pid_process_denom != null) {
 		pidRate = gyroRate / sysConfig.pid_process_denom;
 	}
-	var blackBoxRate = 2 * pidRate * (sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom']);
+	var blackBoxRate = pidRate * (sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom']);
 	var dataBuffer = {
 			fieldIndex: 0,
 			curve: 0,


### PR DESCRIPTION
Removed pidRate multiplication times two.  It was reporting false motor noise peak results.