### PR TITLE
Close Header Info with shortcut H

### DIFF
--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -641,11 +641,13 @@ function HeaderDialog(dialog, onSave) {
 	// Public variables
 
     this.show = function(sysConfig) {
-        dialog.modal('show');
-        renderSysConfig(sysConfig);
-        // Disable changing input and dropdowns
-        $('#dlgHeaderDialog input').prop('disabled', 'disabled');
-        $('#dlgHeaderDialog select').prop('disabled', 'disabled');
+        dialog.modal('toggle');
+        if (dialog.data('bs.modal').isShown) {
+            renderSysConfig(sysConfig);
+            // Disable changing input and dropdowns
+            $('#dlgHeaderDialog input').prop('disabled', 'disabled');
+            $('#dlgHeaderDialog select').prop('disabled', 'disabled');
+        }
     }
 
  	// Buttons


### PR DESCRIPTION
Other shortcuts, like `T` for the table info, opens the table and if pressed again, closes it.

But the `H` shortcut opens the Header Info and if pressed again, nothing happens. This change makes that the when pressed again, the Header Info closes.