### PR TITLE
Fix samples overflow in Spectrum

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -208,7 +208,7 @@ try {
 
     var dataLoad = function() {
 
-        var samples = new Float64Array(MAX_ANALYSER_LENGTH/1000);
+        var samples = new Float64Array(MAX_ANALYSER_LENGTH / (1000 * 1000) * blackBoxRate);
 
         var samplesCount = getFlightSamples(samples);
 
@@ -220,7 +220,7 @@ try {
         var fftOutput = fft(samples);
 
         // Normalize the result
-        fftData = normalizeFft(fftOutput, samplesCount)
+        fftData = normalizeFft(fftOutput, samples.length);
 
     };
 


### PR DESCRIPTION
This fixes a problem detected here: https://github.com/betaflight/blackbox-log-viewer/pull/322 but it was not part of the PR.

This is a very old bug, but it has not affected until the refactor done here: https://github.com/betaflight/blackbox-log-viewer/pull/313

I think this PR is correct, but my Math knowledge is very basic, so I will try to explain the problem to see if there are other hidden problems:

- The Blackbox analyzes a maximum of 5 min. of data. To store this data it creates an array of 300000 frames.
- The problem, is that with blackbox rates bigger than 1kHz, this array is small. The storage was overflowing but JavaScript was silent about this...
- The FFT analyzes ALWAYS 300000 frames (it does not matter if the selected part is bigger or smaller)
- The draw function tries to draw the correct number of frames, thus the strange behaviour observed in the latest part of the graph.

This PR fixes it:
- Giving the correct number of frames to the array.
- The FFT analyzes ALWAYS the maximum size possible (despite the final part is zero), that is the same it was doing before this fix. Using arbitraries sizes produced a very slow FFT calculation.

The only problem with this is that now the array can be bigger than before. In my tests all is ok, but merging it we can see if there are other underlying problems.