### PR TITLE
Show friendly debug names in graph legend

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -109,14 +109,14 @@ function GraphConfig(graphConfig) {
                         if (logFieldNames[k].match(nameRegex)) {
                             // add special condition for rcCommands as each of the fields requires a different scaling.
                             let forceNewCurve = (nameRoot=='rcCommand') || (nameRoot=='rcCommands');
-                            newGraph.fields.push(adaptField($.extend({}, field, {name: logFieldNames[k]}), colorIndexOffset, forceNewCurve));
+                            newGraph.fields.push(adaptField($.extend({}, field, {name: logFieldNames[k], friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(logFieldNames[k], flightLog.getSysConfig().debug_mode)}), colorIndexOffset, forceNewCurve));
                             colorIndexOffset++;
                         }
                     }
                 } else {
                     // Don't add fields if they don't exist in this log
                     if (flightLog.getMainFieldIndexByName(field.name) !== undefined) {
-                        newGraph.fields.push(adaptField($.extend({}, field)));
+                        newGraph.fields.push(adaptField($.extend({}, field, {friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(field.name, flightLog.getSysConfig().debug_mode)})));
                     }
                 }
             }

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -34,7 +34,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                 li.append(valueElem);
                 li.append(settingsElem);
 
-                nameElem.text(FlightLogFieldPresenter.fieldNameToFriendly(field.name));
+                nameElem.text(field.friendlyName);
                 settingsElem.text(" ");
                 settingsElem.css('background', field.color);
                 fieldList.append(li);
@@ -72,7 +72,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                selectedFieldIndex    = $(this).attr('field');
 
            if(!e.altKey) {
-               config.selectedFieldName     = FlightLogFieldPresenter.fieldNameToFriendly($(this).attr('name'));
+               config.selectedFieldName     = config.getGraphs()[selectedGraphIndex].fields[selectedFieldIndex].friendlyName;
                config.selectedGraphIndex    = selectedGraphIndex;
                config.selectedFieldIndex    = selectedFieldIndex;
                if (onNewSelectionChange) {

--- a/js/main.js
+++ b/js/main.js
@@ -1018,7 +1018,7 @@ function BlackboxLogViewer() {
                 if (graphs.length == 0 || graphs[0].fields.length == 0) {
                     hasAnalyser = false;
                 } else { 
-                    activeGraphConfig.selectedFieldName = FlightLogFieldPresenter.fieldNameToFriendly(graphs[0].fields[0].name);
+                    activeGraphConfig.selectedFieldName = graphs[0].fields[0].friendlyName;
                     activeGraphConfig.selectedGraphIndex = 0;
                     activeGraphConfig.selectedFieldIndex = 0;
                     hasAnalyser = true;
@@ -1496,14 +1496,14 @@ function BlackboxLogViewer() {
                 for(var i=0; i<graphConfig[parseInt(graph)].fields.length; i++) {
                     graphConfig[parseInt(graph)].fields[i].smoothing += ((delta)?-scroll:+scroll);
                     graphConfig[parseInt(graph)].fields[i].smoothing = constrain(graphConfig[parseInt(graph)].fields[i].smoothing, range.min, range.max);
-                    changedValue += fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[i].name) + ' ' + (graphConfig[parseInt(graph)].fields[i].smoothing / 100).toFixed(2)+ '%\n';
+                    changedValue += graphConfig[parseInt(graph)].fields[i].friendlyName + ' ' + (graphConfig[parseInt(graph)].fields[i].smoothing / 100).toFixed(2)+ '%\n';
                 }
                 return changedValue;
             }
             if(graph!=null && field!=null) { // change single pen
                 graphConfig[parseInt(graph)].fields[parseInt(field)].smoothing += ((delta)?-scroll:+scroll);
                 graphConfig[parseInt(graph)].fields[parseInt(field)].smoothing = constrain(graphConfig[parseInt(graph)].fields[parseInt(field)].smoothing, range.min, range.max);
-                return changedValue + fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[parseInt(field)].name) + ' ' + (graphConfig[parseInt(graph)].fields[parseInt(field)].smoothing / 100).toFixed(2) + '%\n';
+                return changedValue + graphConfig[parseInt(graph)].fields[parseInt(field)].friendlyName + ' ' + (graphConfig[parseInt(graph)].fields[parseInt(field)].smoothing / 100).toFixed(2) + '%\n';
             }
             return false; // nothing was changed
         }
@@ -1528,14 +1528,14 @@ function BlackboxLogViewer() {
                 for(var i=0; i<graphConfig[parseInt(graph)].fields.length; i++) {
                     graphConfig[parseInt(graph)].fields[i].curve.outputRange += ((delta)?-scroll:+scroll);
                     graphConfig[parseInt(graph)].fields[i].curve.outputRange = constrain(graphConfig[parseInt(graph)].fields[i].curve.outputRange, range.min, range.max);
-                    changedValue += fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[i].name) + ' x' + (graphConfig[parseInt(graph)].fields[i].curve.outputRange).toFixed(1)+ '\n';
+                    changedValue += graphConfig[parseInt(graph)].fields[i].friendlyName + ' x' + (graphConfig[parseInt(graph)].fields[i].curve.outputRange).toFixed(1)+ '\n';
                 }
                 return changedValue;
             }
             if(graph!=null && field!=null) { // change single pen
                 graphConfig[parseInt(graph)].fields[parseInt(field)].curve.outputRange += ((delta)?-scroll:+scroll);
                 graphConfig[parseInt(graph)].fields[parseInt(field)].curve.outputRange = constrain(graphConfig[parseInt(graph)].fields[parseInt(field)].curve.outputRange, range.min, range.max);
-                return changedValue + fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[parseInt(field)].name) + ' x' + (graphConfig[parseInt(graph)].fields[parseInt(field)].curve.outputRange).toFixed(1) + '\n';;
+                return changedValue + graphConfig[parseInt(graph)].fields[parseInt(field)].friendlyName + ' x' + (graphConfig[parseInt(graph)].fields[parseInt(field)].curve.outputRange).toFixed(1) + '\n';;
             }
             return false; // nothing was changed
         }
@@ -1560,14 +1560,14 @@ function BlackboxLogViewer() {
                 for(var i=0; i<graphConfig[parseInt(graph)].fields.length; i++) {
                     graphConfig[parseInt(graph)].fields[i].curve.power += ((delta)?-scroll:+scroll);
                     graphConfig[parseInt(graph)].fields[i].curve.power = constrain(graphConfig[parseInt(graph)].fields[i].curve.power, range.min, range.max);
-                    changedValue += fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[i].name) + ' ' + (graphConfig[parseInt(graph)].fields[i].curve.power * 100).toFixed(2)+ '%\n';
+                    changedValue += graphConfig[parseInt(graph)].fields[i].friendlyName + ' ' + (graphConfig[parseInt(graph)].fields[i].curve.power * 100).toFixed(2)+ '%\n';
                 }
                 return changedValue;
             }
             if(graph!=null && field!=null) { // change single pen
                 graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power += ((delta)?-scroll:+scroll);
                 graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power = constrain(graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power, range.min, range.max);
-                return changedValue + fieldPresenter.fieldNameToFriendly(graphConfig[parseInt(graph)].fields[parseInt(field)].name) + ' ' + (graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power * 100).toFixed(2) + '%\n';;
+                return changedValue + graphConfig[parseInt(graph)].fields[parseInt(field)].friendlyName + ' ' + (graphConfig[parseInt(graph)].fields[parseInt(field)].curve.power * 100).toFixed(2) + '%\n';;
             }
             return false; // nothing was changed
         }


### PR DESCRIPTION
I'm not totally happy with the way this is implemented.

`debug_mode` from the flight log is needed for proper rendering of the debug friendly names.
`GraphLegend` is created before a log file has been loaded and thus its methods do not have access to the `flightLog` but have access to `GraphConfig`.
I've added the `debugMode` field to `GraphConfig` so that `GraphLegend` can access it.

`debugMode` does not sit very naturally in `GraphConfig` but it was the simplest way I found to solve this.

Please tell me if there's a more correct approach.