### PR TITLE
Adjust content of debug[3] FFT_FREQ

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -234,7 +234,7 @@ function FlightLogFieldPresenter() {
                             'debug[0]':'Center Freq [roll]',
                             'debug[1]':'Center Freq [pitch]',
                             'debug[2]':'Center Freq [yaw]',
-                            'debug[3]':'Not used',
+                            'debug[3]':'Gyro Raw [roll]',
             },
             'GYRO_RAW' :   {
                             'debug[all]':'Debug Gyro Raw', 
@@ -485,7 +485,12 @@ function FlightLogFieldPresenter() {
                 case 'FFT_TIME':
                     return value.toFixed(0) + "\u03BCS";
                 case 'FFT_FREQ':
-                    return value.toFixed(0) + "Hz";
+                    switch (fieldName) {
+                    case 'debug[3]':
+                        return Math.round(flightLog.gyroRawToDegreesPerSecond(value)) + "deg/s";
+                    default:
+                        return value.toFixed(0) + "Hz";
+                    }
                 default:
 					return value.toFixed(0);
 			}	


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/239

The content of the debug[3] field, that was empty, has changed since 3.5.0 and stores the raw gyro roll data.

I have made the simplest change possible, changing the name of the content for all versions because:
- It's only a debug value
- At the moment that the names list is readed, there is no info of version. So adjust the name to the version will mess the code.
- The worst that happens is that versions earlier to 3.5.0 will have a zero value always in this field.