### PR TITLE
Hide Yaw LPF Filter if zero

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -283,9 +283,11 @@ try {
 		}
 		offset++; // make some space!
 		try {
-			if(dataBuffer.fieldName.match(/(.*yaw.*)/i)!=null) {
-				if(flightLog.getSysConfig().yaw_lpf_hz!=null)      		drawLowpassFilter(flightLog.getSysConfig().yaw_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'YAW LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
-			} else {
+            if (dataBuffer.fieldName.match(/(.*yaw.*)/i) != null) {
+                if (flightLog.getSysConfig().yaw_lpf_hz != null && flightLog.getSysConfig().yaw_lpf_hz > 0) {
+                    drawLowpassFilter(flightLog.getSysConfig().yaw_lpf_hz,  PLOTTED_BLACKBOX_RATE, 'YAW LPF cutoff', WIDTH, HEIGHT, (15*offset++) + MARGIN);
+                }
+            } else {
                 // Dynamic dterm lpf 
                 if(flightLog.getSysConfig().dterm_lpf_dyn_hz[0] != null && flightLog.getSysConfig().dterm_lpf_dyn_hz[0] > 0 &&
                         flightLog.getSysConfig().dterm_lpf_dyn_hz[1] > flightLog.getSysConfig().dterm_lpf_dyn_hz[0]) {


### PR DESCRIPTION
Only show the yaw lpf filter if configured (not zero).

I have observed too that it only appears when the field of the spectrum contains the `yaw` word. I don't know if it can be interesting to hide other filters for other fields.

- Maybe show only d term filters if the field selected is a d term? Hide gyro filters if not in a gyro field?

I'm not too sure, but I throw here the question ;)