### PR TITLE
Added support for rate_limits in header.

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -1026,10 +1026,11 @@ FlightLog.prototype.rcCommandRawToDegreesPerSecond = function(value, axis, curre
             }
             */
 
+            var limit = sysConfig["rate_limits"][axis];
             if (sysConfig.pidController == 0 /* LEGACY */) {
                 return  constrain(angleRate * 4.1, -8190.0, 8190.0) >> 2; // Rate limit protection
             } else {
-                return  constrain(angleRate, -1998.0, 1998.0); // Rate limit protection (deg/sec)
+                return  constrain(angleRate, -1.0 * limit, limit); // Rate limit protection (deg/sec)
             }
         };
 

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -210,6 +210,7 @@ var FlightLogParser = function(logData) {
             serialrx_provider:null,                 // name of the serial rx provider
             superExpoFactor:null,                   // Super Expo Factor
             rates:[null, null, null],               // Rates [ROLL, PITCH, YAW]
+            rate_limits:[1998, 1998, 1998],         // Limits [ROLL, PITCH, YAW] with defaults for backward compatibility
             rc_rates:[null, null, null],            // RC Rates [ROLL, PITCH, YAW]
             rc_expo:[null, null, null],             // RC Expo [ROLL, PITCH, YAW]
             looptime:null,                          // Looptime
@@ -656,6 +657,7 @@ var FlightLogParser = function(logData) {
 
             /* CSV packed values */
             case "rates":
+            case "rate_limits":
             case "rollPID":
             case "pitchPID":
             case "yawPID":


### PR DESCRIPTION
Ref. https://github.com/betaflight/betaflight/pull/6402 I have added support for rate_limits in the log header for use in this PR revision to `flightlog.js/calculateSetpointRate()`.
Defaults of 1998 are set for backward compatibility with previous version of calculation.