### PR TITLE
Add AG type and RC Smoothing type info to Header

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,6 +900,12 @@
                                     <table class="parameter cf">
                                         <tbody>
                                             <tr>
+                                                <td name="antiGravityMode" class="bf-only">
+                                                    <label>AG Mode</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
                                                 <td name="antiGravityGain" class="bf-only">
                                                     <label>AG Gain</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
@@ -1385,15 +1391,58 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
+                                                    <th colspan="5">RC Smoothing</th>
+                                                </tr>
+                                                <tr>
+                                                    <td name='rc_smoothing_type'>
+                                                        <label>Type</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
                                                     <td name='rc_interpolation'>
-                                                        <label>RC Interpolation</label>
+                                                        <label>Interpolation</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
                                                     <td name="rc_interpolation_interval">
-                                                        <label>RC Interval (ms)</label>
+                                                        <label>Interval (ms)</label>
                                                         <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="rc_smoothing_cutoffs_1">
+                                                        <label>Input Hz</label>
+                                                        <input type="number" step="1" min="0" max="255" />
+                                                    </td>
+                                                    <td name="rc_smoothing_cutoffs_2">
+                                                        <label>Derivative Hz</label>
+                                                        <input type="number" step="1" min="0" max="255" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="rc_smoothing_rx_average">
+                                                        <label>RX Average (ms)</label>
+                                                        <input type="number" step="0.1" min="0"/>
+                                                    </td>
+                                                    <td name='rc_smoothing_filter_type_1'>
+                                                        <label>Input Type</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name='rc_smoothing_filter_type_2'>
+                                                        <label>Derivative Type</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name='rc_smoothing_debug_axis'>
+                                                        <label>Debug Axis</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
                                                     </td>
                                                 </tr>
                                             </tbody>

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -200,6 +200,34 @@ var
 			"JETIEXBUS"
     ]),
 
+    ANTI_GRAVITY_MODE = makeReadOnly([
+        "SMOOTH",
+        "STEP"
+    ]),
+
+    RC_SMOOTHING_TYPE = makeReadOnly([
+        "INTERPOLATION", 
+        "FILTER"
+    ]),
+
+    RC_SMOOTHING_INPUT_TYPE = makeReadOnly([
+        "PT1", 
+        "BIQUAD"
+    ]),
+
+    RC_SMOOTHING_DERIVATIVE_TYPE = makeReadOnly([
+        "OFF", 
+        "PT1", 
+        "BIQUAD"
+    ]),
+
+    RC_SMOOTHING_DEBUG_AXIS = makeReadOnly([
+        "ROLL", 
+        "PITCH", 
+        "YAW", 
+        "THROTTLE"
+    ]),
+
     RC_INTERPOLATION = makeReadOnly([
             "OFF",
             "DEFAULT",

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -199,76 +199,84 @@ var FlightLogParser = function(logData) {
         // standard logger.
 
         defaultSysConfigExtension = {
-            thrMid:null,              	    // Throttle Mid Position
-            thrExpo:null,              	    // Throttle Expo
-            tpa_breakpoint:null,            // TPA Breakpoint
-            airmode_activate_throttle:null, // airmode activation level
-            serialrx_provider:null,         // name of the serial rx provider
-            superExpoFactor:null,           // Super Expo Factor
-            rates:[null, null, null],	    // Rates [ROLL, PITCH, YAW]
-            rc_rates:[null, null, null],    // RC Rates [ROLL, PITCH, YAW]
-            rc_expo:[null, null, null],     // RC Expo [ROLL, PITCH, YAW]
-            looptime:null,                  // Looptime
-            gyro_sync_denom:null,           // Gyro Sync Denom
-            pid_process_denom:null,         // PID Process Denom
-            pidController:null,             // Active PID Controller
-            rollPID:[null, null, null],	    // Roll [P, I, D]
-            pitchPID:[null, null, null],	// Pitch[P, I, D]
-            yawPID:[null, null, null],	    // Yaw  [P, I, D]
-            feedforward_transition:null,    // Feedforward transition
-            altPID:[null, null, null],	    // Altitude Hold [P, I, D]
-            posPID:[null, null, null],	    // Position Hold [P, I, D]
-            posrPID:[null, null, null],	    // Position Rate [P, I, D]
-            navrPID:[null, null, null],	    // Nav Rate      [P, I, D]
-            levelPID:[null, null, null],	// Level Mode    [P, I, D]
-            magPID:null,              	    // Magnetometer   P
-            velPID:[null, null, null],	    // Velocity      [P, I, D]
-            yaw_p_limit:null,               // Yaw P Limit
-            yaw_lpf_hz:null,                // Yaw LowPass Filter Hz
-            dterm_average_count:null,       // DTerm Average Count
-            rollPitchItermResetRate:null,   // ITerm Reset rate for Roll and Pitch
-            yawItermResetRate:null,         // ITerm Reset Rate for Yaw
-            dterm_lpf_hz:null,              // DTerm Lowpass Filter Hz
-            dterm_lpf2_hz:null,              // DTerm Lowpass Filter Hz 2
-            dterm_differentiator:null,      // DTerm Differentiator
-            H_sensitivity:null,             // Horizon Sensitivity
-            iterm_reset_offset:null,        // I-Term reset offset
-            deadband:null,                  // Roll, Pitch Deadband
-            yaw_deadband:null,              // Yaw Deadband
-            gyro_lpf:null,                  // Gyro lpf setting.
-            gyro_32khz_hardware_lpf:null,   // Gyro 32khz hardware lpf setting. (post BF3.4)
-            gyro_lowpass_hz:null,           // Gyro Soft Lowpass Filter Hz
-            gyro_lowpass2_hz:null,          // Gyro Soft Lowpass Filter Hz 2
-            gyro_notch_hz:null,             // Gyro Notch Frequency
-            gyro_notch_cutoff:null,         // Gyro Notch Cutoff
-            dterm_notch_hz:null,            // Dterm Notch Frequency
-            dterm_notch_cutoff:null,        // Dterm Notch Cutoff
-            acc_lpf_hz:null,                // Accelerometer Lowpass filter Hz
-            acc_hardware:null,              // Accelerometer Hardware type
-            baro_hardware:null,             // Barometer Hardware type
-            mag_hardware:null,              // Magnetometer Hardware type
-            gyro_cal_on_first_arm:null,     // Gyro Calibrate on first arm
-            vbat_pid_compensation:null,     // VBAT PID compensation
-            rc_smoothing:null,              // RC Control Smoothing
-            rc_interpolation:null, 			// RC Control Interpolation type
-            rc_interpolation_interval:null, // RC Control Interpolation Interval
-            dterm_filter_type:null,         // D term filtering type (PT1, BIQUAD)
-            pidAtMinThrottle:null,          // Stabilisation at zero throttle
-            itermThrottleGain:null,         // Betaflight PID
-            ptermSetpointWeight:null,       // Betaflight PID
-            dtermSetpointWeight:null,       // Betaflight PID
-            yawRateAccelLimit:null,         // Betaflight PID
-            rateAccelLimit:null,            // Betaflight PID
-            gyro_soft_type:null,            // Gyro soft filter type (PT1, BIQUAD)
-            gyro_soft2_type:null,           // Gyro soft filter 2 type (PT1, BIQUAD)
-            debug_mode:null,                // Selected Debug Mode
-            features:null,                  // Activated features (e.g. MOTORSTOP etc)
-            Craft_name:null,                // Craft Name
-            motorOutput:[null,null],        // Minimum and maximum outputs to motor's
-            digitalIdleOffset:null,         // min throttle for d-shot (as a percentage)
-            pidSumLimit:null,               // PID sum limit
-            pidSumLimitYaw:null,            // PID sum limit yaw
-            unknownHeaders : []             // Unknown Extra Headers
+            anti_gravity_gain:null,                 // Anti gravity gain
+            anti_gravity_mode:null,                 // Anti gravity mode
+            anti_gravity_threshold:null,            // Anti gravity threshold for step mode
+            thrMid:null,                            // Throttle Mid Position
+            thrExpo:null,                           // Throttle Expo
+            tpa_breakpoint:null,                    // TPA Breakpoint
+            airmode_activate_throttle:null,         // airmode activation level
+            serialrx_provider:null,                 // name of the serial rx provider
+            superExpoFactor:null,                   // Super Expo Factor
+            rates:[null, null, null],               // Rates [ROLL, PITCH, YAW]
+            rc_rates:[null, null, null],            // RC Rates [ROLL, PITCH, YAW]
+            rc_expo:[null, null, null],             // RC Expo [ROLL, PITCH, YAW]
+            looptime:null,                          // Looptime
+            gyro_sync_denom:null,                   // Gyro Sync Denom
+            pid_process_denom:null,                 // PID Process Denom
+            pidController:null,                     // Active PID Controller
+            rollPID:[null, null, null],             // Roll [P, I, D]
+            pitchPID:[null, null, null],            // Pitch[P, I, D]
+            yawPID:[null, null, null],              // Yaw  [P, I, D]
+            feedforward_transition:null,            // Feedforward transition
+            altPID:[null, null, null],              // Altitude Hold [P, I, D]
+            posPID:[null, null, null],              // Position Hold [P, I, D]
+            posrPID:[null, null, null],             // Position Rate [P, I, D]
+            navrPID:[null, null, null],             // Nav Rate      [P, I, D]
+            levelPID:[null, null, null],            // Level Mode    [P, I, D]
+            magPID:null,                            // Magnetometer   P
+            velPID:[null, null, null],              // Velocity      [P, I, D]
+            yaw_p_limit:null,                       // Yaw P Limit
+            yaw_lpf_hz:null,                        // Yaw LowPass Filter Hz
+            dterm_average_count:null,               // DTerm Average Count
+            rollPitchItermResetRate:null,           // ITerm Reset rate for Roll and Pitch
+            yawItermResetRate:null,                 // ITerm Reset Rate for Yaw
+            dterm_lpf_hz:null,                      // DTerm Lowpass Filter Hz
+            dterm_lpf2_hz:null,                     // DTerm Lowpass Filter Hz 2
+            dterm_differentiator:null,              // DTerm Differentiator
+            H_sensitivity:null,                     // Horizon Sensitivity
+            iterm_reset_offset:null,                // I-Term reset offset
+            deadband:null,                          // Roll, Pitch Deadband
+            yaw_deadband:null,                      // Yaw Deadband
+            gyro_lpf:null,                          // Gyro lpf setting.
+            gyro_32khz_hardware_lpf:null,           // Gyro 32khz hardware lpf setting. (post BF3.4)
+            gyro_lowpass_hz:null,                   // Gyro Soft Lowpass Filter Hz
+            gyro_lowpass2_hz:null,                  // Gyro Soft Lowpass Filter Hz 2
+            gyro_notch_hz:null,                     // Gyro Notch Frequency
+            gyro_notch_cutoff:null,                 // Gyro Notch Cutoff
+            dterm_notch_hz:null,                    // Dterm Notch Frequency
+            dterm_notch_cutoff:null,                // Dterm Notch Cutoff
+            acc_lpf_hz:null,                        // Accelerometer Lowpass filter Hz
+            acc_hardware:null,                      // Accelerometer Hardware type
+            baro_hardware:null,                     // Barometer Hardware type
+            mag_hardware:null,                      // Magnetometer Hardware type
+            gyro_cal_on_first_arm:null,             // Gyro Calibrate on first arm
+            vbat_pid_compensation:null,             // VBAT PID compensation
+            rc_smoothing:null,                      // RC Control Smoothing
+            rc_smoothing_type:null,                 // Type of the RC Smoothing
+            rc_interpolation:null,                  // RC Control Interpolation type
+            rc_interpolation_interval:null,         // RC Control Interpolation Interval
+            rc_smoothing_cutoffs:[null, null],      // RC Smoothing input and derivative cutoff
+            rc_smoothing_filter_type:[null,null],   // RC Smoothing input and derivative type
+            rc_smoothing_rx_average:null,           // RC Smoothing rx average readed in ms
+            rc_smoothing_debug_axis:null,           // Axis recorded in the debug mode of rc_smoothing
+            dterm_filter_type:null,                 // D term filtering type (PT1, BIQUAD)
+            pidAtMinThrottle:null,                  // Stabilisation at zero throttle
+            itermThrottleGain:null,                 // Betaflight PID
+            ptermSetpointWeight:null,               // Betaflight PID
+            dtermSetpointWeight:null,               // Betaflight PID
+            yawRateAccelLimit:null,                 // Betaflight PID
+            rateAccelLimit:null,                    // Betaflight PID
+            gyro_soft_type:null,                    // Gyro soft filter type (PT1, BIQUAD)
+            gyro_soft2_type:null,                   // Gyro soft filter 2 type (PT1, BIQUAD)
+            debug_mode:null,                        // Selected Debug Mode
+            features:null,                          // Activated features (e.g. MOTORSTOP etc)
+            Craft_name:null,                        // Craft Name
+            motorOutput:[null,null],                // Minimum and maximum outputs to motor's
+            digitalIdleOffset:null,                 // min throttle for d-shot (as a percentage)
+            pidSumLimit:null,                       // PID sum limit
+            pidSumLimitYaw:null,                    // PID sum limit yaw
+            unknownHeaders : []                     // Unknown Extra Headers
         },
 
         // Translation of the field values name to the sysConfig var where it must be stored
@@ -527,6 +535,9 @@ var FlightLogParser = function(logData) {
             case "gyro_cal_on_first_arm":
             case "vbat_pid_compensation":
             case "rc_smoothing":
+            case "rc_smoothing_type":
+            case "rc_smoothing_debug_axis":
+            case "rc_smoothing_rx_average":
             case "superExpoYawMode":
             case "features":
             case "dynamic_pid":
@@ -551,6 +562,7 @@ var FlightLogParser = function(logData) {
             case "gyro_soft_type":
             case "gyro_soft2_type":
             case "debug_mode":
+            case "anti_gravity_mode":
             case "anti_gravity_gain":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
@@ -640,6 +652,8 @@ var FlightLogParser = function(logData) {
             case "levelPID":
             case "velPID":
             case "motorOutput":
+            case "rc_smoothing_cutoffs":
+            case "rc_smoothing_filter_type":
                 that.sysConfig[fieldName] = parseCommaSeparatedString(fieldValue);
             break;
             case "magPID":

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -65,7 +65,15 @@ function HeaderDialog(dialog, onSave) {
             {name:'itermWindupPointPercent'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.1.0', max:'999.9.9'},
             {name:'pidSumLimit'        			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
             {name:'pidSumLimitYaw'     			, type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
-            {name:'feedforward_transition'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'}
+            {name:'rc_smoothing_type'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
+            {name:'feedforward_transition'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'antiGravityMode'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_cutoffs_1'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_cutoffs_2'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_filter_type_1'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_filter_type_1'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_rx_average'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+            {name:'rc_smoothing_debug_axis'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -539,8 +547,28 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
 		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
-    	renderSelect('rc_interpolation'		    ,sysConfig.rc_interpolation, RC_INTERPOLATION);
-        setParameter('rc_interpolation_interval',sysConfig.rc_interpolation_interval,0);
+        renderSelect('rc_smoothing_type'          ,sysConfig.rc_smoothing_type, RC_SMOOTHING_TYPE);
+        renderSelect('rc_interpolation'           ,sysConfig.rc_interpolation, RC_INTERPOLATION);
+        setParameter('rc_interpolation_interval'  ,sysConfig.rc_interpolation_interval,0);
+        setParameter('rc_smoothing_cutoffs_1'     ,sysConfig.rc_smoothing_cutoffs[0], 0);
+        setParameter('rc_smoothing_cutoffs_2'     ,sysConfig.rc_smoothing_cutoffs[1], 0);
+        renderSelect('rc_smoothing_filter_type_1' ,sysConfig.rc_smoothing_filter_type[0], RC_SMOOTHING_INPUT_TYPE);
+        renderSelect('rc_smoothing_filter_type_2' ,sysConfig.rc_smoothing_filter_type[1], RC_SMOOTHING_DERIVATIVE_TYPE);
+        setParameter('rc_smoothing_rx_average'    ,sysConfig.rc_smoothing_rx_average, 3);
+        renderSelect('rc_smoothing_debug_axis'    ,sysConfig.rc_smoothing_filter_type[1], RC_SMOOTHING_DEBUG_AXIS);
+
+        if (sysConfig.rc_smoothing_type === RC_SMOOTHING_TYPE.indexOf('FILTER')) {
+            $('.parameter td[name="rc_interpolation"]').css('display', 'none');
+            $('.parameter td[name="rc_interpolation_interval"]').css('display', 'none');
+        } else {
+            $('.parameter td[name="rc_smoothing_type"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_cutoffs_1"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_cutoffs_2"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_filter_type_1"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_filter_type_2"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_rx_average"]').css('display', 'none');
+            $('.parameter td[name="rc_smoothing_debug_axis"]').css('display', 'none');
+        }
     	renderSelect('unsynced_fast_pwm'		,sysConfig.unsynced_fast_pwm, MOTOR_SYNC);
     	renderSelect('fast_pwm_protocol'		,sysConfig.fast_pwm_protocol, FAST_PROTOCOL);
         setParameter('motor_pwm_rate'		    ,sysConfig.motor_pwm_rate,0);
@@ -561,6 +589,7 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('motorOutputLow'			,sysConfig.motorOutput[0],0);
 		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1],0);
 		setParameter('digitalIdleOffset'		,sysConfig.digitalIdleOffset,2);
+        renderSelect('antiGravityMode'          ,sysConfig.anti_gravity_mode, ANTI_GRAVITY_MODE);
         if((activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) ||
                 (activeSysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '2.0.0'))) {
             setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,3);
@@ -568,6 +597,9 @@ function HeaderDialog(dialog, onSave) {
             setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,0);
         }
         setParameter('antiGravityThreshold'     ,sysConfig.anti_gravity_threshold,0);
+        if (sysConfig.anti_gravity_mode === ANTI_GRAVITY_MODE.indexOf('SMOOTH')) {
+            $('.parameter td[name="antiGravityThreshold"]').css('display', 'none');
+        }
 		setParameter('setpointRelaxRatio'		,sysConfig.setpointRelaxRatio,2);
 		setParameter('pidSumLimit'     			,sysConfig.pidSumLimit,0);
         setParameter('pidSumLimitYaw'			,sysConfig.pidSumLimitYaw,0);


### PR DESCRIPTION
This add Anti Gravity type and RC Smoothing type info to the header page. I think is better to not merge until the RC Smoothing part is finished in the configurator, in this way I can try to maintain this more similar to configurator (name, order of fields, etc.)