### PR TITLE
Save graph config on reorder by drag and drop.

### DIFF
--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -118,7 +118,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                             for(var i=0; i<newOrder.length; i++) {
                                 newGraphs[i] = oldGraphs[newOrder[i]];
                             }
-                            config.setGraphs(newGraphs);
+                            onNewGraphConfig(newGraphs);
                       },
                 cursor: "move",
             }


### PR DESCRIPTION
Fixes #255 , but also a similar bug when reordering and then saving workspaces. 