### PR TITLE
Add new debug modes name

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -254,7 +254,14 @@ var
             "RUNAWAY_TAKEOFF",
             "SDIO",
             "CURRENT_SENSOR",
-            "USB"
+            "USB",
+            "SMARTAUDIO",
+            "RTH",
+            "ITERM_RELAX",
+            "ACRO_TRAINER",
+            "RC_SMOOTHING",
+            "RX_SIGNAL_LOSS",
+            "RC_SMOOTHING_RATE",
     ]),
 
     SUPER_EXPO_YAW = makeReadOnly([


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/226

The ideal will be add the units, expo, etc. of each of the modes, but this can be done in a later stage. At least now the DEBUG_MODE is identified correctly.