### PR TITLE
Highlight hovered legend field in graph

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -630,6 +630,10 @@ html.has-config .configuration-list {
     margin-left: 0.7em;
 }
 
+.graph-legend-field.highlight{
+    box-shadow: 0px 2px 4px -2px white
+}
+
 html.has-video .graph-row,
 html.has-log .graph-row {
     display:-webkit-flex;

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -16,6 +16,9 @@ function GraphConfig(graphConfig) {
     this.selectedGraphIndex = 0;
     this.selectedFieldIndex = 0;
 
+    this.highlightGraphIndex = null;
+    this.highlightFieldIndex = null;
+
     this.getGraphs = function() {
         return graphs;
     };

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChange, onZoomGraph, onExpandGraph, onNewGraphConfig) {
+function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChange, onHighlightChange, onZoomGraph, onExpandGraph, onNewGraphConfig) {
     var
         that = this;
 
@@ -27,12 +27,31 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                     li = $('<li class="graph-legend-field" name="' + field.name + '" graph="' + i + '" field="' + j +'"></li>');
                 
                 li.text(FlightLogFieldPresenter.fieldNameToFriendly(field.name));
-                li.css('border-bottom', "2px solid " + field.color);
+                li.css('border-bottom', "3px solid " + field.color);
                 fieldList.append(li);
             }
             
             targetElem.append(graphDiv);
         }
+
+        // Add a trigger on legend; highlight the hovered field in plot
+        $('.graph-legend-field').on('mouseenter', function(e){
+            $(this).addClass("highlight")
+            config.highlightGraphIndex = $(this).attr('graph');
+            config.highlightFieldIndex = $(this).attr('field');
+            if (onHighlightChange) {
+                onHighlightChange();
+            }
+        });
+
+        $('.graph-legend-field').on('mouseleave', function(e){
+            $(this).removeClass("highlight")
+            config.highlightGraphIndex = null;
+            config.highlightFieldIndex = null;
+            if (onHighlightChange) {
+                onHighlightChange();
+            }
+        });
 
         // Add a trigger on legend; select the analyser graph/field to plot
         $('.graph-legend-field').on('click', function(e) {

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -500,7 +500,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, craftCanvas, analyserC
      * Plot the given field within the specified time period. When the output from the curve applied to a field
      * value reaches 1.0 it'll be drawn plotHeight pixels away from the origin.
      */
-    function plotField(chunks, startFrameIndex, fieldIndex, curve, plotHeight, color, lineWidth) {
+    function plotField(chunks, startFrameIndex, fieldIndex, curve, plotHeight, color, lineWidth, highlight) {
         var
             GAP_WARNING_BOX_RADIUS = 3,
             chunkIndex, frameIndex,
@@ -587,6 +587,17 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, craftCanvas, analyserC
             frameIndex = 0;
         }
 
+        if (highlight) {
+            // Draw semi-transparent stroke with wider line to simulate glow
+            // Decided not to use canvasContext.shadowBlur for performance reasons
+            var lineWidthTemp = canvasContext.lineWidth;
+            canvasContext.lineWidth = 1.5*canvasContext.lineWidth+3;
+            canvasContext.globalAlpha = 0.5;
+            canvasContext.stroke();
+            canvasContext.lineWidth = lineWidthTemp;
+            canvasContext.globalAlpha = 1.0;
+        }
+        
         canvasContext.stroke();
     }
     
@@ -978,10 +989,10 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, craftCanvas, analyserC
                     
                     for (j = 0; j < graph.fields.length; j++) {
                         var field = graph.fields[j];
-                        
                         plotField(chunks, startFrameIndex, field.index, field.curve, canvas.height * graph.height / 2, 
                             field.color ? field.color : GraphConfig.PALETTE[j % GraphConfig.PALETTE.length],
-                            field.lineWidth ? field.lineWidth : null);
+                            field.lineWidth ? field.lineWidth : null, 
+                            graphConfig.highlightGraphIndex==i && graphConfig.highlightFieldIndex==j);
                     }
                     
                     if (graph.label) {

--- a/js/main.js
+++ b/js/main.js
@@ -672,11 +672,15 @@ function BlackboxLogViewer() {
     }
 
     function onLegendSelectionChange() {
-            hasAnalyser = true;
-            graph.setDrawAnalyser(hasAnalyser);            
-            html.toggleClass("has-analyser", hasAnalyser);
-            prefs.set('hasAnalyser', hasAnalyser);
-            invalidateGraph();
+        hasAnalyser = true;
+        graph.setDrawAnalyser(hasAnalyser);            
+        html.toggleClass("has-analyser", hasAnalyser);
+        prefs.set('hasAnalyser', hasAnalyser);
+        invalidateGraph();
+    }
+
+    function onLegendHighlightChange() {
+        invalidateGraph();
     }
 
     function setMarker(state) { // update marker field
@@ -829,7 +833,7 @@ function BlackboxLogViewer() {
             $(".viewer-download").hide();
         }
 
-        graphLegend = new GraphLegend($(".log-graph-legend"), activeGraphConfig, onLegendVisbilityChange, onLegendSelectionChange, zoomGraphConfig, expandGraphConfig, newGraphConfig);
+        graphLegend = new GraphLegend($(".log-graph-legend"), activeGraphConfig, onLegendVisbilityChange, onLegendSelectionChange, onLegendHighlightChange, zoomGraphConfig, expandGraphConfig, newGraphConfig);
         
         prefs.get('log-legend-hidden', function(item) {
             if (item) {


### PR DESCRIPTION
Fixes #37 

Decided not to use shadowBlur in the canvas rendering for performance issues. Instead, it now renders twice with a wider semi-transparent stroke first to create a glow effect. Also increased the width of the colored line under the legend field for improved readability. 