### PR TITLE
Fix dterm lpf dyn name

### DIFF
--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -292,6 +292,7 @@ var FlightLogParser = function(logData) {
             d_notch_cut               : "dterm_notch_cutoff", 
             d_setpoint_weight         : "dtermSetpointWeight",
             dterm_lowpass_hz          : "dterm_lpf_hz",
+            dterm_lowpass_dyn_hz      : "dterm_lpf_dyn_hz",
             dterm_lowpass2_hz         : "dterm_lpf2_hz",
             dterm_setpoint_weight     : "dtermSetpointWeight",  
             digital_idle_value        : "digitalIdleOffset",


### PR DESCRIPTION
The name of the dterm lpf dynamic was wrong. I think is cleaner to use the translation table to maintain some coherence with the other variable names in the Blackbox, but I can rename all the appearances of the variable in the code if we think is a better option.