### PR TITLE
Store user selected expo, smooth and grid

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1549,7 +1549,7 @@ function BlackboxLogViewer() {
         loadInitialOverrideStatus();
 
         function toggleOverrideStatus(userSetting, className) {
-            userSettings[userSetting] = !userSettings[userSetting]; // toggle current setting            
+            userSettings[userSetting] = !userSettings[userSetting]; // toggle current setting
             html.toggleClass(className, userSettings[userSetting]);
             saveOneUserSetting(userSetting, userSettings[userSetting]);
             graph.refreshOptions(userSettings);

--- a/js/main.js
+++ b/js/main.js
@@ -1530,9 +1530,28 @@ function BlackboxLogViewer() {
             return false; // nothing was changed
         }
 
+        function saveOneUserSetting(name, value) {
+            prefs.get('userSettings', function(data) {
+                data[name] = value;
+                prefs.set('userSettings', data);
+            });
+        }
+
+        var loadInitialOverrideStatus = function() {
+            prefs.get('userSettings', function(data) {
+
+                html.toggleClass('has-expo-override',      data['graphExpoOverride']);
+                html.toggleClass('has-smoothing-override', data['graphSmoothOverride']);
+                html.toggleClass('has-grid-override',      data['graphGridOverride']);
+
+            });
+        }
+        loadInitialOverrideStatus();
+
         function toggleOverrideStatus(userSetting, className) {
-            userSettings[userSetting] = !userSettings[userSetting]; // toggle current setting
+            userSettings[userSetting] = !userSettings[userSetting]; // toggle current setting            
             html.toggleClass(className, userSettings[userSetting]);
+            saveOneUserSetting(userSetting, userSettings[userSetting]);
             graph.refreshOptions(userSettings);
             graph.refreshGraphConfig();
             invalidateGraph();


### PR DESCRIPTION
Store the user selected status of expo, smooth and grid in the storage, and reload it when loading the app.

Follow up of https://github.com/betaflight/blackbox-log-viewer/pull/175
Fixes #139 and #137

I think this is better than the other approach: https://github.com/betaflight/blackbox-log-viewer/pull/161 and it will be interesting to do the same for other elements with button in the interface, like the sticks or the craft.