### PR TITLE
Fix max curve when rate_limit not defined

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -1027,7 +1027,7 @@ FlightLog.prototype.rcCommandRawToDegreesPerSecond = function(value, axis, curre
             */
 
             var limit = sysConfig["rate_limits"][axis];
-            if (sysConfig.pidController == 0 /* LEGACY */) {
+            if (sysConfig.pidController == 0 || limit == null) { /* LEGACY */
                 return  constrain(angleRate * 4.1, -8190.0, 8190.0) >> 2; // Rate limit protection
             } else {
                 return  constrain(angleRate, -1.0 * limit, limit); // Rate limit protection (deg/sec)


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/307

EDIT: I only edit to say that this bug affects to old versions of Betaflight (3.2.7 in the issue I think remember) that don't write the rate_limits value to the Blackbox.