### PR TITLE
Fix loading of saved graphs

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -109,14 +109,14 @@ function GraphConfig(graphConfig) {
                         if (logFieldNames[k].match(nameRegex)) {
                             // add special condition for rcCommands as each of the fields requires a different scaling.
                             let forceNewCurve = (nameRoot=='rcCommand') || (nameRoot=='rcCommands');
-                            newGraph.fields.push(adaptField($.extend({}, field, {name: logFieldNames[k], friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(logFieldNames[k], flightLog.getSysConfig().debug_mode)}), colorIndexOffset, forceNewCurve));
+                            newGraph.fields.push(adaptField($.extend({}, field, {curve: $.extend({}, field.curve), name: logFieldNames[k], friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(logFieldNames[k], flightLog.getSysConfig().debug_mode)}), colorIndexOffset, forceNewCurve));
                             colorIndexOffset++;
                         }
                     }
                 } else {
                     // Don't add fields if they don't exist in this log
                     if (flightLog.getMainFieldIndexByName(field.name) !== undefined) {
-                        newGraph.fields.push(adaptField($.extend({}, field, {friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(field.name, flightLog.getSysConfig().debug_mode)})));
+                        newGraph.fields.push(adaptField($.extend({}, field, {curve: $.extend({}, field.curve), friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(field.name, flightLog.getSysConfig().debug_mode)})));
                     }
                 }
             }


### PR DESCRIPTION
Loading of saved graphs did not make copies of the `curve` objects and
thus any quick zoom/smooth/expo modifications of the curve affected
the saved template (not the one saved in the preferences, but that in
memory).

Additional effect was that for saved graphs using xxx[all] curves
all child curves would use the same curve object which makes it
impossible to zoom/smooth/expo individually.