### PR TITLE
Fix super low resolution export when no video

### DIFF
--- a/js/flightlog_video_renderer.js
+++ b/js/flightlog_video_renderer.js
@@ -291,7 +291,7 @@ function FlightLogVideoRenderer(flightLog, logParameters, videoOptions, events) 
         delete logParameters.flightVideo;
     }
 
-    var options = $.extend({}, userSettings || {}, {eraseBackground : !logParameters.flightVideo, drawEvents : false});
+    var options = $.extend({}, userSettings || {}, {eraseBackground : !logParameters.flightVideo, drawEvents : false, fillBackground : !logParameters.flightVideo});
     
     graph = new FlightLogGrapher(flightLog, logParameters.graphConfig, canvas, stickCanvas, craftCanvas, analyserCanvas, options);
 

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -713,7 +713,13 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
         windowEndTime = windowStartTime + windowWidthMicros;
         
         if (options.eraseBackground) {
-            canvasContext.clearRect(0, 0, canvas.width, canvas.height);
+            // Work-around: The webm-writer does not like transparent backgrounds. Fill canvas with black.
+            if (options.fillBackground) {
+                canvasContext.fillStyle = 'black';
+                canvasContext.fillRect(0, 0, canvas.width, canvas.height);
+            } else {
+                canvasContext.clearRect(0, 0, canvas.width, canvas.height);
+            }
         }
         
         var 


### PR DESCRIPTION
The webm-writer does not seem like transparent backgrounds. Workaround: Fill the whole canvas with black when exporting without video. Fixes #112. 