### PR TITLE
Remember aircraft and sticks visibility

### DIFF
--- a/js/grapher.js
+++ b/js/grapher.js
@@ -45,7 +45,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
         
         defaultOptions = {
             gapless:false,
-            drawCraft:"3D", drawPidTable:true, drawSticks:true, drawTime:true,
+            craftType:"3D", drawPidTable:true, drawSticks:true, drawTime:true,
             drawAnalyser:true,              // add an analyser option
             analyserSampleRate:2000/*Hz*/,  // the loop time for the log
             eraseBackground: true           // Set to false if you want the graph to draw on top of an existing canvas image
@@ -692,7 +692,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
         
         if (craft2D) {
             craft2D.resize(craftSize, craftSize);
-        } else {
+        } else if (craft3D) {
             craft3D.resize(craftSize, craftSize);
         }
 
@@ -815,9 +815,9 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                     drawFrameLabel(centerFrame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_ITERATION], Math.round((windowCenterTime - flightLog.getMinTime()) / 1000));
                 }
                 
-                if (options.drawCraft == '3D') {
+                if (options.craftType == '3D') {
                     craft3D.render(centerFrame, flightLog.getMainFieldIndexes());
-                } else if (options.drawCraft == '2D') {
+                } else if (options.craftType == '2D') {
                     craft2D.render(centerFrame, flightLog.getMainFieldIndexes());
                     
                 }
@@ -901,28 +901,30 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
     }
     
     this.initializeCraftModel = function() {
-        // Ensure drawCraft is a valid value
-        if (["2D", "3D"].indexOf(options.drawCraft) == -1) {
-            options.drawCraft = false;
+
+        // Ensure craftType is a valid value
+        if (["2D", "3D"].indexOf(options.craftType) == -1) {
+            options.craftType = defaultOptions.craftType;
         }
-        
-        if (options.drawCraft == '3D') {
+
+        if (options.craftType == '3D') {
             if (craftCanvas) {
                 try {
                     craft3D = new Craft3D(flightLog, craftCanvas, idents.motorColors);
                 } catch (e) {
                     //WebGL not supported, fall back to 2D rendering
-                    options.drawCraft = '2D';
+                    options.craftType = '2D';
                 }
             } else {
                 //Dedicated craft canvas not provided so we can't render in 3D, fall back
-                options.drawCraft = '2D';
+                options.craftType = '2D';
             }
         }
         
-        if (options.drawCraft == '2D') {
+        if (options.craftType == '2D') {
             craft2D = new Craft2D(flightLog, craftCanvas, idents.motorColors);
         }
+
     }
     
     this.destroy = function() {

--- a/js/main.js
+++ b/js/main.js
@@ -66,7 +66,7 @@ function BlackboxLogViewer() {
         fieldPresenter = FlightLogFieldPresenter,
         
         hasVideo = false, hasLog = false, hasMarker = false, // add measure feature
-        hasTable = true, hasCraft = true, hasSticks = true, hasAnalyser, hasAnalyserFullscreen,
+        hasTable = true, hasAnalyser, hasAnalyserFullscreen,
         hasAnalyserSticks = false, viewVideo = true, hasTableOverlay = false, hadTable,
         hasConfig = false, hasConfigOverlay = false,
 
@@ -678,9 +678,12 @@ function BlackboxLogViewer() {
             currentOffsetCache.index    = null;      // and clear the index
             
             hasLog = true; html.toggleClass("has-log", hasLog);
-            html.toggleClass("has-craft", hasCraft);
             html.toggleClass("has-table", hasTable);
-            html.toggleClass("has-sticks", hasSticks);
+            html.toggleClass("has-craft",              userSettings.drawCraft);
+            html.toggleClass("has-sticks",             userSettings.drawSticks);
+            html.toggleClass('has-expo-override',      userSettings.graphExpoOverride);
+            html.toggleClass('has-smoothing-override', userSettings.graphSmoothOverride);
+            html.toggleClass('has-grid-override',      userSettings.graphSmoothOverride);
 
             setTimeout(function(){$(window).resize();}, 500 ); // refresh the window size;
 
@@ -904,20 +907,6 @@ function BlackboxLogViewer() {
             }
         });
 
-        prefs.get('hasCraft', function(item) {
-           if (item) {
-               hasCraft = item;
-               html.toggleClass("has-craft", hasCraft);
-           } 
-        });
-
-        prefs.get('hasSticks', function(item) {
-           if (item) {
-               hasSticks = item;
-               html.toggleClass("has-sticks", hasSticks);
-           } 
-        });
-
         /* Always start with the table hidden
         prefs.get('hasTable', function(item) {
            if (item) {
@@ -956,16 +945,16 @@ function BlackboxLogViewer() {
         });
 
         $(".view-craft").click(function() {
-            hasCraft = !hasCraft;
-            html.toggleClass("has-craft", hasCraft);       
-            prefs.set('hasCraft', hasCraft);
+            userSettings.drawCraft = !userSettings.drawCraft;
+            html.toggleClass("has-craft", userSettings.drawCraft);
+            saveOneUserSetting('drawCraft', userSettings.drawCraft);
         });
 
         $(".view-sticks").click(function() {
-            hasSticks = !hasSticks;
-            graph.setDrawSticks(hasSticks);            
-            html.toggleClass("has-sticks", hasSticks);  
-            prefs.set('hasSticks', hasSticks);
+            userSettings.drawSticks = !userSettings.drawSticks;
+            graph.setDrawSticks(userSettings.drawSticks);
+            html.toggleClass("has-sticks", userSettings.drawSticks);
+            saveOneUserSetting('drawSticks', userSettings.drawSticks);
             invalidateGraph();
         });
         
@@ -1353,9 +1342,9 @@ function BlackboxLogViewer() {
                     outTime: videoExportOutTime,
                     flightVideo: (hasVideo && viewVideo) ? video.cloneNode() : false,
                     flightVideoOffset: videoOffset,
-                    hasCraft: hasCraft,
+                    hasCraft: userSettings.drawCraft,
                     hasAnalyser: hasAnalyser,
-                    hasSticks: hasSticks
+                    hasSticks: userSettings.drawSticks
                 }, videoConfig);
                 
                 e.preventDefault();
@@ -1548,17 +1537,6 @@ function BlackboxLogViewer() {
                 prefs.set('userSettings', data);
             });
         }
-
-        var loadInitialOverrideStatus = function() {
-            prefs.get('userSettings', function(data) {
-
-                html.toggleClass('has-expo-override',      data['graphExpoOverride']);
-                html.toggleClass('has-smoothing-override', data['graphSmoothOverride']);
-                html.toggleClass('has-grid-override',      data['graphGridOverride']);
-
-            });
-        }
-        loadInitialOverrideStatus();
 
         function toggleOverrideStatus(userSetting, className) {
             userSettings[userSetting] = !userSettings[userSetting]; // toggle current setting

--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -45,9 +45,10 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 		stickInvertYaw		: false,			// Invert yaw in stick display?
         legendUnits			: true,	            // Show units on legend?
 		gapless				: false,
-		drawCraft			: "3D", 
+        drawCraft           : "3D", 
+        hasCraft            : true,
 		drawPidTable		: true, 
-		drawSticks			: true, 
+        drawSticks          : true, 
 		drawTime			: true,
 		drawEvents			: true,
 		drawAnalyser		: true,             // add an analyser option


### PR DESCRIPTION
The code to remember the aircraft and sticks visibility existed, but it was wrong.

I have unified it with the overrides to store all this kind of user variables in the userSettings.

I think this helps too the @wolkesson problem, fixes https://github.com/betaflight/blackbox-log-viewer/issues/25