### PR TITLE
Reorganize and fix header filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -997,31 +997,59 @@
                                     <div class="spacer_box_title">Filters</div>
                                 </div>
                                 <div class="spacer_box">
+
                                     <table class="parameter cf">
                                         <thead>
-                                            <tr>
-                                                <th colspan="4">Gyro Filters</th>
-                                            </tr>
-                                        </thead>
+                                               <tr>
+                                                   <th colspan="4">Gyro Hardware Lowpass Filters</th>
+                                               </tr>
+                                           </thead>
                                         <tbody>
                                             <tr>
-                                                <td name='gyro_lpf'>
-                                                    <label>Hardware</label>
+                                                <td name='gyro_hardware_lpf' colspan="2">
+                                                    <label>Gyro Hardware LPF</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
+                                                <td name='gyro_32khz_hardware_lpf' colspan="2">
+                                                    <label>Gyro 32KHz Hardware LPF</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+                                    <table class="parameter cf">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="4">Gyro Software Filters</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
                                                 <td name='gyro_soft_type'>
-                                                    <label>Type</label>
+                                                    <label>Type Stage 1<br>&nbsp;</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
                                                 <td name="gyro_lowpass_hz">
-                                                    <label>Soft (Hz)</label>
+                                                    <label>Soft Stage 1<br>(Hz)</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
-                                                <td></td>
+                                                <td name='gyro_soft2_type'>
+                                                    <label>Type Stage 2<br>&nbsp;</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                                <td name="gyro_lowpass2_hz">
+                                                    <label>Soft Stage 2<br>(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
                                             </tr>
                                             <tr>
                                                 <td name='gyro_notch_hz'>
@@ -1214,33 +1242,6 @@
                                             <tr>
                                                 <td name='debug_mode'>
                                                     <label>Debug Mode</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey debug">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Gyro Hardware Lowpass Settings</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='gyro_hardware_lpf'>
-                                                    <label>Gyro Hardware LPF</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td name='gyro_32khz_hardware_lpf'>
-                                                    <label>Gyro 32KHz Hardware LPF</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -236,11 +236,10 @@ var FlightLogParser = function(logData) {
             iterm_reset_offset:null,        // I-Term reset offset
             deadband:null,                  // Roll, Pitch Deadband
             yaw_deadband:null,              // Yaw Deadband
-            gyro_lpf:null,                  // Gyro lpf setting. (pre BF3.4)
-            gyro_hardware_lpf:null,         // Gyro hardware lpf setting. (post BF3.4)
-            gyro_32khz_hardware_lpf:null,   // Gyro 32khz hardware lpf setting. (post BF3.4)
             gyro_lpf:null,                  // Gyro lpf setting.
+            gyro_32khz_hardware_lpf:null,   // Gyro 32khz hardware lpf setting. (post BF3.4)
             gyro_lowpass_hz:null,           // Gyro Soft Lowpass Filter Hz
+            gyro_lowpass2_hz:null,          // Gyro Soft Lowpass Filter Hz 2
             gyro_notch_hz:null,             // Gyro Notch Frequency
             gyro_notch_cutoff:null,         // Gyro Notch Cutoff
             dterm_notch_hz:null,            // Dterm Notch Frequency
@@ -262,6 +261,7 @@ var FlightLogParser = function(logData) {
             yawRateAccelLimit:null,         // Betaflight PID
             rateAccelLimit:null,            // Betaflight PID
             gyro_soft_type:null,            // Gyro soft filter type (PT1, BIQUAD)
+            gyro_soft2_type:null,           // Gyro soft filter 2 type (PT1, BIQUAD)
             debug_mode:null,                // Selected Debug Mode
             features:null,                  // Activated features (e.g. MOTORSTOP etc)
             Craft_name:null,                // Craft Name
@@ -285,8 +285,10 @@ var FlightLogParser = function(logData) {
             dterm_setpoint_weight     : "dtermSetpointWeight",  
             digital_idle_value        : "digitalIdleOffset",
             dshot_idle_value          : "digitalIdleOffset",
+            gyro_hardware_lpf         : "gyro_lpf",
             gyro_lowpass              : "gyro_lowpass_hz",
-            gyro_lowpass_type         : "gyro_lpf",
+            gyro_lowpass_type         : "gyro_soft_type",
+            gyro_lowpass2_type        : "gyro_soft2_type",
             "gyro.scale"              : "gyro_scale",
             iterm_windup              : "itermWindupPointPercent",
             motor_pwm_protocol        : "fast_pwm_protocol",
@@ -548,6 +550,7 @@ var FlightLogParser = function(logData) {
             case "setpointRelaxRatio":
             case "dtermSetpointWeight":
             case "gyro_soft_type":
+            case "gyro_soft2_type":
             case "debug_mode":
             case "anti_gravity_gain":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
@@ -580,6 +583,7 @@ var FlightLogParser = function(logData) {
 
             case "yaw_lpf_hz":
             case "gyro_lowpass_hz":
+            case "gyro_lowpass2_hz":
             case "dterm_notch_hz":
             case "dterm_notch_cutoff":
             case "dterm_lpf_hz":

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -244,9 +244,14 @@ try {
 		drawGridLines(PLOTTED_BLACKBOX_RATE, LEFT, TOP, WIDTH, HEIGHT, MARGIN);
 
 		var offset = 0;
-		if (mouseFrequency !=null) drawMarkerLine(mouseFrequency,  PLOTTED_BLACKBOX_RATE, '', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(0,255,0,0.50)", 3);
+		if (mouseFrequency !=null) drawMarkerLine(mouseFrequency, PLOTTED_BLACKBOX_RATE, '', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(0,255,0,0.50)", 3);
 		offset++; // make some space!
-		if(flightLog.getSysConfig().gyro_lowpass_hz!=null) 		drawMarkerLine(flightLog.getSysConfig().gyro_lowpass_hz,  PLOTTED_BLACKBOX_RATE, 'GYRO LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+        if(flightLog.getSysConfig().gyro_lowpass_hz != null) {
+            drawMarkerLine(flightLog.getSysConfig().gyro_lowpass_hz,  PLOTTED_BLACKBOX_RATE, 'GYRO LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+        }
+        if(flightLog.getSysConfig().gyro_lowpass2_hz != null) {
+            drawMarkerLine(flightLog.getSysConfig().gyro_lowpass2_hz, PLOTTED_BLACKBOX_RATE, 'GYRO LPF2 cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(95,199,95,0.50)");
+        }
 		if(flightLog.getSysConfig().gyro_notch_hz!=null && flightLog.getSysConfig().gyro_notch_cutoff!=null ) {
 			if(flightLog.getSysConfig().gyro_notch_hz.length > 0) { //there are multiple gyro notch filters
 				var gradient = canvasCtx.createLinearGradient(0,0,0,(HEIGHT));

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -48,6 +48,9 @@ function HeaderDialog(dialog, onSave) {
             {name:'yawRateAccelLimit'			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
             {name:'rateAccelLimit'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
             {name:'gyro_soft_type'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+            {name:'gyro_soft2_type'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
+            {name:'gyro_lowpass2_hz'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
+            {name:'gyro_32khz_hardware_lpf'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
             {name:'debug_mode'					, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
 			{name:'gyro_notch_hz_2'				, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'},
 			{name:'gyro_notch_cutoff_2'		    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.1', max:'999.9.9'},
@@ -480,9 +483,15 @@ function HeaderDialog(dialog, onSave) {
         setParameter('iterm_reset_offset'		,sysConfig.iterm_reset_offset,0);
         setParameter('deadband'					,sysConfig.deadband,0);
         setParameter('yaw_deadband'				,sysConfig.yaw_deadband,0);
-    	renderSelect('gyro_lpf'			    	,sysConfig.gyro_lpf, GYRO_LPF);
-    	renderSelect('gyro_hardware_lpf'		,sysConfig.gyro_hardware_lpf, GYRO_HARDWARE_LPF);
-    	renderSelect('gyro_32khz_hardware_lpf'		,sysConfig.gyro_32khz_hardware_lpf, GYRO_32KHZ_HARDWARE_LPF);
+
+        if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.4.0')) {
+            renderSelect('gyro_hardware_lpf'       ,sysConfig.gyro_lpf, GYRO_HARDWARE_LPF);
+            
+        } else {
+            renderSelect('gyro_hardware_lpf'       ,sysConfig.gyro_lpf, GYRO_LPF);
+        }
+
+        renderSelect('gyro_32khz_hardware_lpf'  ,sysConfig.gyro_32khz_hardware_lpf, GYRO_32KHZ_HARDWARE_LPF);
         setParameter('acc_lpf_hz'				,sysConfig.acc_lpf_hz,2);
         setParameter('acc_cut_hz'				,sysConfig.acc_cut_hz,2);
 	    setParameter('airmode_activate_throttle',sysConfig.airmode_activate_throttle, 0);
@@ -506,6 +515,7 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('dterm_lpf_hz'				,sysConfig.dterm_lpf_hz,0);
 		setParameter('yaw_lpf_hz'				,sysConfig.yaw_lpf_hz,0);
 		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
+		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
     	renderSelect('rc_interpolation'		    ,sysConfig.rc_interpolation, RC_INTERPOLATION);
         setParameter('rc_interpolation_interval',sysConfig.rc_interpolation_interval,0);
@@ -523,6 +533,7 @@ function HeaderDialog(dialog, onSave) {
             setParameter('rateAccelLimit'       , sysConfig.rateAccelLimit, 1);
         }
         renderSelect('gyro_soft_type'			,sysConfig.gyro_soft_type, FILTER_TYPE);
+        renderSelect('gyro_soft2_type'          ,sysConfig.gyro_soft2_type, FILTER_TYPE);
         renderSelect('debug_mode'				,sysConfig.debug_mode, DEBUG_MODE);
 		setParameter('motorOutputLow'			,sysConfig.motorOutput[0],0);
 		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1],0);


### PR DESCRIPTION
Reorganize all the filters of the header, adding the stage2 gyro filter that was missing to the header and to the spectrum.

![image](https://user-images.githubusercontent.com/2673520/39943797-7555d2aa-5564-11e8-98b8-c55a975bf357.png)

![image](https://user-images.githubusercontent.com/2673520/39943846-a44b353c-5564-11e8-9ab4-d2f00601507f.png)
