### PR TITLE
Fix antigravity field value

### DIFF
--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -488,6 +488,7 @@ var FlightLogParser = function(logData) {
             case "dtermSetpointWeight":
             case "gyro_soft_type":
             case "debug_mode":
+            case "anti_gravity_gain":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
 
@@ -556,8 +557,7 @@ var FlightLogParser = function(logData) {
                 break
 
             case "yawRateAccelLimit":
-            case "rateAccelLimit":
-            case "anti_gravity_gain":
+            case "rateAccelLimit":            
                 if((that.sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(that.sysConfig.firmwareVersion, '3.1.0')) ||
                    (that.sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(that.sysConfig.firmwareVersion, '2.0.0'))) {
                     that.sysConfig[fieldName] = parseInt(fieldValue, 10)/1000;

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -527,7 +527,12 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('motorOutputLow'			,sysConfig.motorOutput[0],0);
 		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1],0);
 		setParameter('digitalIdleOffset'		,sysConfig.digitalIdleOffset,2);
-        setParameter('antiGravityGain'          ,sysConfig.anti_gravity_gain,0);
+        if((activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) ||
+                (activeSysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '2.0.0'))) {
+            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,3);
+        } else {
+            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,0);
+        }
         setParameter('antiGravityThreshold'     ,sysConfig.anti_gravity_threshold,0);
 		setParameter('setpointRelaxRatio'		,sysConfig.setpointRelaxRatio,2);
 		setParameter('pidSumLimit'     			,sysConfig.pidSumLimit,0);


### PR DESCRIPTION
Fix the antigravity field. Now, for a `3500` value, for example, it shows `4` and the correct is `3.5` or `3.500` (to not lose decimals if some user configures it from the CLI).