### PR TITLE
Add RPM Debug with common scaling

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -237,6 +237,20 @@ function FlightLogFieldPresenter() {
                             'debug[2]':'Gyro Raw [Z]',
                             'debug[3]':'Not Used',
                         },
+            'ESC_SENSOR_RPM' :   {
+                            'debug[all]':'ESC RPM', 
+                            'debug[0]':'ESC RPM [1]',
+                            'debug[1]':'ESC RPM [2]',
+                            'debug[2]':'ESC RPM [3]',
+                            'debug[3]':'ESC RPM [4]',
+                        },
+            'DSHOT_RPM_TELEMETRY' :   {
+                            'debug[all]':'DSHOT RPM', 
+                            'debug[0]':'DSHOT RPM [1]',
+                            'debug[1]':'DSHOT RPM [2]',
+                            'debug[2]':'DSHOT RPM [3]',
+                            'debug[3]':'DSHOT RPM [4]',
+                        },
             };
     
     function presentFlags(flags, flagNames) {


### PR DESCRIPTION
Related to #196

It is useful to have the RPM traces on the same graph, because we can compare actual motor outputs when the same commands are given.

Curve scaling is implemented that calculates min/max over all four debug traces.