### PR TITLE
Refresh graph when start-log-here

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1109,7 +1109,7 @@ function BlackboxLogViewer() {
         $(".log-play-pause").click(logPlayPause);
         
         var logSyncHere = function() {
-            setVideoOffset(video.currentTime);
+            setVideoOffset(video.currentTime, true);
         };
         $(".log-sync-here").click(logSyncHere);
         


### PR DESCRIPTION
When pressed the start-log-here and the video is paused, the graph is
not refreshed until some other operation refreshes it.

Cherry-pick from CF: https://github.com/cleanflight/blackbox-log-viewer/commit/55f7149895cf8689e947d40efd0986ce5ee8cdd8