### PR TITLE
Rename the Gyros ADC Scaled fields

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -57,10 +57,10 @@ function FlightLogFieldPresenter() {
         'gyroADC[2]': 'Gyro [yaw]',
 
         //Virtual field
-        'gyroADCs[all]': 'Gyros Scaled',
-        'gyroADCs[0]': 'Gyro Scaled [roll]',
-        'gyroADCs[1]': 'Gyro Scaled [pitch]',
-        'gyroADCs[2]': 'Gyro Scaled [yaw]',
+        'gyroADCs[all]': 'Gyros ADC Scaled',
+        'gyroADCs[0]': 'Gyro ADC Scaled [roll]',
+        'gyroADCs[1]': 'Gyro ADC Scaled [pitch]',
+        'gyroADCs[2]': 'Gyro ADC Scaled [yaw]',
 
         //End-users prefer 1-based indexing
         'motor[all]': 'Motors',


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/258

Is a simple rename. But maybe is better to remove the Gyro ADC fields. Is a calculated field:
https://github.com/betaflight/blackbox-log-viewer/blob/b38379618ae2104615bcfdc7f20a9db082893fdf/js/flightlog.js#L603-L608

Nobody seems to know what represents. It seems the same than the gyro. Maybe in an older version it had some sense? 