### PR TITLE
Add PID Error VS Setpoint graph to the analyser

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -549,7 +549,7 @@ html.has-sticks #stickCanvas {
 	display:block;
 }
 
-html.has-analyser-fullscreen.has-analyser .analyser input {
+html.has-analyser-fullscreen.has-analyser .analyser input:not(.onlyFullScreenException) {
 	display:block;
 }
 

--- a/index.html
+++ b/index.html
@@ -454,6 +454,7 @@
                             <select id="spectrumTypeSelect">
                                 <option value="0">Frequency</option>
                                 <option value="1">Freq. vs Throttle</option>
+                                <option value="2">Error vs Setpoint</option>
                             </select>
                         </div>
 

--- a/js/graph_spectrum.js
+++ b/js/graph_spectrum.js
@@ -112,11 +112,14 @@ var
                 fftData = GraphSpectrumCalc.dataLoadFrequencyVsThrottle();
                 break;
 
+            case SPECTRUM_TYPE.PIDERROR_VS_SETPOINT:
+                fftData = GraphSpectrumCalc.dataLoadPidErrorVsSetpoint();
+                break;
+
             case SPECTRUM_TYPE.FREQUENCY:
             default:
                 fftData = GraphSpectrumCalc.dataLoadFrequency();
                 break;
-
             }
 
         };
@@ -196,7 +199,12 @@ var
                 dataReload = true;
                 that.plotSpectrum(dataBuffer.fieldIndex, dataBuffer.curve, dataBuffer.fieldName);
             }
-        });
+
+            // Hide overdraw and zoomY if needed
+            const pidErrorVsSetpointSelected = optionSelected === SPECTRUM_TYPE.PIDERROR_VS_SETPOINT;
+            overdrawSpectrumTypeElem.toggle(!pidErrorVsSetpointSelected);
+            analyserZoomYElem.toggleClass('onlyFullScreenException', pidErrorVsSetpointSelected);
+        }).change();
 
         // Spectrum overdraw to show
         userSettings.overdrawSpectrumType = userSettings.overdrawSpectrumType || SPECTRUM_OVERDRAW_TYPE.ALL_FILTERS;


### PR DESCRIPTION
This adds a PID Error VS Setpoint graph to the analyser window, similar to the one of PID Toolbox.

![image](https://user-images.githubusercontent.com/2673520/69333858-ced66080-0c59-11ea-87f0-0d17083f3c37.png)

Maximized it looks like:

![image](https://user-images.githubusercontent.com/2673520/69333952-fb8a7800-0c59-11ea-898a-e2b96c015a67.png)

- By default, it reduces the data to a maximum of 100deg/sec, after tests, this seems a good limit where the PID Error is stable between different flights.
- It shows the data grouped in 10 different groups, to have enough data at each group.
- At the background, in blue, you can see the line with all the data without grouping. In this way you can decide if the data of this group is stable enough or not.
- If you move the slider, you can see the data over 100deg/sec if interested in, and if you press the shift key you can mark any interesting point.

![image](https://user-images.githubusercontent.com/2673520/69334145-63d95980-0c5a-11ea-8c23-de8333ab6e28.png)

The data shown is only an average of the data received in the Blackbox log. I'm not good at mathematics so I don't know if there is a better statistical function for this, but the data shown seems good enough to me.