### PR TITLE
Add RPM Filter info to the Header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1197,6 +1197,25 @@
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
+
+                                            <tr class='dshot_bidir_required'>
+                                                <td name='gyro_rpm_notch_harmonics'>
+                                                    <label>RPM Notch
+                                                           <br>Harmonics</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name="gyro_rpm_notch_q">
+                                                    <label>RPM Notch
+                                                        <br>Q</label>
+                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                </td>
+                                                <td name='gyro_rpm_notch_min'>
+                                                    <label>RPM Notch
+                                                        <br>Min(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                            </tr>
+
                                         </tbody>
                                     </table>
                                     <table class="parameter cf">
@@ -1267,6 +1286,25 @@
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
+
+                                            <tr class='dshot_bidir_required'>
+                                                <td name='dterm_rpm_notch_harmonics'>
+                                                    <label>RPM Notch
+                                                           <br>Harmonics</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name="dterm_rpm_notch_q">
+                                                    <label>RPM Notch
+                                                        <br>Q</label>
+                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                </td>
+                                                <td name='dterm_rpm_notch_min'>
+                                                    <label>RPM Notch
+                                                        <br>Min(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                            </tr>
+
                                         </tbody>
                                     </table>
                                     <table class="parameter cf">
@@ -1654,6 +1692,13 @@
                                                         <label>Motor Rate</label>
                                                         <input type="number" step="1" min="0" max="32000" />
                                                     </td>
+                                                        <td name="dshot_bidir">
+                                                        <label>DSHOT Bidir</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -233,6 +233,7 @@ var FlightLogParser = function(logData) {
             dterm_average_count:null,               // DTerm Average Count
             rollPitchItermResetRate:null,           // ITerm Reset rate for Roll and Pitch
             yawItermResetRate:null,                 // ITerm Reset Rate for Yaw
+            dshot_bidir:null,                       // DShot bidir protocol enabled
             dterm_lpf_hz:null,                      // DTerm Lowpass Filter Hz
             dterm_lpf_dyn_hz:[null, null],          // DTerm Lowpass Dynamic Filter Min and Max Hz
             dterm_lpf2_hz:null,                     // DTerm Lowpass Filter Hz 2
@@ -248,6 +249,12 @@ var FlightLogParser = function(logData) {
             gyro_lowpass2_hz:null,                  // Gyro Soft Lowpass Filter Hz 2
             gyro_notch_hz:null,                     // Gyro Notch Frequency
             gyro_notch_cutoff:null,                 // Gyro Notch Cutoff
+            gyro_rpm_notch_harmonics:null,          // Number of Harmonics in the gyro rpm filter
+            gyro_rpm_notch_q:null,                  // Value of Q in the gyro rpm filter
+            gyro_rpm_notch_min:null,                // Min Hz for the gyro rpm filter
+            dterm_rpm_notch_harmonics:null,         // Number of Harmonics in the dterm rpm filter
+            dterm_rpm_notch_q:null,                 // Value of Q in the dterm rpm filter
+            dterm_rpm_notch_min:null,               // Min Hz for the dterm rpm filter
             dterm_notch_hz:null,                    // Dterm Notch Frequency
             dterm_notch_cutoff:null,                // Dterm Notch Cutoff
             acc_lpf_hz:null,                        // Accelerometer Lowpass filter Hz
@@ -585,6 +592,14 @@ var FlightLogParser = function(logData) {
             case "use_integrated_yaw":
             case "d_min_gain":
             case "d_min_advance":
+            case "dshot_bidir":
+            case "gyro_rpm_notch_harmonics":
+            case "gyro_rpm_notch_q":
+            case "gyro_rpm_notch_min":
+            case "dterm_rpm_notch_harmonics":
+            case "dterm_rpm_notch_q":
+            case "dterm_rpm_notch_min":
+            
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
 

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -80,6 +80,14 @@ function HeaderDialog(dialog, onSave) {
             {name:'rc_smoothing_active_cutoffs_1', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
             {name:'rc_smoothing_active_cutoffs_2', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
             {name:'rc_interpolation_channels'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
+            {name:'gyro_rpm_notch_harmonics'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'gyro_rpm_notch_q'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'gyro_rpm_notch_min'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'dterm_rpm_notch_harmonics'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'dterm_rpm_notch_q'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'dterm_rpm_notch_min'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+            {name:'dshot_bidir'                 , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+
     ];
 
 	function isParameterValid(name) {
@@ -553,6 +561,16 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
 		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
+        setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics, 0);
+        setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q        , 0);
+        setParameter('gyro_rpm_notch_min'      , sysConfig.gyro_rpm_notch_min      , 0);
+
+        setParameter('dterm_rpm_notch_harmonics', sysConfig.dterm_rpm_notch_harmonics, 0);
+        setParameter('dterm_rpm_notch_q'        , sysConfig.dterm_rpm_notch_q        , 0);
+        setParameter('dterm_rpm_notch_min'      , sysConfig.dterm_rpm_notch_min      , 0);
+
+        $('.dshot_bidir_required').toggle(sysConfig.dshot_bidir == 1);
+
         renderSelect('rc_smoothing_type'          ,sysConfig.rc_smoothing_type, RC_SMOOTHING_TYPE);
         renderSelect('rc_interpolation'           ,sysConfig.rc_interpolation, RC_INTERPOLATION);
         setParameter('rc_interpolation_interval'  ,sysConfig.rc_interpolation_interval,0);
@@ -595,15 +613,17 @@ function HeaderDialog(dialog, onSave) {
             setParameter('rate_limits_roll'  , sysConfig.rate_limits[0], 0);
             setParameter('rate_limits_pitch' , sysConfig.rate_limits[1], 0);
             setParameter('rate_limits_yaw'   , sysConfig.rate_limits[2], 0);
-            $("rate_limits").show();
+            $("#rate_limits").show();
         } else {
             $("#d_min").hide();
-            $("rate_limits").hide();
+            $("#rate_limits").hide();
         }
 
     	renderSelect('unsynced_fast_pwm'		,sysConfig.unsynced_fast_pwm, MOTOR_SYNC);
     	renderSelect('fast_pwm_protocol'		,sysConfig.fast_pwm_protocol, FAST_PROTOCOL);
         setParameter('motor_pwm_rate'		    ,sysConfig.motor_pwm_rate,0);
+        renderSelect('dshot_bidir'              ,sysConfig.dshot_bidir, OFF_ON);
+
         renderSelect('dterm_filter_type'		,sysConfig.dterm_filter_type, FILTER_TYPE);
         setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight,2);
         setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight,2);


### PR DESCRIPTION
Adds RPM Filter info to the Header. It needs https://github.com/betaflight/betaflight/pull/8992 to be merged first.

![image](https://user-images.githubusercontent.com/2673520/66208479-76e99780-e6b5-11e9-978a-815df6c0971a.png)
