### PR TITLE
Improving toolbar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -133,9 +133,7 @@ a.disabled {
 }
 
 .header-pane {
-    margin-left:5%;
-    margin-right: 5%;
-    width: 90%;
+    width: 100%;
 }
 
 html:not(.has-log):not(.has-video) .header-pane {
@@ -211,8 +209,7 @@ html:not(.has-log):not(.has-video) .header-pane {
 
 
 
-.log-close-legend-dialog,
-.open-keys-dialog {
+.log-close-legend-dialog {
     float: right;
     font-size: 14px;
     color: #bbb;
@@ -437,7 +434,19 @@ html:not(.has-grid-override) span.has-grid-override {
 html.has-analyser-fullscreen.has-analyser .analyser input {
 	display:block;
 }
-
+.analyser:hover .visibility{
+    opacity: 1;
+    transition: opacity 500ms ease-in;
+}
+.analyser .visibility{
+    color: #bbb;
+    opacity: 0;
+}
+.analyser .visibility:hover{
+    color: white;
+    cursor: pointer;
+    animation: ease-in 500ms;
+}
 .analyser input#analyserZoomX {
 	width: 100px;
 	height : 10px;
@@ -830,6 +839,18 @@ progress {
 
 .navbar {
     margin-bottom:5px;
+}
+
+.btn-nobg{
+    color: lightgray;
+    border: 1px solid #00000000;
+    background: none;
+}
+
+.btn-nobg:hover{
+    border: 1px solid grey; 
+    color: white;
+    margin: -1px;
 }
 
 .navbar-logo {

--- a/css/main.css
+++ b/css/main.css
@@ -434,19 +434,27 @@ html:not(.has-grid-override) span.has-grid-override {
 html.has-analyser-fullscreen.has-analyser .analyser input {
 	display:block;
 }
-.analyser:hover .visibility{
+
+.analyser:hover #analyserResize{
     opacity: 1;
     transition: opacity 500ms ease-in;
 }
-.analyser .visibility{
+.analyser #analyserResize {
     color: #bbb;
     opacity: 0;
+    top: 5px;
+	left: 975px;
+    float: right;
+	z-index: 9;
+    position: absolute;
+    font-size: 18px;
 }
-.analyser .visibility:hover{
+.analyser #analyserResize:hover {
     color: white;
     cursor: pointer;
     animation: ease-in 500ms;
 }
+
 .analyser input#analyserZoomX {
 	width: 100px;
 	height : 10px;
@@ -841,16 +849,14 @@ progress {
     margin-bottom:5px;
 }
 
-.btn-nobg{
-    color: lightgray;
-    border: 1px solid #00000000;
+.btn-nobg {
+    color: #BBB;
     background: none;
 }
 
-.btn-nobg:hover{
-    border: 1px solid grey; 
+.btn-nobg:hover {
     color: white;
-    margin: -1px;
+    text-shadow: 1px 1px 2px gray, 0 0 5px blue, 0 0 10px white;
 }
 
 .navbar-logo {

--- a/css/main.css
+++ b/css/main.css
@@ -69,60 +69,121 @@ a.disabled {
     }
 }
 
-/* toolbar expansion */
+/*** toolbar expansion ***/
 
-@media (max-width: 1200px) {
+/* With video */
+
+@media (max-width: 950px) {
+    /* hidden when width is 1200px or less */
+    html.has-video .view-buttons-expanded
+    { display: none!important;}
+}
+
+@media (min-width: 951px) {
+    /* hidden when width is 1200px or less */
+    html.has-video .view-buttons
+    { display: none!important;}
+}
+
+@media (max-width: 1150px) {
+    /* Hide if smaller than 1150px */
     html.has-video .playback-rate-expanded,
     html.has-video .graph-zoom-expanded,
     html.has-video .log-sync-expanded {
         display: none !important;
     }
 }
-@media (min-width: 1201px) {
-    html.has-video .playback-menu,
+@media (min-width: 1151px) {
+    /* Hide if larger than 1150px */
+    html.has-video .playback-rate,
     html.has-video .zoom-menu,
     html.has-video .sync-menu
         {display: none!important;}
 }
 
-@media (max-width: 800px) {
+@media (max-width: 1285px) {
+    /*  Hide if smaller than 1285px */
+    html.has-video .log-chart-time-panel
+        { display: none!important;}
+}
+
+@media (max-width: 1420px) {
+    /*  Hide if smaller than 1500px */
+    html.has-video .playback-rate-expanded input.playback-rate-text,
+    html.has-video .graph-zoom-expanded input.graph-zoom
+    { display: none!important;}
+}
+
+/* Without video */
+
+@media (max-width: 750px) {
+    /* hide titles when width is 500px or less */
+    .video-top-controls * h4 { 
+        display: none!important;
+    }
+    .video-top-controls {
+        height: 50px;
+        padding-top: 10px;
+    }
+    .graph-row,
+    .log-field-values    {
+        top: 30px!important;
+    }
+}
+
+
+@media (max-width: 650px) {
+    /* hidden when width is 1200px or less */
+    html:not(.has-video) .view-buttons-expanded
+    { display: none!important;}
+}
+
+@media (min-width: 651px) {
+    /* hidden when width is 1200px or less */
+    html:not(.has-video) .view-buttons
+    { display: none!important;}
+}
+
+@media (max-width: 750px) {
+    /* Hide if smaller than 750px */
     html:not(.has-video) .playback-rate-expanded,
     html:not(.has-video) .graph-zoom-expanded,
     html:not(.has-video) .log-sync-expanded {
         display: none !important;
     }
 }
-@media (min-width: 801px) {
-    html:not(.has-video) .playback-menu,
+
+@media (min-width: 751px) {
+    /* Hide if larger than 750px */
+    html:not(.has-video) .playback-rate,
     html:not(.has-video) .zoom-menu,
     html:not(.has-video) .sync-menu
         {display: none!important;}
 }
 
 @media (max-width: 900px) {
-    /* hidden depending upon screen size */
+    /*  Hide if smaller than 900px */
     html:not(.has-video) .log-chart-time-panel
         { display: none!important;}
 }
 
-@media (max-width: 1300px) {
-    /* hidden depending upon screen size */
-    html.has-video .log-chart-time-panel
-        { display: none!important;}
-}
-
-@media (max-width: 1200px) {
-    /* hidden depending upon screen size */
-    html:not(.has-video) .view-buttons-expanded
+@media (max-width: 1050px) {
+    /*  Hide if smaller than 1050px */
+    html:not(.has-video) .playback-rate-expanded input.playback-rate-text,
+    html:not(.has-video) .graph-zoom-expanded input.graph-zoom
     { display: none!important;}
 }
 
-@media (max-width: 1540px) {
-    /* hidden depending upon screen size */
-    html.has-video .view-buttons-expanded
-    { display: none!important;}
+/*** end toolbar expansion ***/
+input.playback-rate-text,
+input.graph-zoom, 
+input.video-offset {
+    width: 65px!important;
 }
 
+input.graph-time {
+    text-align: right;
+}
 
 .welcome-pane, .main-pane {
     position: fixed;
@@ -179,35 +240,10 @@ html:not(.has-log):not(.has-video) .header-pane {
     display:none;
 }
 
-/* Phone 
-.graph-row {
-    height:300px;
-}
-*/
 #main-page {
     position: static;
     top: 60px;
 }
-
-/* Desktop */
-@media (min-height:580px) {
-    .graph-row {
-        /* height:460px; */
-    }
-}
-
-@media (min-height:720px) {
-    .graph-row {
-        /* height: 630px; */
-    }
-}
-
-.log-graph,
-.log-graph-config {
-    /* height:100%; */
-}
-
-
 
 .log-close-legend-dialog {
     float: right;
@@ -757,11 +793,9 @@ html.has-log .video-top-controls {
 	position:fixed;
 	z-index:10;
 	background-color:white;
-	padding-bottom:10px;
 	width: 100%;
 	min-width: 1390px;
 	white-space: nowrap;
-	height: 80px;
 }
 
 html.has-video .log-graph,
@@ -787,7 +821,7 @@ html.video-hidden video {
 }
 
 html:not(.has-video) .view-video {
-    visibility:hidden;
+	display:none;
 }
 
 html:not(.has-video) a.view-video,

--- a/index.html
+++ b/index.html
@@ -242,10 +242,10 @@
                         <button type="button" class="btn btn-default view-analyser" data-toggle="tooltip" title="View/hide analyser display">
                             <span class="glyphicon glyphicon-equalizer"></span>
                         </button>
-                        <button type="button" class="btn btn-default view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
+                        <!-- <button type="button" class="btn btn-default view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
                             <span class="glyphicon glyphicon-resize-full"></span>
                             <span class="glyphicon glyphicon-resize-small"></span>
-                        </button>
+                        </button> -->
                     </div>
                 </div>
             </li>
@@ -429,7 +429,12 @@
                 <div class="analyser">
                     <div style="position: relative">
                         <canvas width="0" height="0" id="analyserCanvas"></canvas>
-                        <span class="visibility glyphicon glyphicon-resize-full view-analyser-fullscreen"></span>
+                        
+                        <div id="analyserResize" class="btn-nobg view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
+                            <span class="glyphicon glyphicon-resize-full"></span>
+                            <span class="glyphicon glyphicon-resize-small"></span>
+                        </div>
+
                         <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
                         />
                         <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"

--- a/index.html
+++ b/index.html
@@ -183,11 +183,21 @@
                             Open log file/video
                             <input type="file" class="file-open" multiple>
                         </span>
-                        <button type="button" class="btn btn-default view-zoom-in" data-toggle="tooltip" title="Zoom In Window" style="display: none;">
+                    </div>
+                    <div class="btn-group"  style="display: none;">
+                        <button type="button" class="btn btn-default view-zoom-in" data-toggle="tooltip" title="Zoom In Window">
                             <span class="glyphicon glyphicon-zoom-in"></span>
                         </button>
-                        <button type="button" class="btn btn-default view-zoom-out" data-toggle="tooltip" title="Zoom Out Window" style="display: none;">
+                        <button type="button" class="btn btn-default view-zoom-out" data-toggle="tooltip" title="Zoom Out Window">
                             <span class="glyphicon glyphicon-zoom-out"></span>
+                        </button>
+                    </div>
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-nobg open-user-settings-dialog" data-toggle="tooltip" title="Show Settings">
+                            <span class="glyphicon glyphicon-cog"></span>
+                        </button>
+                        <button type="button" class="btn btn-nobg open-keys-dialog" data-toggle="tooltip" title="Show Shortcuts">
+                            <span class="glyphicon glyphicon-question-sign"></span>
                         </button>
                     </div>
                 </div>
@@ -201,79 +211,22 @@
                 <h4>View</h4>
                 <div>
                     <div class="btn-group view-buttons" role="group">
-                        <button type="button" class="btn btn-default open-header-dialog" data-toggle="tooltip" title="View/hide header">
+                        <button type="button" class="btn btn-default view-config" data-toggle="tooltip" title="View graph">
+                            <span class="glyphicon glyphicon-home"></span>
+                        </button>
+                        <button type="button" class="btn btn-default open-header-dialog" data-toggle="tooltip" title="View log header">
                             <span class="glyphicon glyphicon-info-sign"></span>
                         </button>
+                        <button type="button" class="btn btn-default view-table" data-toggle="tooltip" title="View table">
+                            <span class="glyphicon glyphicon-list-alt"></span>
+                        </button>
                     </div>
-                    <div class="btn-group view-menu">
-                        <div class="dropdown">
-                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" id="view-menu">
-                                View
-                                <span class="caret"></span>
-                            </button>
-                            <ul class="dropdown-menu" role="menu" aria-labelledby="view-menu">
-                                <li>
-                                    <a href="#" class="open-header-dialog auto-hide-menu" data-toggle="tooltip" title="View/hide header">
-                                        <span class="glyphicon glyphicon-info-sign"></span> Header
-                                        <span class="pull-right">H</span>
-                                    </a>
-                                </li>
-                                <li class="divider"></li>
-                                <li class="dropdown-header">Overlays</li>
-                                <li>
-                                    <a href="#" id="auto-hide-menu" class="view-video auto-hide-menu" data-toggle="tooltip" title="View/hide video display">
-                                        <span class="glyphicon glyphicon-film"></span> Video
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="#" id="auto-hide-menu" class="view-craft auto-hide-menu" data-toggle="tooltip" title="View/hide craft display">
-                                        <span class="glyphicon glyphicon-plane"></span> Craft
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="#" id="auto-hide-menu" class="view-sticks auto-hide-menu" data-toggle="tooltip" title="View/hide stick display">
-                                        <span class="glyphicon glyphicon-pawn"></span> Sticks
-                                    </a>
-                                </li>
-                                <li class="divider"></li>
-                                <li class="dropdown-header">Details</li>
-                                <li>
-                                    <a href="#" class="view-table auto-hide-menu" data-toggle="tooltip" title="View/hide statistics display">
-                                        <span class="glyphicon glyphicon-list-alt"></span> Values Table
-                                        <span class="pull-right">T</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="#" class="view-config auto-hide-menu" data-toggle="tooltip" title="View/hide configuration file">
-                                        <span class="glyphicon glyphicon-list-alt"></span> Config
-                                        <span class="pull-right">C</span>
-                                    </a>
-                                </li>
-                                <li class="divider has-analyser"></li>
-                                <li class="dropdown-header has-analyser">Analyser</li>
-                                <li>
-                                    <a href="#" class="view-analyser auto-hide-menu" data-toggle="tooltip" title="View/hide analyser display">
-                                        <span class="glyphicon glyphicon-equalizer"></span> Show/Hide
-                                        <span class="pull-right">A</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="#" class="view-analyser-fullscreen auto-hide-menu" data-toggle="tooltip" title="Zoom Analyser Window">
-                                        <span class="glyphicon glyphicon-resize-full"></span>
-                                        <span class="glyphicon glyphicon-resize-small"></span> Re-size
-                                        <span class="pull-right">&#x21E7;A</span>
-                                    </a>
-                                </li>
-                                <li class="divider"></li>
-                                <li>
-                                    <a href="#" class="open-user-settings-dialog auto-hide-menu" data-toggle="tooltip" title="Show User Settings">
-                                        <span class="glyphicon glyphicon-cog"></span> Preferences
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div class="btn-group view-buttons-expanded" role="group">
+                </div>
+            </li>
+            <li class="log-overlay-panel">
+                <h4>Overlay</h4>
+                <div>
+                    <div class="btn-group view-buttons" role="group">
                         <button type="button" class="btn btn-default view-video" data-toggle="tooltip" title="View/hide video display">
                             <span class="glyphicon glyphicon-film"></span>
                         </button>
@@ -282,9 +235,6 @@
                         </button>
                         <button type="button" class="btn btn-default view-sticks" data-toggle="tooltip" title="View/hide stick display">
                             <span class="glyphicon glyphicon-pawn"></span>
-                        </button>
-                        <button type="button" class="btn btn-default view-table" data-toggle="tooltip" title="View/hide statistics display">
-                            <span class="glyphicon glyphicon-list-alt"></span>
                         </button>
                         <button type="button" class="btn btn-default view-analyser-sticks" style="display:none" data-toggle="tooltip" title="View/hide stick analyser">
                             <span class="glyphicon glyphicon-screenshot"></span>
@@ -477,21 +427,24 @@
                 <canvas width="200" height="100" id="graphCanvas"></canvas>
                 <canvas width="0" height="0" id="craftCanvas"></canvas>
                 <div class="analyser">
-                    <canvas width="0" height="0" id="analyserCanvas"></canvas>
-                    <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
-                    />
-                    <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
-                    />
-                    <datalist id="analyserZoomXTicks">
-                        <option>100</option>
-                        <option>200</option>
-                        <option>300</option>
-                        <option>400</option>
-                        <option>500</option>
-                    </datalist>
-                    <datalist id="analyserZoomYTicks">
-                        <option>100</option>
-                    </datalist>
+                    <div style="position: relative">
+                        <canvas width="0" height="0" id="analyserCanvas"></canvas>
+                        <span class="visibility glyphicon glyphicon-resize-full view-analyser-fullscreen"></span>
+                        <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
+                        />
+                        <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
+                        />
+                        <datalist id="analyserZoomXTicks">
+                            <option>100</option>
+                            <option>200</option>
+                            <option>300</option>
+                            <option>400</option>
+                            <option>500</option>
+                        </datalist>
+                        <datalist id="analyserZoomYTicks">
+                            <option>100</option>
+                        </datalist>
+                    </div>
                 </div>
                 <canvas width="0" height="0" id="analyserStickCanvas"></canvas>
                 <span class="log-open-legend-dialog glyphicon glyphicon-cog" data-toggle="tooltip" title="Show the legend"></span>
@@ -499,7 +452,6 @@
             <div class="log-graph-config no-wheel">
                 <h2 class="no-wheel">Legend
                     <span class="log-close-legend-dialog glyphicon glyphicon-remove no-wheel" data-toggle="tooltip" title="Hide the legend"></span>
-                    <span class="open-keys-dialog glyphicon glyphicon-question-sign no-wheel" data-toggle="tooltip" title="Show the keyboard shortcuts"></span>
                 </h2>
                 <div class="log-index no-wheel"></div>
                 <div class="log-graph-legend no-wheel">

--- a/index.html
+++ b/index.html
@@ -209,24 +209,65 @@
         <ul class="video-top-controls list-unstyled">
             <li class="log-view-panel">
                 <h4>View</h4>
-                <div>
-                    <div class="btn-group view-buttons" role="group">
-                        <button type="button" class="btn btn-default view-config" data-toggle="tooltip" title="View graph">
-                            <span class="glyphicon glyphicon-home"></span>
-                        </button>
-                        <button type="button" class="btn btn-default open-header-dialog" data-toggle="tooltip" title="View log header">
-                            <span class="glyphicon glyphicon-info-sign"></span>
-                        </button>
-                        <button type="button" class="btn btn-default view-table" data-toggle="tooltip" title="View table">
-                            <span class="glyphicon glyphicon-list-alt"></span>
-                        </button>
-                    </div>
+                <div class="dropdown view-buttons">
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" id="view-menu">
+                        View
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu" aria-labelledby="view-menu">
+                        <li>
+                            <a href="#" class="open-header-dialog auto-hide-menu" data-toggle="tooltip" title="View/hide header">
+                                <span class="glyphicon glyphicon-info-sign"></span> Header
+                                <span class="pull-right">H</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="view-table auto-hide-menu" data-toggle="tooltip" title="View/hide statistics display">
+                                <span class="glyphicon glyphicon-list-alt"></span> Values Table
+                                <span class="pull-right">T</span>
+                            </a>
+                        </li>
+                        <li class="divider"></li>
+                        <li class="dropdown-header">Overlay</li>
+                        <li>
+                            <a href="#" id="auto-hide-menu" class="view-video auto-hide-menu" data-toggle="tooltip" title="View/hide video display">
+                                <span class="glyphicon glyphicon-film"></span> Video
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" id="auto-hide-menu" class="view-craft auto-hide-menu" data-toggle="tooltip" title="View/hide craft display">
+                                <span class="glyphicon glyphicon-plane"></span> Craft
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" id="auto-hide-menu" class="view-sticks auto-hide-menu" data-toggle="tooltip" title="View/hide stick display">
+                                <span class="glyphicon glyphicon-pawn"></span> Sticks
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" id="auto-hide-menu" class="view-analyser auto-hide-menu" data-toggle="tooltip" title="View/hide analyser display">
+                                <span class="glyphicon glyphicon-equalizer"></span> Analyser
+                                <span class="pull-right">A</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="btn-group view-buttons-expanded" role="group">
+                    <button type="button" class="btn btn-default view-config" data-toggle="tooltip" title="View graph">
+                        <span class="glyphicon glyphicon-home"></span>
+                    </button>
+                    <button type="button" class="btn btn-default open-header-dialog" data-toggle="tooltip" title="View log header">
+                        <span class="glyphicon glyphicon-info-sign"></span>
+                    </button>
+                    <button type="button" class="btn btn-default view-table" data-toggle="tooltip" title="View table">
+                        <span class="glyphicon glyphicon-list-alt"></span>
+                    </button>
                 </div>
             </li>
-            <li class="log-overlay-panel">
+            <li class="log-overlay-panel view-buttons-expanded">
                 <h4>Overlay</h4>
                 <div>
-                    <div class="btn-group view-buttons" role="group">
+                    <div class="btn-group" role="group">
                         <button type="button" class="btn btn-default view-video" data-toggle="tooltip" title="View/hide video display">
                             <span class="glyphicon glyphicon-film"></span>
                         </button>
@@ -242,10 +283,6 @@
                         <button type="button" class="btn btn-default view-analyser" data-toggle="tooltip" title="View/hide analyser display">
                             <span class="glyphicon glyphicon-equalizer"></span>
                         </button>
-                        <!-- <button type="button" class="btn btn-default view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
-                            <span class="glyphicon glyphicon-resize-full"></span>
-                            <span class="glyphicon glyphicon-resize-small"></span>
-                        </button> -->
                     </div>
                 </div>
             </li>
@@ -283,19 +320,19 @@
                 <h4>Speed</h4>
                 <div class="form-inline">
                     <div class="form-group">
-                        <div class="btn-group playback-menu">
+                        <div class="btn-group playback-rate">
                             <div class="dropdown">
-                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" id="playback-menu">
+                                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" id="playback-rate">
                                     Speed
                                     <span class="caret"></span>
                                 </button>
-                                <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="playback-menu">
+                                <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="playback-rate">
                                     <li>
                                         <div class="pull-right">
                                             <div class="panel-body">
                                                 Speed
                                                 <div class="playback-rate-control btn-group btn-group-vertical"></div>
-                                                <input type="text" class="form-control playback-rate small-screen" value="1.0" size="5" data-toggle="tooltip" title="Directly set the playback speed">
+                                                <input type="text" class="form-control playback-rate-text" value="1.0" size="5" data-toggle="tooltip" title="Directly set the playback speed">
                                             </div>
                                         </div>
                                     </li>
@@ -304,7 +341,7 @@
                         </div>
                         <div class="playback-rate-expanded">
                             <div class="playback-rate-control btn-group btn-group-vertical"></div>
-                            <input type="text" class="form-control playback-rate small-screen" value="1.0" size="5" data-toggle="tooltip" title="Directly set the playback speed">
+                            <input type="text" class="form-control playback-rate-text" value="1.0" size="5" data-toggle="tooltip" title="Directly set the playback speed">
                         </div>
                     </div>
                 </div>
@@ -393,12 +430,12 @@
                                     </li>
                                     <li>
                                         <a href="#" class="log-sync-here auto-hide-menu" data-toggle="tooltip" title="Set the log start to this video frame">
-                                            <span class="glyphicon glyphicon-fast-backward"></span> Start Log Here
+                                            <span class="glyphicon glyphicon-object-align-left"></span> Start Log Here
                                         </a>
                                     </li>
                                     <li class="has-marker">
                                         <a href="#" class="log-smart-sync auto-hide-menu" data-toggle="tooltip" title="Set the marked position to here...">
-                                            <span class="glyphicon glyphicon-object-align-left"></span> Smart Sync
+                                            <span class="glyphicon glyphicon-object-align-vertical"></span> Smart Sync
                                             <span class="pull-right">&#x2325;M</span>
                                         </a>
                                     </li>
@@ -410,7 +447,9 @@
                                 <button type="button" class="btn btn-default log-sync-back" data-toggle="tooltip" title="Move log earlier">
                                     <span class="glyphicon glyphicon-step-backward"></span>
                                 </button>
-                                <button type="button" class="btn btn-default log-sync-here">Start log here</button>
+                                <button type="button" class="btn btn-default log-sync-here" data-toggle="tooltip" title="Start log here">
+                                    <span class="glyphicon glyphicon-object-align-left"></span>
+                                </button>
                                 <button type="button" class="btn btn-default log-sync-forward" data-toggle="tooltip" title="Move log later">
                                     <span class="glyphicon glyphicon-step-forward"></span>
                                 </button>
@@ -427,29 +466,27 @@
                 <canvas width="200" height="100" id="graphCanvas"></canvas>
                 <canvas width="0" height="0" id="craftCanvas"></canvas>
                 <div class="analyser">
-                    <div style="position: relative">
-                        <canvas width="0" height="0" id="analyserCanvas"></canvas>
-                        
-                        <div id="analyserResize" class="btn-nobg view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
-                            <span class="glyphicon glyphicon-resize-full"></span>
-                            <span class="glyphicon glyphicon-resize-small"></span>
-                        </div>
-
-                        <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
-                        />
-                        <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
-                        />
-                        <datalist id="analyserZoomXTicks">
-                            <option>100</option>
-                            <option>200</option>
-                            <option>300</option>
-                            <option>400</option>
-                            <option>500</option>
-                        </datalist>
-                        <datalist id="analyserZoomYTicks">
-                            <option>100</option>
-                        </datalist>
+                    <canvas width="0" height="0" id="analyserCanvas"></canvas>
+                    
+                    <div id="analyserResize" class="btn-nobg view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
+                        <span class="glyphicon glyphicon-resize-full"></span>
+                        <span class="glyphicon glyphicon-resize-small"></span>
                     </div>
+
+                    <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
+                    />
+                    <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
+                    />
+                    <datalist id="analyserZoomXTicks">
+                        <option>100</option>
+                        <option>200</option>
+                        <option>300</option>
+                        <option>400</option>
+                        <option>500</option>
+                    </datalist>
+                    <datalist id="analyserZoomYTicks">
+                        <option>100</option>
+                    </datalist>
                 </div>
                 <canvas width="0" height="0" id="analyserStickCanvas"></canvas>
                 <span class="log-open-legend-dialog glyphicon glyphicon-cog" data-toggle="tooltip" title="Show the legend"></span>

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -120,7 +120,10 @@ try {
         });
 		$("input:last-of-type", parentElem).css({
 			left: (canvasCtx.canvas.width - 20) + "px"
-        });
+		});
+		$("#analyserResize", parentElem).css({
+			left: (canvasCtx.canvas.width - 28) + "px"
+		})
 
 	};
 	

--- a/js/main.js
+++ b/js/main.js
@@ -1857,7 +1857,7 @@ function BlackboxLogViewer() {
             .on("slide change set", function() {
                 setPlaybackRate(parseFloat($(this).val()));
             })
-            .Link("lower").to($(".playback-rate"));
+            .Link("lower").to($(".playback-rate-text"));
     
         $(".graph-zoom-control")
             .noUiSlider({


### PR DESCRIPTION
Improving the toolbar #127 

- [x] Fixed broken screen size responsiveness of toolbar. 
- [x] Split out graph overlays to separate group. 
- [x] Moved preferences and keyboard shortcuts to the upper right corner.
- [x] Analyzer fullscreen button moved into the rendered overlay.