### PR TITLE
Debugging without nw.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ openLinksInExternalBrowserByDefault();
 
 $(document).ready(function () {
     // translate to user-selected language
-    localize();
+    if (isNW()) { localize(); }
 });
 
 function checkForConfiguratorUpdates() {
@@ -53,20 +53,7 @@ function notifyOutdatedVersion(releaseData) {
     });
 }
 
-function getManifestVersion(manifest) {
-    if (!manifest) {
-        manifest = chrome.runtime.getManifest();
-    }
-
-    var version = manifest.version_name;
-    if (!version) {
-        version = manifest.version;
-    }
-
-    return version;
-}
-
-checkForConfiguratorUpdates();
+if (isNW()) { checkForConfiguratorUpdates(); }
 
 function openLinksInExternalBrowserByDefault() {
     try {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@ openLinksInExternalBrowserByDefault();
 
 $(document).ready(function () {
     // translate to user-selected language
-    if (isNW()) { localize(); }
+    if (isNW()) { 
+        localize(); 
+    }
 });
 
 function checkForConfiguratorUpdates() {
@@ -53,7 +55,9 @@ function notifyOutdatedVersion(releaseData) {
     });
 }
 
-if (isNW()) { checkForConfiguratorUpdates(); }
+if (isNW()) { 
+    checkForConfiguratorUpdates(); 
+}
 
 function openLinksInExternalBrowserByDefault() {
     try {

--- a/js/main.js
+++ b/js/main.js
@@ -1991,19 +1991,6 @@ function BlackboxLogViewer() {
     });
 }
 
-function getManifestVersion(manifest) {
-    if (!manifest) {
-        manifest = chrome.runtime.getManifest();
-    }
-
-    var version = manifest.version_name;
-    if (!version) {
-        version = manifest.version;
-    }
-
-    return version;
-}
-
 // Boostrap's data API is extremely slow when there are a lot of DOM elements churning, don't use it
 $(document).off('.data-api');
 

--- a/js/main.js
+++ b/js/main.js
@@ -942,7 +942,7 @@ function BlackboxLogViewer() {
             loadFiles(files);
 
             // Clear the files, in this way we can open a file with the same path/name again
-            e.target.files.clear();
+            e.target.value = "";
         });
         
         // New View Controls

--- a/js/tools.js
+++ b/js/tools.js
@@ -449,7 +449,7 @@ function firmwareGreaterOrEqual(sysConfig, bf_version, cf_version) {
     }
 }
 
-function isNW(){
+function isNW() {
     try{
         return (typeof require('nw.gui') !== "undefined");
     } catch (e){

--- a/js/tools.js
+++ b/js/tools.js
@@ -448,3 +448,30 @@ function firmwareGreaterOrEqual(sysConfig, bf_version, cf_version) {
                (sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(sysConfig.firmwareVersion, cf_version));
     }
 }
+
+function isNW(){
+    try{
+        return (typeof require('nw.gui') !== "undefined");
+    } catch (e){
+        return false;
+    }
+}
+
+function getManifestVersion(manifest) {
+    try {
+        if (!manifest) {
+            manifest = chrome.runtime.getManifest();
+        }
+
+        var version = manifest.version_name;
+        if (!version) {
+            version = manifest.version;
+        }
+
+        return version;
+
+    } catch (error) {
+        console.log("manifest does not exist, probably not running nw.js");
+        return "-"
+    }
+}

--- a/js/tools.js
+++ b/js/tools.js
@@ -450,9 +450,9 @@ function firmwareGreaterOrEqual(sysConfig, bf_version, cf_version) {
 }
 
 function isNW() {
-    try{
+    try {
         return (typeof require('nw.gui') !== "undefined");
-    } catch (e){
+    } catch (error) {
         return false;
     }
 }


### PR DESCRIPTION
Allow for debugging most of the application without rebuilding it. This saves a lot of time! It can now be run directly from the file system, with some limitations in video-export. In VS Code for example you may start a debug session with the follow contents in `.vscode/launch.json`:

```
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "chrome",
            "request": "launch",
            "name": "Launch Chrome",
            "url": "${workspaceFolder}/index.html",
            "webRoot": "${workspaceFolder}", 
        },
    ]
}
```
Or, you may run and edit directly in Chrome DevTools from filesystem.

Moved getManifestVersion in accordance to #207. 
Re-fixed #197, since latest Chrome (66.0.3359.181) doesn't support clearing a FileList. 