### PR TITLE
Fix blackboxrate depending on pidrate/gyrorate factor

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -62,7 +62,7 @@ try {
     if (sysConfig.pid_process_denom != null) {
 		pidRate = gyroRate / sysConfig.pid_process_denom;
 	}
-	var blackBoxRate = 2 * pidRate * (sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom']);
+	var blackBoxRate = (gyroRate/pidRate) * pidRate * (sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom']);
 	var dataBuffer = {
 			fieldIndex: 0,
 			curve: 0,


### PR DESCRIPTION
Fixed blackbox rate calculation depending on pidrate and gyrorate (e.g. 8k/4k).

When running on gyro/pid rate on 8k/4k and 1k blackbox rate, the blackbox-log-viewer calculated a blackbox rate of 0.250k instead of 0.5k. This resulted in the analyses graph to only show up to 250Hz instead of 500Hz.