### PR TITLE
Video volume 100%

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -713,7 +713,7 @@ function BlackboxLogViewer() {
         }
             
         videoURL = URL.createObjectURL(file);
-        video.volume = 0.05;
+        video.volume = 1.00;
         video.src = videoURL;
         
         // Reapply the last playbackRate to the new video


### PR DESCRIPTION
I don't know if this has been made for some reason, but the actual video volume is only 5%. This PR returns it to 100% (the same as the system).

To hear the sound I'm raising the system volume, and if then I reproduce a video outside the Blackbox, the volume is way high.

I think is better to have both similar, you can use the mixer of the SO to modify that. Another solution is to add an option to modify the volume in the app but I don't know if it is necessary.