### PR TITLE
Fix overwritten FlightLogGrapher.destroy() method

### DIFF
--- a/js/grapher.js
+++ b/js/grapher.js
@@ -969,9 +969,6 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
     
     this.destroy = function() {
         $(canvas).off("mousedown", onMouseDown);
-    };
-    
-    this.destroy = function() {
         $(canvas).off("touchstart", onTouchStart);
     };
     


### PR DESCRIPTION
#250 adds second `destroy()` method which overwrites the first one. This caused the `onMouseDown` handler _not_ to be unbound on graph destroy.

This was not causing problem on first log open, but on consequent opens the older handlers continue to execute, causing weird behavior when drag-panning at different zoom levels.