### PR TITLE
Open registered files by extension

### DIFF
--- a/assets/windows/FileAssociation.nsh
+++ b/assets/windows/FileAssociation.nsh
@@ -1,0 +1,190 @@
+/*
+_____________________________________________________________________________
+ 
+                       File Association
+_____________________________________________________________________________
+ 
+ Based on code taken from http://nsis.sourceforge.net/File_Association 
+ 
+ Usage in script:
+ 1. !include "FileAssociation.nsh"
+ 2. [Section|Function]
+      ${FileAssociationFunction} "Param1" "Param2" "..." $var
+    [SectionEnd|FunctionEnd]
+ 
+ FileAssociationFunction=[RegisterExtension|UnRegisterExtension]
+ 
+_____________________________________________________________________________
+ 
+ ${RegisterExtension} "[executable]" "[extension]" "[description]"
+ 
+"[executable]"     ; executable which opens the file format
+                   ;
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+ 
+ ${UnRegisterExtension} "[extension]" "[description]"
+ 
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+_____________________________________________________________________________
+ 
+                         Macros
+_____________________________________________________________________________
+ 
+ Change log window verbosity (default: 3=no script)
+ 
+ Example:
+ !include "FileAssociation.nsh"
+ !insertmacro RegisterExtension
+ ${FileAssociation_VERBOSE} 4   # all verbosity
+ !insertmacro UnRegisterExtension
+ ${FileAssociation_VERBOSE} 3   # no script
+*/
+ 
+ 
+!ifndef FileAssociation_INCLUDED
+!define FileAssociation_INCLUDED
+ 
+!include Util.nsh
+ 
+!verbose push
+!verbose 3
+!ifndef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE 3
+!endif
+!verbose ${_FileAssociation_VERBOSE}
+!define FileAssociation_VERBOSE `!insertmacro FileAssociation_VERBOSE`
+!verbose pop
+ 
+!macro FileAssociation_VERBOSE _VERBOSE
+  !verbose push
+  !verbose 3
+  !undef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE ${_VERBOSE}
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!macro RegisterExtensionCall _EXECUTABLE _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_DESCRIPTION}`
+  Push `${_EXTENSION}`
+  Push `${_EXECUTABLE}`
+  ${CallArtificialFunction} RegisterExtension_
+  !verbose pop
+!macroend
+ 
+!macro UnRegisterExtensionCall _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_EXTENSION}`
+  Push `${_DESCRIPTION}`
+  ${CallArtificialFunction} UnRegisterExtension_
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define RegisterExtension `!insertmacro RegisterExtensionCall`
+!define un.RegisterExtension `!insertmacro RegisterExtensionCall`
+ 
+!macro RegisterExtension
+!macroend
+ 
+!macro un.RegisterExtension
+!macroend
+ 
+!macro RegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R2 ;exe
+  Exch
+  Exch $R1 ;ext
+  Exch
+  Exch 2
+  Exch $R0 ;desc
+  Exch 2
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R1 ""  ; read current file association
+  StrCmp "$1" "" NoBackup  ; is it empty
+  StrCmp "$1" "$R0" NoBackup  ; is it our own
+    WriteRegStr HKCR $R1 "backup_val" "$1"  ; backup current value
+NoBackup:
+  WriteRegStr HKCR $R1 "" "$R0"  ; set our file association
+ 
+  ReadRegStr $0 HKCR $R0 ""
+  StrCmp $0 "" 0 Skip
+    WriteRegStr HKCR "$R0" "" "$R0"
+    WriteRegStr HKCR "$R0\shell" "" "open"
+    WriteRegStr HKCR "$R0\DefaultIcon" "" "$R2,0"
+Skip:
+  WriteRegStr HKCR "$R0\shell\open\command" "" '"$R2" "%1"'
+  WriteRegStr HKCR "$R0\shell\edit" "" "Edit $R0"
+  WriteRegStr HKCR "$R0\shell\edit\command" "" '"$R2" "%1"'
+ 
+  Pop $1
+  Pop $0
+  Pop $R2
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+!define un.UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+ 
+!macro UnRegisterExtension
+!macroend
+ 
+!macro un.UnRegisterExtension
+!macroend
+ 
+!macro UnRegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R1 ;desc
+  Exch
+  Exch $R0 ;ext
+  Exch
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R0 ""
+  StrCmp $1 $R1 0 NoOwn ; only do this if we own it
+  ReadRegStr $1 HKCR $R0 "backup_val"
+  StrCmp $1 "" 0 Restore ; if backup="" then delete the whole key
+  DeleteRegKey HKCR $R0
+  Goto NoOwn
+ 
+Restore:
+  WriteRegStr HKCR $R0 "" $1
+  DeleteRegValue HKCR $R0 "backup_val"
+  DeleteRegKey HKCR $R1 ;Delete key with association name settings
+ 
+NoOwn:
+ 
+  Pop $1
+  Pop $0
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+!endif # !FileAssociation_INCLUDED

--- a/assets/windows/installer.nsi
+++ b/assets/windows/installer.nsi
@@ -2,6 +2,7 @@
 !include "FileFunc.nsh"
 !include "LogicLib.nsh"
 !include "UnInst.nsh"
+!include "FileAssociation.nsh"
 
 # Receives variables from the command line
 # ${VERSION} - Version to generate (x.y.z)
@@ -18,7 +19,10 @@
 !define FILE_NAME_UNINSTALLER "uninstall-betaflight-blackbox-explorer.exe"
 !define FILE_NAME_EXECUTABLE  "betaflight-blackbox-explorer.exe"
 !define LICENSE               "..\..\LICENSE"
-
+!define EXT1                  ".BFL"
+!define EXT1_NAME             "Betaflight Blackbox Explorer log file"
+!define EXT2                  ".BBL"
+!define EXT2_NAME             "Blackbox Explorer log file"
 
 Name "${APP_NAME}"
 BrandingText "${COMPANY_NAME}"
@@ -163,6 +167,9 @@ Section
     WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
                 "EstimatedSize" "$0"
 
+	# Register extension
+	${registerExtension} "$INSTDIR\${FILE_NAME_EXECUTABLE}" "${EXT1}" "${EXT1_NAME}"
+	${registerExtension} "$INSTDIR\${FILE_NAME_EXECUTABLE}" "${EXT2}" "${EXT2_NAME}"
 
 SectionEnd
 
@@ -189,5 +196,9 @@ Section "Uninstall"
     DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
     DeleteRegKey HKCU "Software\${GROUP_NAME}\${APP_NAME}"
     DeleteRegKey /ifempty HKCU "Software\${GROUP_NAME}"
+
+	# UnRegister extension	
+	${unregisterExtension} "${EXT1}" "${EXT1_NAME}"
+	${unregisterExtension} "${EXT2}" "${EXT2_NAME}"
 
 SectionEnd

--- a/background.js
+++ b/background.js
@@ -1,16 +1,24 @@
 'use strict';
 
 function startApplication() {
-    chrome.app.window.create('index.html', {
+    chrome.app.window.create('index.html', 
+    {
         id: 'main',
         frame: 'chrome',
         innerBounds : {
             'width' : 1340,
             'height' : 920
         }
-    }, function (createdWindow) {
+    }, 
+    function (createdWindow) {
         if (getChromeVersion() >= 54) {
             createdWindow.icon = 'images/bf_icon_128.png';
+        }
+        try {
+            var gui = require('nw.gui');
+            createdWindow.contentWindow.argv = gui.App.argv;
+        } catch (e) {
+            // Require not supported, inside chrome
         }
     });
 }

--- a/css/main.css
+++ b/css/main.css
@@ -824,6 +824,17 @@ progress {
 .jumbotron {
     padding: 15px;
 }
+
+.hiddenElement {
+    display: none;
+}
+
+.loading-message {
+    padding-left: 30px;
+    font-weight: bold;
+    font-size: 1.5em;
+}
+
 .navbar-inverse .navbar-brand {
     color: #EAEAEA;
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
                 <span class="btn btn-primary btn-lg btn-file" data-toggle="tooltip" title="Start by opening a log or video file"> Open log file/video
                     <input type="file" class="file-open" multiple>
                 </span>
+                <span id="loading-file-text" class="hiddenElement loading-message"></span>
             </div>
         </div>
         <div class="container">


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/109

This change associates BFL and BBL (maybe is better change it to only BFL) files to the Blackbox, and opens automatically the files when selected in the file explorer.

Some things:
- I've added a message of "trying to open file..." to let the user know that we are working. The message is very simple, and maybe not the better method, but do it "elegant" now and change the way we are opening the files will mess this PR, so I think that is better to not do it here...
- I've associated the files in the windows installer, I don't know how to do it in Linux or Mac (and if it will work). If someone knows a Linux command to add to the installer, I can add it and test it.
- Only works under nw.js, so Chromebooks will not work neither.
