### PR TITLE
More font weight for the Zoom Expo Smooth texts

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -614,6 +614,7 @@ html.has-config .configuration-list {
     font-size: 8px;
     color:  black;
     opacity: 0.8;
+    font-weight: bold;
     padding-left: 0.3em;
 }
 


### PR DESCRIPTION
I don't know if I'm the only one... but is difficult to me to read the little texts of the zoom, expo and smooth settings depending on the background color and distance to monitor. This is a simple change to make them more visible.

Before:
![image](https://user-images.githubusercontent.com/2673520/42137678-4124a800-7d71-11e8-9adf-d13236b37047.png)

After:
![image](https://user-images.githubusercontent.com/2673520/42137676-332382da-7d71-11e8-8f67-254614057397.png)
