### PR TITLE
Adjust playback min rate to 10

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -22,7 +22,7 @@ function BlackboxLogViewer() {
         GRAPH_STATE_PLAY = 1,
         
         SMALL_JUMP_TIME = 100 * 1000,
-        PLAYBACK_MIN_RATE = 5,
+        PLAYBACK_MIN_RATE = 10,
         PLAYBACK_MAX_RATE = 300,
         PLAYBACK_DEFAULT_RATE = 100,
         PLAYBACK_RATE_STEP = 5,


### PR DESCRIPTION
The actual valor of 5 produces an error in the console when adjusted. 

I don't know if the problem is the codec, the operating system, the Chrome/nw.js implementation of webmedia or the video itself, but for security is better to up it a little.

> Uncaught DOMException: Failed to set the 'playbackRate' property on 'HTMLMediaElement': The provided playback rate (0.05) is not in the supported playback range.