### PR TITLE
Added Frequency vs Throttle Spectrum Graph

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -534,6 +534,27 @@ html.has-analyser-fullscreen.has-analyser .analyser input {
     position: absolute;
     font-size: 18px;
 }
+
+.analyser:hover #spectrumType {
+    opacity: 1;
+    transition: opacity 500ms ease-in;
+}
+
+.analyser #spectrumType {
+    color: #bbb;
+    opacity: 0;
+    left: 5px;
+    float: left;
+    z-index: 9;
+    position: absolute;
+    font-size: 9px;
+}
+
+analyser #spectrumType select {
+    border-radius: 3px;
+    padding: 0px 5px;
+}
+
 .analyser #analyserResize:hover {
     color: white;
     cursor: pointer;
@@ -555,7 +576,7 @@ html.has-analyser-fullscreen.has-analyser .analyser input {
 	top: 30px;
 }
 
-.analyser input {
+.analyser input.onlyFullScreen {
 	display: none;
 	padding: 3px;
 	margin-right: 3px;

--- a/index.html
+++ b/index.html
@@ -444,15 +444,22 @@
                 <canvas width="0" height="0" id="craftCanvas"></canvas>
                 <div class="analyser">
                     <canvas width="0" height="0" id="analyserCanvas"></canvas>
-                    
+
+                    <div id="spectrumType" data-toggle="tooltip" title="Type of Spectrum">
+                        <select id="spectrumTypeSelect">
+                            <option value="0">Frequency</option>
+                            <option value="1">Freq. vs Throttle</option>
+                        </select>
+                    </div>
+
                     <div id="analyserResize" class="btn-nobg view-analyser-fullscreen" data-toggle="tooltip" title="Zoom Analyser Window">
                         <span class="glyphicon glyphicon-resize-full"></span>
                         <span class="glyphicon glyphicon-resize-small"></span>
                     </div>
 
-                    <input id="analyserZoomX" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
+                    <input id="analyserZoomX" class="onlyFullScreen" type="range" name="analyserZoomX" value="100" min="100" max="500" step="10" title="" list="analyserZoomXTicks"
                     />
-                    <input id="analyserZoomY" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
+                    <input id="analyserZoomY" class="onlyFullScreen" type="range" name="analyserZoomY" value="100" min="10" max="1000" step="10" list="analyserZoomYTicks"
                     />
                     <datalist id="analyserZoomXTicks">
                         <option>100</option>

--- a/js/graph_spectrum_plot.js
+++ b/js/graph_spectrum_plot.js
@@ -1,16 +1,27 @@
 "use strict";
 
-const DEFAULT_FONT_FACE       = "Verdana, Arial, sans-serif",
+const BLUR_FILTER_PIXEL       = 1,
+      DEFAULT_FONT_FACE       = "Verdana, Arial, sans-serif",
       DEFAULT_MARK_LINE_WIDTH = 2,
-      MARGIN                  = 10; // pixels;
+      MARGIN                  = 10,
+      MARGIN_BOTTOM           = 10,
+      MARGIN_LEFT             = 25,
+      MARGIN_LEFT_FULLSCREEN  = 35;
+
+const SPECTRUM_TYPE = {
+        FREQUENCY        : 0,
+        FREQ_VS_THROTTLE : 1,
+      };
 
 var GraphSpectrumPlot = GraphSpectrumPlot || {
-    _isFullScreen : false,
-    _cachedCanvas : null,
-    _canvasCtx    : null,
-    _fftData      : null,
-    _mouseFrequency : null,
-    _sysConfig    : null,
+    _isFullScreen     : false,
+    _cachedCanvas     : null,
+    _cachedDataCanvas : null,
+    _canvasCtx        : null,
+    _fftData          : null,
+    _mouseFrequency   : null,
+    _spectrumType     : null,
+    _sysConfig        : null,
     _zoomX : 1.0,
     _zoomY : 1.0,
     _drawingParams : {
@@ -22,29 +33,39 @@ var GraphSpectrumPlot = GraphSpectrumPlot || {
 GraphSpectrumPlot.initialize = function(canvas, sysConfig) {
     this._canvasCtx = canvas.getContext("2d");
     this._sysConfig = sysConfig;
-    this._invalicateCache();
+    this._invalidateCache();
+    this._invalidateDataCache();
 };
 
 GraphSpectrumPlot.setZoom = function(zoomX, zoomY) {
+
+    var modifiedZoomY = (this._zoomY !=  zoomY);
+
     this._zoomX =  zoomX;
     this._zoomY =  zoomY;
-    this._invalicateCache();
+    this._invalidateCache();
+
+    if (modifiedZoomY) {
+        this._invalidateDataCache();
+    }
 };
 
 GraphSpectrumPlot.setSize = function(width, height) {
     this._canvasCtx.canvas.width  =  width; 
     this._canvasCtx.canvas.height =  height;
-    this._invalicateCache();
+    this._invalidateCache();
 };
 
 GraphSpectrumPlot.setFullScreen = function(isFullScreen) {
     this._isFullScreen = isFullScreen; 
-    this._invalicateCache();
+    this._invalidateCache();
 };
 
-GraphSpectrumPlot.setData = function(fftData) {
+GraphSpectrumPlot.setData = function(fftData, spectrumType) {
     this._fftData = fftData;
-    this._invalicateCache();
+    this._spectrumType = spectrumType;
+    this._invalidateCache();
+    this._invalidateDataCache();
 };
 
 GraphSpectrumPlot.setMouseFrequency = function(mouseFrequency) {
@@ -78,9 +99,23 @@ GraphSpectrumPlot._drawCachedElements = function() {
 
 GraphSpectrumPlot._drawGraph = function(canvasCtx) {
 
+    switch(this._spectrumType) {
+
+    case SPECTRUM_TYPE.FREQUENCY:
+        this._drawFrequencyGraph(canvasCtx);
+        break;
+
+    case SPECTRUM_TYPE.FREQ_VS_THROTTLE:
+        this._drawFrequencyVsThrottleGraph(canvasCtx);
+        break;
+    }
+
+}
+
+GraphSpectrumPlot._drawFrequencyGraph = function(canvasCtx) {
+
     canvasCtx.lineWidth = 1;
-    
-    
+
     var HEIGHT = canvasCtx.canvas.height - MARGIN;
     var WIDTH  = canvasCtx.canvas.width;
     var LEFT   = canvasCtx.canvas.left;
@@ -126,7 +161,77 @@ GraphSpectrumPlot._drawGraph = function(canvasCtx) {
 
 };
 
+GraphSpectrumPlot._drawFrequencyVsThrottleGraph = function(canvasCtx) {
+
+    var PLOTTED_BLACKBOX_RATE = this._fftData.blackBoxRate / this._zoomX;
+
+    var ACTUAL_MARGIN_LEFT = (this._isFullScreen)? MARGIN_LEFT_FULLSCREEN : MARGIN_LEFT;
+    var WIDTH  = canvasCtx.canvas.width - ACTUAL_MARGIN_LEFT;
+    var HEIGHT = canvasCtx.canvas.height - MARGIN_BOTTOM;
+    var LEFT   = canvasCtx.canvas.offsetLeft + ACTUAL_MARGIN_LEFT;
+    var TOP    = canvasCtx.canvas.offsetTop;
+
+    canvasCtx.translate(LEFT, TOP);
+
+    if (this._cachedDataCanvas == null) {
+        this._cachedDataCanvas = this._drawHeatMap();
+    } 
+
+    canvasCtx.drawImage(this._cachedDataCanvas, 0, 0, WIDTH, HEIGHT);
+
+    canvasCtx.drawImage(this._cachedDataCanvas, 
+            0, 0, this._cachedDataCanvas.width / this._zoomX, this._cachedDataCanvas.height,
+            0, 0, WIDTH, HEIGHT);
+
+
+    this._drawAxisLabel(canvasCtx, this._fftData.fieldName, WIDTH  - 4, HEIGHT - 6, 'right');
+    this._drawGridLines(canvasCtx, PLOTTED_BLACKBOX_RATE, LEFT, TOP, WIDTH, HEIGHT, MARGIN_BOTTOM);
+    this._drawThrottleLines(canvasCtx, LEFT, TOP, WIDTH, HEIGHT, ACTUAL_MARGIN_LEFT);
+
+}
+
+GraphSpectrumPlot._drawHeatMap = function() {
+
+    const THROTTLE_VALUES_SIZE  = 100;
+    const SCALE_HEATMAP         = 1.3;  // Value decided after some tests to be similar to the scale of frequency graph
+                                        // This value will be maximum color
+
+    var heatMapCanvas = document.createElement('canvas');
+    var canvasCtx = heatMapCanvas.getContext("2d", { alpha: false });
+
+    // We use always a canvas of the size of the FFT data (is not too big)
+    canvasCtx.canvas.width  = this._fftData.fftLength;
+    canvasCtx.canvas.height = THROTTLE_VALUES_SIZE;
+
+    var fftColorScale = 100 / (this._zoomY * SCALE_HEATMAP);
+
+    // Loop for throttle
+    for(var j = 0; j < 100; j++) {
+        // Loop for frequency
+        for(var i = 0; i < this._fftData.fftLength; i ++) {
+            let valuePlot = Math.round(Math.min(this._fftData.fftOutput[j][i] * fftColorScale, 100));
+
+            // The fillStyle is slow, but I haven't found a way to do this faster...
+            canvasCtx.fillStyle = `hsl(360, 100%, ${valuePlot}%)`;
+            canvasCtx.fillRect(i, 99 - j, 1, 1);
+
+        }
+    }
+
+    // The resulting image has imperfections, usually we not have all the data in the input, so we apply a little of blur 
+    canvasCtx.filter = `blur(${BLUR_FILTER_PIXEL}px)`;
+    canvasCtx.drawImage(heatMapCanvas, 0, 0);
+    canvasCtx.filter = 'none';
+
+    return heatMapCanvas;
+}
+
 GraphSpectrumPlot._drawFiltersAndMarkers = function(canvasCtx) {
+
+    // At this moment we not draw filters or markers for the spectrum vs throttle graph
+    if (this._spectrumType == SPECTRUM_TYPE.FREQ_VS_THROTTLE) {
+        return;
+    }
 
     var HEIGHT = this._canvasCtx.canvas.height - MARGIN;
     var WIDTH  = this._canvasCtx.canvas.width;
@@ -204,6 +309,11 @@ GraphSpectrumPlot._drawFiltersAndMarkers = function(canvasCtx) {
 
 GraphSpectrumPlot._drawNotCachedElements = function() {
 
+    // At this moment we not draw filters or markers for the spectrum vs throttle graph
+    if (this._spectrumType == SPECTRUM_TYPE.FREQ_VS_THROTTLE) {
+        return;
+    }
+
     var canvasCtx = this._canvasCtx; // Not cached canvas
 
     var HEIGHT = this._canvasCtx.canvas.height - MARGIN;
@@ -216,7 +326,7 @@ GraphSpectrumPlot._drawNotCachedElements = function() {
     }
 }
 
-GraphSpectrumPlot._drawAxisLabel = function(canvasCtx, axisLabel, X, Y, align) {
+GraphSpectrumPlot._drawAxisLabel = function(canvasCtx, axisLabel, X, Y, align, baseline) {
     canvasCtx.font = ((this._isFullScreen)? this._drawingParams.fontSizeFrameLabelFullscreen : this._drawingParams.fontSizeFrameLabel) + "pt " + DEFAULT_FONT_FACE;
     canvasCtx.fillStyle = "rgba(255,255,255,0.9)";
     if(align) {
@@ -224,13 +334,17 @@ GraphSpectrumPlot._drawAxisLabel = function(canvasCtx, axisLabel, X, Y, align) {
     } else {
         canvasCtx.textAlign = 'center';
     }
-
+    if (baseline) {
+        canvasCtx.textBaseline = baseline;
+    } else {
+        canvasCtx.textBaseline = 'alphabetic';
+    }
     canvasCtx.fillText(axisLabel, X, Y);
 };
 
 GraphSpectrumPlot._drawGridLines = function(canvasCtx, sampleRate, LEFT, TOP, WIDTH, HEIGHT, MARGIN) {
 
-    var ticks = 5;
+    const ticks = 5;
     var frequencyInterval = (sampleRate / ticks) / 2;
     var frequency = 0;
 
@@ -246,6 +360,25 @@ GraphSpectrumPlot._drawGridLines = function(canvasCtx, sampleRate, LEFT, TOP, WI
         var textAlign = (i==0)?'left':((i==ticks)?'right':'center');
         this._drawAxisLabel(canvasCtx, (frequency.toFixed(0))+"Hz", i * (WIDTH / ticks), HEIGHT + MARGIN, textAlign);
         frequency += frequencyInterval;
+    }   
+};
+
+GraphSpectrumPlot._drawThrottleLines = function(canvasCtx, LEFT, TOP, WIDTH, HEIGHT, MARGIN) {
+
+    const ticks = 5;
+    for(var i=0; i<=ticks; i++) {
+            canvasCtx.beginPath();
+            canvasCtx.lineWidth = 1;
+            canvasCtx.strokeStyle = "rgba(255,255,255,0.25)";
+
+            var verticalPosition = i * (HEIGHT / ticks); 
+            canvasCtx.moveTo(0, verticalPosition);
+            canvasCtx.lineTo(WIDTH, verticalPosition);
+
+            canvasCtx.stroke();
+            var throttleValue = 100 - i*20; 
+            var textBaseline = (i==0)?'top':((i==ticks)?'bottom':'middle');
+            this._drawAxisLabel(canvasCtx, throttleValue + "%", 0, verticalPosition, "right", textBaseline);
     }   
 };
 
@@ -329,6 +462,10 @@ GraphSpectrumPlot._drawNotchFilter = function(canvasCtx, center, cutoff, sampleR
 
 };
 
-GraphSpectrumPlot._invalicateCache = function() {
+GraphSpectrumPlot._invalidateCache = function() {
     this._cachedCanvas = null;
+};
+
+GraphSpectrumPlot._invalidateDataCache = function() {
+    this._cachedDataCanvas = null;
 };


### PR DESCRIPTION
This PR continues the serie of PR about the Spectrum Graph that we let here: https://github.com/betaflight/blackbox-log-viewer/pull/316

This PR adds the possibility to show the Frequency vs Throttle in the Spectrum graph:
![image](https://user-images.githubusercontent.com/2673520/57008927-c81bc980-6bf3-11e9-963e-6d0d72785551.png)

The sliders in the maximized version move the frequency and the intensity of the heat scale. 

I cached all that I could but some things are slow. I will try to optimize it in future PR if I find a way.

My math skills are very limited, so thanks to @bw1129 the author of PidToolBox for point me in the right direction. 

I'm pretty sure there are things that can be done better, I imitated the way it was done in the standard frequency spectrum, so if someone with better knowledge of maths want to take a look, there are some things that I'm not sure why are done in this way, specially related with the size of the arrays passed to the FFT.
I think that the future PR can be:
- Refactor the `spectrum_graph.js` file and divide it into two, one for control and the other for the calcs.
- Add the filters to the graph, like in the standard frequency graph.