### PR TITLE
Add dterm_lowpass_hz and yaw_lowpass_hz

### DIFF
--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -579,6 +579,14 @@ var FlightLogParser = function(logData) {
                 }
             break;
 
+            case "dterm_lowpass_hz":
+                that.sysConfig['dterm_lpf_hz'] = parseInt(fieldValue, 10);
+            break;
+            
+            case "yaw_lowpass_hz":
+                that.sysConfig['yaw_lpf_hz'] = parseInt(fieldValue, 10);
+            break;
+            
             case "gyro_notch_hz":
             case "gyro_notch_cutoff":
                 if((that.sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(that.sysConfig.firmwareVersion, '3.0.1')) ||


### PR DESCRIPTION
This adds the `dterm_lowpass_hz` and `yaw_lowpass_hz` that were modified in https://github.com/betaflight/betaflight/pull/5458/

I don't know if it is a good idea add the translation table that I added to CF here https://github.com/cleanflight/blackbox-log-viewer/pull/59

I think it simplifies the code for this kind of renaming, but as discussed in the PR, others preferred to simply add a one more case to the switch (this is the reason because I did not add it to BF). Any thoughts about this?