### PR TITLE
Better user experience using the Spectrum zoom

### DIFF
--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -11,8 +11,6 @@ const
 var 
     that = this,
 
-    mouseFrequency= null,
-
     analyserZoomX = 1.0, /* 100% */
     analyserZoomY = 1.0, /* 100% */
 
@@ -166,17 +164,17 @@ var
         });
 
         /* add zoom controls */
-        analyserZoomXElem.on('input', function () {
+        analyserZoomXElem.on('input', $.debounce(100, function () {
             analyserZoomX = (analyserZoomXElem.val() / 100);
             GraphSpectrumPlot.setZoom(analyserZoomX, analyserZoomY);
             that.refresh();
-        }).val(100);
+        })).val(100);
 
-        analyserZoomYElem.on('input', function () {
+        analyserZoomYElem.on('input', $.debounce(100, function () {
             analyserZoomY = 1 / (analyserZoomYElem.val() / 100);
             GraphSpectrumPlot.setZoom(analyserZoomX, analyserZoomY);
             that.refresh();
-        }).val(100);
+        })).val(100);
 
         // Spectrum type to show
         userSettings.spectrumType = userSettings.spectrumType || SPECTRUM_TYPE.FREQUENCY;

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -164,17 +164,22 @@ var
         });
 
         /* add zoom controls */
-        analyserZoomXElem.on('input', $.debounce(100, function () {
+        const DEFAULT_ZOOM = 100;
+        analyserZoomXElem.on('input', $.debounce(100, function() {
             analyserZoomX = (analyserZoomXElem.val() / 100);
             GraphSpectrumPlot.setZoom(analyserZoomX, analyserZoomY);
             that.refresh();
-        })).val(100);
+        })).dblclick(function() {
+            $(this).val(DEFAULT_ZOOM).trigger("input");
+        }).val(DEFAULT_ZOOM);;
 
-        analyserZoomYElem.on('input', $.debounce(100, function () {
+        analyserZoomYElem.on('input', $.debounce(100, function() {
             analyserZoomY = 1 / (analyserZoomYElem.val() / 100);
             GraphSpectrumPlot.setZoom(analyserZoomX, analyserZoomY);
             that.refresh();
-        })).val(100);
+        })).dblclick(function() {
+            $(this).val(DEFAULT_ZOOM).trigger("input");
+        }).val(DEFAULT_ZOOM);
 
         // Spectrum type to show
         userSettings.spectrumType = userSettings.spectrumType || SPECTRUM_TYPE.FREQUENCY;


### PR DESCRIPTION
This PR adds two features to the zoom of the Spectrum:
- A debounce function to increase the responsiveness (specially now that we have the noise vs throttle graph, that is more cpu intensive).
- Support to double click, that resets the zoom value.