### PR TITLE
Remove gyro ADC Scaled field

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -11,7 +11,7 @@
  */
 function FlightLog(logData) {
     var
-        ADDITIONAL_COMPUTED_FIELD_COUNT = 16, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GYROADC_SCALED **/
+        ADDITIONAL_COMPUTED_FIELD_COUNT = 15, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED **/
 
         that = this,
         logIndex = false,
@@ -226,7 +226,6 @@ function FlightLog(logData) {
         fieldNames.push("heading[0]", "heading[1]", "heading[2]");
         fieldNames.push("axisSum[0]", "axisSum[1]", "axisSum[2]");
         fieldNames.push("rcCommands[0]", "rcCommands[1]", "rcCommands[2]", "rcCommands[3]"); // Custom calculated scaled rccommand
-        fieldNames.push("gyroADCs[0]", "gyroADCs[1]", "gyroADCs[2]"); // Custom calculated gyro deg/sec
         fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
 
         fieldNameToIndex = {};
@@ -597,16 +596,10 @@ function FlightLog(logData) {
                         }
                     }
 
-                    // Calculate the scaled Gyro ADC
-                    var fieldIndexGyroADCs = fieldIndex;
-                    for (var axis = 0; axis < 3; axis++) {
-                        destFrame[fieldIndex++] =
-                            (gyroADC[axis] !== undefined ? that.gyroRawToDegreesPerSecond(srcFrame[gyroADC[axis]]) : 0);
-                    }
-
                     // Calculate the PID Error
                     for (var axis = 0; axis < 3; axis++) {
-                        destFrame[fieldIndex++] = destFrame[fieldIndexGyroADCs + axis] - destFrame[fieldIndexRcCommands + axis];
+                        let gyroADCdegrees = (gyroADC[axis] !== undefined ? that.gyroRawToDegreesPerSecond(srcFrame[gyroADC[axis]]) : 0);
+                        destFrame[fieldIndex++] = gyroADCdegrees - destFrame[fieldIndexRcCommands + axis];
                     }
 
                 }

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -56,12 +56,6 @@ function FlightLogFieldPresenter() {
         'gyroADC[1]': 'Gyro [pitch]',
         'gyroADC[2]': 'Gyro [yaw]',
 
-        //Virtual field
-        'gyroADCs[all]': 'Gyros Scaled',
-        'gyroADCs[0]': 'Gyro Scaled [roll]',
-        'gyroADCs[1]': 'Gyro Scaled [pitch]',
-        'gyroADCs[2]': 'Gyro Scaled [yaw]',
-
         //End-users prefer 1-based indexing
         'motor[all]': 'Motors',
         'motor[0]': 'Motor [1]', 

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -278,8 +278,7 @@ GraphConfig.load = function(config) {
                 };
             } else if (fieldName.match(/^axisError\[/)  ||     // Gyro, Gyro Scaled, RC Command Scaled and axisError
                        fieldName.match(/^rcCommands\[/) ||     // These use the same scaling as they are in the
-                       fieldName.match(/^gyroADCs\[/)   ||     // same range.
-                       fieldName.match(/^gyroADC\[/)) { 
+                       fieldName.match(/^gyroADC\[/)) {        // same range.
                 return {
                     offset: 0,
                     power: 0.25, /* Make this 1.0 to scale linearly */


### PR DESCRIPTION
This is a follow up of https://github.com/betaflight/blackbox-log-viewer/pull/259

As requested in the other PR, this PR removes the calculated field Gyro Scaledd.

After looking at the code, I think that in the past:
- The Gyro was the gyro in raw value.
- The Gyro Scaled was the Gyro converted in degrees/second.

This seems clear because the PID Error is calculated from the Gyro Scaled, both are calculated fields, and at this point we have not the "scaled" value of the gyro. Someone decided to add it in this way.

Now, when the Gyro is presented, it is converted into degrees/second, so it is no more the Gyro raw value.

@etracer65 @mikeller what do you think about this? We continue removing this or is better to try to go backwards and let the Gyro as raw value and the Gyro Scaled as degrees/second value?