### PR TITLE
Fix G frames detected as invalid

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -368,7 +368,10 @@ function FlightLog(logData) {
                     var
                         destFrame;
 
-                    if (frameValid) {
+                    // The G frames need to be processed always. They are "invalid" if not H (Home) has been detected 
+                    // before, but if not processed the viewer shows cuts and gaps. This happens if the quad takes off before 
+                    // fixing enough satellites.
+                    if (frameValid || (frameType == 'G')) {
                         switch (frameType) {
                             case 'P':
                             case 'I':


### PR DESCRIPTION
This is a follow up of: https://github.com/betaflight/blackbox-log-viewer/pull/246

Fixes the G frames producing cuts in the viewer when taking off without a GPS fix.