### PR TITLE
Better video error message

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -707,7 +707,7 @@ function BlackboxLogViewer() {
         }
         
         if (!URL.createObjectURL) {
-            alert("Sorry, your web browser doesn't support showing videos from your local computer. Try Google Chrome instead.");
+            alert("Sorry, your web browser doesn't support showing videos from your local computer.");
             currentOffsetCache.video = null; // clear the associated video name
             return;
         }
@@ -729,7 +729,11 @@ function BlackboxLogViewer() {
     }
     
     function reportVideoError(e) {
-        alert("Your video could not be loaded, your browser might not support this kind of video. Try Google Chrome instead.");
+        let errorMessage = 'Error while loading the video.';
+        if (e.currentTarget.error.code) {
+            errorMessage += ' ERROR (' + e.currentTarget.error.code + '): ' + e.currentTarget.error.message;
+        }
+        alert(errorMessage);
     }
     
     function onLegendVisbilityChange(hidden) {


### PR DESCRIPTION
I don't know if consider that this fixes https://github.com/betaflight/blackbox-log-viewer/issues/192

The video does not load neither, but shows a better error. I don't know if is a good idea show this to the user, but can help when someone has an error and opens an issue:
![image](https://user-images.githubusercontent.com/2673520/40613942-e6f1f6d6-6280-11e8-813a-8dee057c466e.png)
