### PR TITLE
Rc smoothing graph fix

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -566,6 +566,8 @@ function FlightLogFieldPresenter() {
                     break;
                 case 'RC_SMOOTHING':
                     switch (fieldName) {
+                        case 'debug[0]':
+                            return (value + 1500).toFixed(0) + " us";
                         case 'debug[3]': // rx frame rate [us]
                             return (value / 1000).toFixed(1) + 'ms';
                     }

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -470,7 +470,12 @@ GraphConfig.load = function(config) {
                     case 'RC_SMOOTHING':
                         switch (fieldName) {
                             case 'debug[0]': // raw RC command
-                                return getCurveForMinMaxFieldsZeroOffset('debug[0]');
+                                return {
+                                    offset: 0,
+                                    power: 0.25,
+                                    inputRange: 500 * gyroScaleMargin, // +20% to let compare in the same scale with the rccommands 
+                                    outputRange: 1.0
+                                };
                             case 'debug[1]': // raw RC command derivative
                             case 'debug[2]': // smoothed RC command derivative
                                 return getCurveForMinMaxFieldsZeroOffset('debug[1]', 'debug[2]');


### PR DESCRIPTION
Problem:  
Raw RC Command does not overlay nicely with Smoothed RC Command and it makes comparing them hard.

Fix:  
Shall be pretty self-explanatory, see code and screenshots.

**Before the fix**
<img width="1039" alt="RC_Smoothing_Graph_Fix_Before" src="https://user-images.githubusercontent.com/1061565/64521526-74836000-d2f8-11e9-88a0-c0530255457d.png">

**After the fix**
<img width="1043" alt="RC_Smoothing_Graph_Fix_After" src="https://user-images.githubusercontent.com/1061565/64521532-75b48d00-d2f8-11e9-8638-f5fd57f6df70.png">
