### PR TITLE
Gyro sensors/debug: standardize gyro debugging enum elements

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -335,13 +335,21 @@ var
 
 function adjustFieldDefsList(firmwareType, firmwareVersion) {
     if((firmwareType == FIRMWARE_TYPE_BETAFLIGHT) && semver.gte(firmwareVersion, '3.3.0')) {
+
+        // Debug names
         DEBUG_MODE = DEBUG_MODE_COMPLETE.slice(0);
         DEBUG_MODE.splice(DEBUG_MODE.indexOf('MIXER'),        1);
         DEBUG_MODE.splice(DEBUG_MODE.indexOf('AIRMODE'),      1);
         DEBUG_MODE.splice(DEBUG_MODE.indexOf('VELOCITY'),     1);
         DEBUG_MODE.splice(DEBUG_MODE.indexOf('DTERM_FILTER'), 1);
+        
+        if(semver.gte(firmwareVersion, '3.4.0')) {
+            DEBUG_MODE.splice(DEBUG_MODE.indexOf('GYRO'),     1, 'GYRO_FILTERED');
+            DEBUG_MODE.splice(DEBUG_MODE.indexOf('NOTCH'),    1, 'GYRO_SCALED');
+        }
         DEBUG_MODE = makeReadOnly(DEBUG_MODE);
 
+        // Flight mode names
         FLIGHT_LOG_FLIGHT_MODE_NAME = makeReadOnly(FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3);
 
     } else {

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -126,6 +126,13 @@ function FlightLogFieldPresenter() {
 							'debug[2]':'Gyro Raw [Z]',
 							'debug[3]':'Not Used',
 						},
+            'GYRO_FILTERED' : {
+                            'debug[all]':'Debug Gyro Filtered',  
+                            'debug[0]':'Gyro Filtered [X]',
+                            'debug[1]':'Gyro Filtered [Y]',
+                            'debug[2]':'Gyro Filtered [Z]',
+                            'debug[3]':'Not Used',
+                        },
 			'ACCELEROMETER' : 	{	
 							'debug[all]':'Debug Accel.',	
 							'debug[0]':'Accel. Raw [X]',
@@ -154,6 +161,13 @@ function FlightLogFieldPresenter() {
 							'debug[2]':'Gyro Pre-Notch [yaw]',
 							'debug[3]':'Not Used',
 						},
+            'GYRO_SCALED' : {
+                            'debug[all]':'Debug Gyro Scaled', 
+                            'debug[0]':'Gyro Scaled [roll]',
+                            'debug[1]':'Gyro Scaled [pitch]',
+                            'debug[2]':'Gyro Scaled [yaw]',
+                            'debug[3]':'Not Used',
+                        },
 			'RC_INTERPOLATION' : 	{	
 							'debug[all]':'Debug RC',	
 							'debug[0]':'RC Command Raw [roll]',
@@ -423,9 +437,11 @@ function FlightLogFieldPresenter() {
 						default:
 							return (value/10).toFixed(1) + "V"
 					}	
-				case 'GYRO':
-				case 'NOTCH':
-					return Math.round(flightLog.gyroRawToDegreesPerSecond(value)) + "deg/s";
+                case 'GYRO':
+                case 'GYRO_FILTERED':
+                case 'GYRO_SCALED':
+                case 'NOTCH':
+                    return Math.round(flightLog.gyroRawToDegreesPerSecond(value)) + "deg/s";
 				case 'ACCELEROMETER':
 				    return flightLog.accRawToGs(value).toFixed(2) + "g";
 				case 'MIXER':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -357,6 +357,8 @@ GraphConfig.load = function(config) {
                                 outputRange: 1.0
                             };       
                     case 'GYRO':
+                    case 'GYRO_FILTERED':
+                    case 'GYRO_SCALED':
                     case 'NOTCH':
                         return {
                             offset: 0,


### PR DESCRIPTION
To be aligned with https://github.com/betaflight/betaflight/pull/6059

Finally I detect the Betaflight version. We usually don't use old logs, but I know some people using always one or two versions old of Betaflight. 

@fujin I don't know if some name/value changed. All of them are deg/sec for the three axis. Is that correct?