### PR TITLE
Debug graph template and correct debug scales

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -107,8 +107,8 @@ function GraphConfig(graphConfig) {
                     
                     for (var k = 0; k < logFieldNames.length; k++) {
                         if (logFieldNames[k].match(nameRegex)) {
-                            // add special condition for rcCommands as each of the fields requires a different scaling.
-                            let forceNewCurve = (nameRoot=='rcCommand') || (nameRoot=='rcCommands');
+                            // add special condition for rcCommands and debug as each of the fields requires a different scaling.
+                            let forceNewCurve = (nameRoot=='rcCommand') || (nameRoot=='rcCommands') || (nameRoot=='debug');
                             newGraph.fields.push(adaptField($.extend({}, field, {curve: $.extend({}, field.curve), name: logFieldNames[k], friendlyName: FlightLogFieldPresenter.fieldNameToFriendly(logFieldNames[k], flightLog.getSysConfig().debug_mode)}), colorIndexOffset, forceNewCurve));
                             colorIndexOffset++;
                         }
@@ -213,6 +213,10 @@ GraphConfig.load = function(config) {
             {
                 label: "Accelerometers",
                 fields: ["accSmooth[all]"]
+            },
+            {
+                label: "Debug",
+                fields: ["debug[all]"]
             }
         ];
 


### PR DESCRIPTION
* A Debug graph template (adding `debug[all]` curve) is useful
* Since we now have different scales for different curves in some of the debug modes, we have to set `forceNewCurve = true`, otherwise all curves are created with whatever the scale of `debug[all]` might be (unless the `debug[x]` curves are created separately)