### PR TITLE
Fix spectrum Blackbox rate

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -62,7 +62,12 @@ try {
     if (sysConfig.pid_process_denom != null) {
 		pidRate = gyroRate / sysConfig.pid_process_denom;
 	}
-	var blackBoxRate = (gyroRate/pidRate) * pidRate * (sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom']);
+    
+    var blackBoxRate = gyroRate * sysConfig['frameIntervalPNum'] / sysConfig['frameIntervalPDenom'];	
+    if (sysConfig.pid_process_denom != null) {
+        blackBoxRate = blackBoxRate / sysConfig.pid_process_denom;
+    }
+
 	var dataBuffer = {
 			fieldIndex: 0,
 			curve: 0,


### PR DESCRIPTION
This fixes https://github.com/betaflight/blackbox-log-viewer/issues/133 but I'm not too sure if this is the correct solution...

This code was changed the latest time by @basdelfos here https://github.com/betaflight/blackbox-log-viewer/commit/3ef50911df5d8045dc551abb8272f2e2fe61a3ed so maybe he can help.

The problem is that the `frameIntervalPDenom` is the rate, based on the gyro loop, of the Blackbox. But if I'm not wrong, I've observed in the firmware that the method with the counter of `frameIntervalPDenom` is called with the pidloop and not the gyro loop:

https://github.com/betaflight/betaflight/blob/f63edf1a3963548b61cc1592235791c44c416385/src/main/fc/fc_core.c#L950-L976

In the `subTaskMainSubprocesses()` so if I'm not wrong, it is logging at `1/sysConfig.pid_process_denom`  of the desired speed.

Is the logging rate at firmware wrong or we must use this `pid_process_denom` here? I've understood something wrong?