### PR TITLE
Draw filters and others over Frequency vs Throttle Spectrum

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -520,12 +520,19 @@ html.has-analyser-fullscreen.has-analyser .analyser input {
 	display:block;
 }
 
-.analyser:hover #analyserResize{
+#analyser {
+    z-index: 10;
+}
+
+.analyser:hover #analyserResize.non-shift{
     opacity: 1;
+    height: auto;
     transition: opacity 500ms ease-in;
 }
 .analyser #analyserResize {
     color: #bbb;
+    height: 0;
+    overflow: hidden;
     opacity: 0;
     top: 5px;
 	left: 975px;
@@ -535,13 +542,16 @@ html.has-analyser-fullscreen.has-analyser .analyser input {
     font-size: 18px;
 }
 
-.analyser:hover #spectrumType {
+.analyser:hover #spectrumType.non-shift {
     opacity: 1;
+    height: auto;
     transition: opacity 500ms ease-in;
 }
 
 .analyser #spectrumType {
     color: #bbb;
+    height: 0;
+    overflow: hidden;
     opacity: 0;
     left: 5px;
     float: left;

--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
                 <video></video>
                 <canvas width="200" height="100" id="graphCanvas"></canvas>
                 <canvas width="0" height="0" id="craftCanvas"></canvas>
-                <div class="analyser">
+                <div id="analyser" class="analyser">
                     <canvas width="0" height="0" id="analyserCanvas"></canvas>
 
                     <div id="spectrumType" data-toggle="tooltip" title="Type of Spectrum">

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -193,6 +193,11 @@ var
             lastMouseY = 0;
         function trackFrequency(e, analyser) {
             if(e.shiftKey) {
+
+                // Hide the combo and maximize buttons
+                $('#spectrumType').removeClass('non-shift');
+                $('#analyserResize').removeClass('non-shift');
+
                 var rect = analyserCanvas.getBoundingClientRect();
                 var mouseX = e.clientX - rect.left;
                 var mouseY = e.clientY - rect.top;
@@ -205,6 +210,9 @@ var
                     }
                 }
                 e.preventDefault();
+            } else {
+                $('#spectrumType').addClass('non-shift');
+                $('#analyserResize').addClass('non-shift');
             }
         }
     


### PR DESCRIPTION
After completing the refactor of the Spectrum code here: https://github.com/betaflight/blackbox-log-viewer/pull/327, this PR draws the filters over the Frequency vs Throttle graph, similar to the Frequency graph. Id adds too the frequency/throttle mouse marker when pressing MAY.

I'm planning to add a select to filter if we want or not want to draw it, but is better to add it in other PR.