### PR TITLE
Add parsing and header display for gyro hardware lpf settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1228,6 +1228,33 @@
                                     </table>
                                 </div>
                             </div>
+                            <div class="gui_box grey debug">
+                                <div class="gui_box_titlebar">
+                                    <div class="spacer_box_title">Gyro Hardware Lowpass Settings</div>
+                                </div>
+                                <div class="spacer_box">
+                                    <table class="parameter cf">
+                                        <tbody>
+                                            <tr>
+                                                <td name='gyro_hardware_lpf'>
+                                                    <label>Gyro Hardware LPF</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td name='gyro_32khz_hardware_lpf'>
+                                                    <label>Gyro 32KHz Hardware LPF</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
                         </div>
                         <div class="cf_column half right">
                             <div class="spacer_left">

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -207,6 +207,17 @@ var
             "EXPERIMENTAL"
     ]),
 
+    GYRO_HARDWARE_LPF = makeReadOnly([
+            "NORMAL",
+            "EXPERIMENTAL",
+            "1KHZ_SAMPLING"
+    ]),
+
+    GYRO_32KHZ_HARDWARE_LPF = makeReadOnly([
+            "NORMAL",
+            "EXPERIMENTAL"
+    ]),
+
     ACC_HARDWARE = makeReadOnly([
 	        "AUTO",
 	        "NONE",

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -236,6 +236,9 @@ var FlightLogParser = function(logData) {
             iterm_reset_offset:null,        // I-Term reset offset
             deadband:null,                  // Roll, Pitch Deadband
             yaw_deadband:null,              // Yaw Deadband
+            gyro_lpf:null,                  // Gyro lpf setting. (pre BF3.4)
+            gyro_hardware_lpf:null,         // Gyro hardware lpf setting. (post BF3.4)
+            gyro_32khz_hardware_lpf:null,   // Gyro 32khz hardware lpf setting. (post BF3.4)
             gyro_lpf:null,                  // Gyro lpf setting.
             gyro_lowpass_hz:null,           // Gyro Soft Lowpass Filter Hz
             gyro_notch_hz:null,             // Gyro Notch Frequency
@@ -452,6 +455,8 @@ var FlightLogParser = function(logData) {
             case "deadband":
             case "yaw_deadband":
             case "gyro_lpf":
+            case "gyro_hardware_lpf":
+            case "gyro_32khz_hardware_lpf":
             case "acc_lpf_hz":
             case "acc_hardware":
             case "baro_hardware":

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -481,6 +481,8 @@ function HeaderDialog(dialog, onSave) {
         setParameter('deadband'					,sysConfig.deadband,0);
         setParameter('yaw_deadband'				,sysConfig.yaw_deadband,0);
     	renderSelect('gyro_lpf'			    	,sysConfig.gyro_lpf, GYRO_LPF);
+    	renderSelect('gyro_hardware_lpf'		,sysConfig.gyro_hardware_lpf, GYRO_HARDWARE_LPF);
+    	renderSelect('gyro_32khz_hardware_lpf'		,sysConfig.gyro_32khz_hardware_lpf, GYRO_32KHZ_HARDWARE_LPF);
         setParameter('acc_lpf_hz'				,sysConfig.acc_lpf_hz,2);
         setParameter('acc_cut_hz'				,sysConfig.acc_cut_hz,2);
 	    setParameter('airmode_activate_throttle',sysConfig.airmode_activate_throttle, 0);


### PR DESCRIPTION
Related to https://github.com/betaflight/betaflight/pull/5483

Support the new fields `gyro_hardware_lpf` and `gyro_32khz_hardware_lpf`

![gyro_hardware_lpf headers](https://user-images.githubusercontent.com/17088539/37857611-6cf39624-2ef4-11e8-9c71-7f55146453d8.png)
