### PR TITLE
Add dynamic filters and dterm 2 type filter to the Blackbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -1058,6 +1058,24 @@
                                         </thead>
                                         <tbody>
                                             <tr>
+                                                <td name='gyro_soft_dyn_type' colspan="2">
+                                                    <label>Lowpass Dyn Filter<br>Type 1</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td name="gyro_soft_dyn_min_hz">
+                                                    <label>Lowpass Dyn Filter<br>Min Cutoff 1 (Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name="gyro_soft_dyn_max_hz">
+                                                    <label>Lowpass Dyn Filter<br>Max Cutoff 1 (Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+
                                                 <td name='gyro_soft_type'>
                                                     <label>Lowpass Filter<br>Type 1</label>
                                                     <select>
@@ -1110,7 +1128,26 @@
                                             </tr>
                                         </thead>
                                         <tbody>
+
                                             <tr>
+                                                <td name='dterm_dyn_type' colspan="2">
+                                                    <label>Lowpass Dyn Filter<br>Type 1</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td name="dterm_lpf_dyn_min_hz">
+                                                    <label>Lowpass Dyn Filter<br>Min Cutoff 1 (Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name="dterm_lpf_dyn_max_hz">
+                                                    <label>Lowpass Dyn Filter<br>Max Cutoff 1 (Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+
                                                 <td name='dterm_filter_type'>
                                                     <label>Lowpass Filter
                                                         <br>Type 1</label>
@@ -1122,6 +1159,13 @@
                                                     <label>Lowpass Filter
                                                         <br>Cutoff 1 (Hz)</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name='dterm_filter2_type'>
+                                                    <label>Lowpass Filter
+                                                        <br>Type 2</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
                                                 </td>
                                                 <td name="dterm_lpf2_hz">
                                                     <label>Lowpass Filter

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -232,6 +232,7 @@ var FlightLogParser = function(logData) {
             rollPitchItermResetRate:null,           // ITerm Reset rate for Roll and Pitch
             yawItermResetRate:null,                 // ITerm Reset Rate for Yaw
             dterm_lpf_hz:null,                      // DTerm Lowpass Filter Hz
+            dterm_lpf_dyn_hz:[null, null],          // DTerm Lowpass Dynamic Filter Min and Max Hz
             dterm_lpf2_hz:null,                     // DTerm Lowpass Filter Hz 2
             dterm_differentiator:null,              // DTerm Differentiator
             H_sensitivity:null,                     // Horizon Sensitivity
@@ -241,6 +242,7 @@ var FlightLogParser = function(logData) {
             gyro_lpf:null,                          // Gyro lpf setting.
             gyro_32khz_hardware_lpf:null,           // Gyro 32khz hardware lpf setting. (post BF3.4)
             gyro_lowpass_hz:null,                   // Gyro Soft Lowpass Filter Hz
+            gyro_lowpass_dyn_hz:[null, null],       // Gyro Soft Lowpass Dynamic Filter Min and Max Hz
             gyro_lowpass2_hz:null,                  // Gyro Soft Lowpass Filter Hz 2
             gyro_notch_hz:null,                     // Gyro Notch Frequency
             gyro_notch_cutoff:null,                 // Gyro Notch Cutoff
@@ -261,6 +263,7 @@ var FlightLogParser = function(logData) {
             rc_smoothing_rx_average:null,           // RC Smoothing rx average readed in ms
             rc_smoothing_debug_axis:null,           // Axis recorded in the debug mode of rc_smoothing
             dterm_filter_type:null,                 // D term filtering type (PT1, BIQUAD)
+            dterm_filter2_type:null,                // D term 2 filtering type (PT1, BIQUAD)
             pidAtMinThrottle:null,                  // Stabilisation at zero throttle
             itermThrottleGain:null,                 // Betaflight PID
             ptermSetpointWeight:null,               // Betaflight PID
@@ -550,6 +553,7 @@ var FlightLogParser = function(logData) {
             case "vbatref":
             case "acc_1G":
             case "dterm_filter_type":
+            case "dterm_filter2_type":
             case "pidAtMinThrottle":
             case "pidSumLimit":
             case "pidSumLimitYaw":
@@ -654,6 +658,8 @@ var FlightLogParser = function(logData) {
             case "motorOutput":
             case "rc_smoothing_cutoffs":
             case "rc_smoothing_filter_type":
+            case "gyro_lowpass_dyn_hz":
+            case "dterm_lpf_dyn_hz":
                 that.sysConfig[fieldName] = parseCommaSeparatedString(fieldValue);
             break;
             case "magPID":

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -246,9 +246,17 @@ try {
 		var offset = 0;
 		if (mouseFrequency !=null) drawMarkerLine(mouseFrequency, PLOTTED_BLACKBOX_RATE, '', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(0,255,0,0.50)", 3);
 		offset++; // make some space!
-        if ((flightLog.getSysConfig().gyro_lowpass_hz != null) && (flightLog.getSysConfig().gyro_lowpass_hz > 0)) {
+        // Dynamic gyro lpf 
+        if(flightLog.getSysConfig().gyro_lowpass_dyn_hz[0] != null && flightLog.getSysConfig().gyro_lowpass_dyn_hz[0] > 0 &&
+                flightLog.getSysConfig().gyro_lowpass_dyn_hz[1] > flightLog.getSysConfig().gyro_lowpass_dyn_hz[0]) {
+            drawDoubleMarkerLine(flightLog.getSysConfig().gyro_lowpass_dyn_hz[0], flightLog.getSysConfig().gyro_lowpass_dyn_hz[1], PLOTTED_BLACKBOX_RATE, 'GYRO LPF Dyn cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
+
+        // Static gyro lpf
+        } else  if ((flightLog.getSysConfig().gyro_lowpass_hz != null) && (flightLog.getSysConfig().gyro_lowpass_hz > 0)) {
             drawMarkerLine(flightLog.getSysConfig().gyro_lowpass_hz,  PLOTTED_BLACKBOX_RATE, 'GYRO LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,255,128,0.50)");
         }
+
+        // Static gyro lpf 2
         if ((flightLog.getSysConfig().gyro_lowpass2_hz != null) && (flightLog.getSysConfig().gyro_lowpass2_hz > 0)) {
             drawMarkerLine(flightLog.getSysConfig().gyro_lowpass2_hz, PLOTTED_BLACKBOX_RATE, 'GYRO LPF2 cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(95,199,95,0.50)");
         }
@@ -280,9 +288,17 @@ try {
 			if(dataBuffer.fieldName.match(/(.*yaw.*)/i)!=null) {
 				if(flightLog.getSysConfig().yaw_lpf_hz!=null)      		drawMarkerLine(flightLog.getSysConfig().yaw_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'YAW LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
 			} else {
-                if((flightLog.getSysConfig().dterm_lpf_hz != null) && (flightLog.getSysConfig().dterm_lpf_hz > 0)) {
+                // Dynamic dterm lpf 
+                if(flightLog.getSysConfig().dterm_lpf_dyn_hz[0] != null && flightLog.getSysConfig().dterm_lpf_dyn_hz[0] > 0 &&
+                        flightLog.getSysConfig().dterm_lpf_dyn_hz[1] > flightLog.getSysConfig().dterm_lpf_dyn_hz[0]) {
+                    drawDoubleMarkerLine(flightLog.getSysConfig().dterm_lpf_dyn_hz[0], flightLog.getSysConfig().dterm_lpf_dyn_hz[1], PLOTTED_BLACKBOX_RATE, 'GYRO LPF Dyn Min cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,128,255,0.50)");
+
+                // Static dterm lpf
+                } else if((flightLog.getSysConfig().dterm_lpf_hz != null) && (flightLog.getSysConfig().dterm_lpf_hz > 0)) {
                     drawMarkerLine(flightLog.getSysConfig().dterm_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'D-TERM LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(128,128,255,0.50)");
                 }
+
+                // Static dterm lpf 2
                 if((flightLog.getSysConfig().dterm_lpf2_hz != null) && (flightLog.getSysConfig().dterm_lpf2_hz > 0)) {
                     drawMarkerLine(flightLog.getSysConfig().dterm_lpf2_hz,  PLOTTED_BLACKBOX_RATE, 'D-TERM LPF2 cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN, "rgba(90,90,255,0.50)");
                 }
@@ -327,7 +343,26 @@ try {
 		
 		if(label!=null) drawAxisLabel(label + ' ' + (frequency.toFixed(0))+"Hz", (x + 2), OFFSET, 'left');
 		
+        return x;
 	};
+
+	var drawDoubleMarkerLine = function(frequency1, frequency2, sampleRate, label, WIDTH, HEIGHT, OFFSET, stroke, lineWidth) {
+        var x1 = drawMarkerLine(frequency1, sampleRate, null, WIDTH, HEIGHT, OFFSET, stroke, lineWidth);
+        var x2 = drawMarkerLine(frequency2, sampleRate, null, WIDTH, HEIGHT, OFFSET, stroke, lineWidth);
+
+        canvasCtx.beginPath();
+        canvasCtx.lineWidth = lineWidth || 1;
+        canvasCtx.strokeStyle = stroke || "rgba(128,128,255,0.50)";
+
+        canvasCtx.moveTo(x1, OFFSET - 10);
+        canvasCtx.lineTo(x2, OFFSET - 10);
+
+        canvasCtx.stroke();
+
+        if(label!=null) {
+            drawAxisLabel(label + ' ' + (frequency1.toFixed(0))+'-'+(frequency2.toFixed(0))+"Hz", (x1 + 2), OFFSET, 'left');
+        }
+    };
 
 	var drawGridLines = function(sampleRate, LEFT, TOP, WIDTH, HEIGHT, MARGIN) {
 

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -604,6 +604,39 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('pidSumLimit'     			,sysConfig.pidSumLimit,0);
         setParameter('pidSumLimitYaw'			,sysConfig.pidSumLimitYaw,0);
 
+        // Dynamic filters of Betaflight 4.0
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0') &&
+                (sysConfig.gyro_lowpass_dyn_hz[0] != null) && (sysConfig.gyro_lowpass_dyn_hz[0] > 0) &&
+                (sysConfig.gyro_lowpass_dyn_hz[1] > sysConfig.gyro_lowpass_dyn_hz[0])) {
+            renderSelect('gyro_soft_dyn_type', sysConfig.gyro_soft_type, FILTER_TYPE);
+            setParameter('gyro_soft_dyn_min_hz', sysConfig.gyro_lowpass_dyn_hz[0], 0);
+            setParameter('gyro_soft_dyn_max_hz', sysConfig.gyro_lowpass_dyn_hz[1], 0);
+            $('.parameter td[name="gyro_soft_dyn_type"]').parent().css('display', '');
+            $('.parameter td[name="gyro_soft_type"]').css('display', 'none');
+            $('.parameter td[name="gyro_lowpass_hz"]').css('display', 'none');
+        } else {
+            $('.parameter td[name="gyro_soft_dyn_type"]').parent().css('display', 'none');
+            $('.parameter td[name="gyro_soft_dyn_min_hz"]').css('display', 'none');
+            $('.parameter td[name="gyro_soft_dyn_max_hz"]').css('display', 'none');
+        }
+
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0') &&
+                (sysConfig.dterm_lpf_dyn_hz[0] != null) && (sysConfig.dterm_lpf_dyn_hz[0] > 0) &&
+                (sysConfig.dterm_lpf_dyn_hz[1] > sysConfig.dterm_lpf_dyn_hz[0])) {
+            renderSelect('dterm_filter2_type', sysConfig.dterm_filter2_type, FILTER_TYPE);
+            renderSelect('dterm_dyn_type', sysConfig.dterm_filter_type, FILTER_TYPE);
+            setParameter('dterm_lpf_dyn_min_hz', sysConfig.dterm_lpf_dyn_hz[0], 0);
+            setParameter('dterm_lpf_dyn_max_hz', sysConfig.dterm_lpf_dyn_hz[1], 0);
+            $('.parameter td[name="dterm_dyn_type"]').parent().css('display', '');
+            $('.parameter td[name="dterm_filter_type"]').css('display', 'none');
+            $('.parameter td[name="dterm_lpf_hz"]').css('display', 'none');
+        } else {
+            $('.parameter td[name="dterm_filter2_type"]').css('display', 'none');
+            $('.parameter td[name="dterm_dyn_type"]').parent().css('display', 'none');
+            $('.parameter td[name="dterm_lpf_dyn_min_hz"]').css('display', 'none');
+            $('.parameter td[name="dterm_lpf_dyn_max_hz"]').css('display', 'none');
+        }
+
 		/* Packed Flags */
 
         builtFeaturesList(sysConfig);


### PR DESCRIPTION
Adds support for the new dyn filters (header page and spectrum). It adds too the dterm type2 filter from here: https://github.com/betaflight/betaflight/pull/7850

It needs a general rework in aesthetics part (specially the spectrum), but is better to do it in other PR.