### PR TITLE
Fix label of Spectrum when changing the workspace page

### DIFF
--- a/js/grapher.js
+++ b/js/grapher.js
@@ -868,7 +868,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                 try{ // If we do not select a graph/field, then the analyser is hidden
                 var graph = graphs[graphConfig.selectedGraphIndex]; 		
 				var field = graph.fields[graphConfig.selectedFieldIndex];   	            
-                analyser.plotSpectrum(field.index, field.curve, graphConfig.selectedFieldName);
+                analyser.plotSpectrum(field.index, field.curve, field.friendlyName);
                 } catch(err) {console.log('Cannot plot analyser ' + err);}            
             }
 


### PR DESCRIPTION
This is an old bug, but the new cache of the Spectrum made it worse.

When changing the page of the workspace with number, and the Spectrum is active, the label was not refreshed. This fixes it.