### PR TITLE
Step back NW version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ const DEBUG_DIR = './debug/';
 const RELEASE_DIR = './release/';
 
 var nwBuilderOptions = {
-    version: '0.35.3',
+    version: '0.32.4',
     files: './dist/**/*',
     macIcns: './images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Blackbox Explorer'},


### PR DESCRIPTION
There is a bug since version 0.33.0 with the scroll of the header modal
window, as talked here https://github.com/betaflight/blackbox-log-viewer/issues/270.

So at this moment is better to maintain this old version until fixed.
