### PR TITLE
Add settings to save the expo/smooth override

### DIFF
--- a/index.html
+++ b/index.html
@@ -2116,6 +2116,31 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="gui_box grey curve-settings">
+                                <div class="gui_box_titlebar">
+                                    <div class="spacer_box_title">Curve Settings</div>
+                                </div>
+                                <div class="spacer_box">
+                                    <div>
+                                        <label class="option">Expo Off
+                                            <input class="expo-default ios-switch" type="checkbox" />
+                                            <div>
+                                                <div></div>
+                                            </div>
+                                            <span>Expo deactivated by default for all graph curves.</span>
+                                        </label>
+                                    </div>
+                                    <div>
+                                        <label class="option">Smooth Off
+                                            <input class="smooth-default ios-switch" type="checkbox" />
+                                            <div>
+                                                <div></div>
+                                            </div>
+                                            <span>Smoothing deactivated by default for all graph curves.</span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="cf_column half right">

--- a/js/main.js
+++ b/js/main.js
@@ -297,7 +297,18 @@ function BlackboxLogViewer() {
             invalidateGraph();
         }
     }
-    
+
+    function updateOverrideStatus() {
+        // Update override status flags on status bar
+        var overrideStatus = '';
+
+        overrideStatus += (userSettings.graphSmoothOverride?'SMOOTH':'');        
+        overrideStatus += ((userSettings.graphExpoOverride && overrideStatus != '')?'|':'') + (userSettings.graphExpoOverride?'EXPO':'');
+        overrideStatus += ((userSettings.graphGridOverride && overrideStatus != '')?'|':'') + (userSettings.graphGridOverride?'GRID':'');
+
+        $(".overrides", statusBar).text(overrideStatus);
+    }
+
     function renderLogFileInfo(file) {
         $(".log-filename").text(file.name);
 
@@ -586,7 +597,9 @@ function BlackboxLogViewer() {
         }
         
         renderSelectedLogInfo();
-        
+
+        updateOverrideStatus();
+
         updateCanvasSize();
         
         setGraphState(GRAPH_STATE_PAUSED);
@@ -1260,6 +1273,7 @@ function BlackboxLogViewer() {
 	                graph.refreshOptions(newSettings);
 	                graph.refreshLogo();
 	                graph.initializeCraftModel();
+	                updateOverrideStatus();
 	                updateCanvasSize();
 	            }
 
@@ -1524,14 +1538,6 @@ function BlackboxLogViewer() {
                 return changedValue + fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[parseInt(field)].name) + ' ' + (graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power * 100).toFixed(2) + '%\n';;
             }
             return false; // nothing was changed
-        }
-
-        function updateOverrideStatus() {
-            // Update override status flags on status bar
-            var overrideStatus = ((userSettings.graphSmoothOverride)?'SMOOTH':'') +
-                ((userSettings.graphSmoothOverride && userSettings.graphExpoOverride)?'|':'') + ((userSettings.graphExpoOverride)?'EXPO':'') +
-                ((userSettings.graphSmoothOverride && userSettings.graphGridOverride)?'|':'') + ((userSettings.graphGridOverride)?'GRID':'');
-            $(".overrides", statusBar).text(overrideStatus);
         }
 
         function toggleOverrideStatus(userSetting, className) {

--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -133,6 +133,8 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 					   	   left: $('.laptimer-settings input[name="laptimer-left"]').val() + '%',
 					   	   transparency: $('.laptimer-settings input[name="laptimer-transparency"]').val() + '%', },
 				drawLapTimer: ($(".laptimer").is(":checked")),
+                graphSmoothOverride: ($(".smooth-default").is(":checked")),
+                graphExpoOverride: ($(".expo-default").is(":checked")),
     	});
     	return settings;
     }
@@ -294,6 +296,14 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
     $(".legend-units").click(function() {
         currentSettings.legendUnits = $(this).is(":checked");
     });
+    
+    $(".smooth-default").click(function() {
+        currentSettings.graphSmoothOverride = $(this).is(":checked");
+    });
+    
+    $(".expo-default").click(function() {
+        currentSettings.graphExpoOverride = $(this).is(":checked");
+    });
 
     // Load Custom Logo
     function readURL(input) {
@@ -365,6 +375,16 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 				// set the toggle switch
 				$(".legend-units").prop('checked', currentSettings.legendUnits);
 			}
+
+            if(currentSettings.graphSmoothOverride!=null) {
+                // set the toggle switch
+                $(".smooth-default").prop('checked', currentSettings.graphSmoothOverride);
+            }
+
+            if(currentSettings.graphExpoOverride!=null) {
+                // set the toggle switch
+                $(".expo-default").prop('checked', currentSettings.graphExpoOverride);
+            }
 
 
         mixerListSelection(currentSettings.mixerConfiguration); // select current mixer configuration


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/139 and https://github.com/betaflight/blackbox-log-viewer/issues/137

This adds a user setting to disable the  expo and smooth by default when opening the Blackbox app. 
![image](https://user-images.githubusercontent.com/2673520/39595453-d537014a-4f0f-11e8-88aa-6799f2a5d493.png)

What I'm not sure is if the default for all users must be this activated or not, as asked in the issue. By the moment I have left it with expo and smooth enabled by default.