### PR TITLE
Add board info to Blackbox log headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
                         <svg width="24" height="24" viewBox="0 0 8.467 8.467">
                             <path fill="none" stroke="#FFF" stroke-linecap="round" stroke-width=".5" d="M0 4.233s2.117 5.292 4.233 0c2.117-5.291 4.234 0 4.234 0"/>
                             <path fill="#FFF" d="M4.233 0L3.175 1.058h2.117L4.233 0zm0 1.058L3.175 2.117h.794V6.35h-.794l1.058 1.058L5.292 6.35h-.794V2.117h.794L4.233 1.058zm0 6.35H3.175l1.058 1.059 1.059-1.059H4.233z"/>
-                            </svg>                                                        
+                            </svg>
                     </button>
                     <button type="button" class="btn btn-nobg btn-svg-icon toggle-smoothing" data-toggle="tooltip" title="Smoothing On/Off">
                         <svg width="24" height="24" viewBox="0 0 8.467 8.467">
@@ -521,7 +521,7 @@
                             <g fill="none" stroke="#FFF" stroke-width=".198">
                                 <path d="M0 3.175h8.467M0 7.408h8.467M0 5.292h8.467M0 1.058h8.467" opacity=".75"/>
                             </g>
-                            </svg>                              
+                            </svg>
                     </button>
                 </div>
 
@@ -660,6 +660,7 @@
                     </button>
                     <h4 class="modal-title">Log Header Information</h4>
                     <h5 class="modal-title-revision"></h5>
+                    <h5 class="modal-title-board-info"></h5>
                     <h5 class="modal-title-date"></h5>
                     <h5 class="modal-title-craft"></h5>
                 </div>
@@ -930,8 +931,8 @@
                                                 </td>
                                                 <td name="abs_control_gain" class="bf-only">
                                                     <label>
-                                                        Absolute 
-                                                        <br/>Control 
+                                                        Absolute
+                                                        <br/>Control
                                                         <br/>Gain
                                                     </label>
                                                     <input type="number" step="1" min="0" max="999" />
@@ -1122,7 +1123,7 @@
                                                     <span>Changes the yaw PID behaviour</span>
                                                 </td>
                                             </tr>
-                                            
+
                                         </tbody>
                                     </table>
                                 </div>
@@ -1752,7 +1753,7 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    
+
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -313,12 +313,12 @@ var FlightLogParser = function(logData) {
             acc_limit                 : "rateAccelLimit",
             anti_gravity_thresh       : "anti_gravity_threshold",
             currentSensor             : "currentMeter",
-            d_notch_cut               : "dterm_notch_cutoff", 
+            d_notch_cut               : "dterm_notch_cutoff",
             d_setpoint_weight         : "dtermSetpointWeight",
             dterm_lowpass_hz          : "dterm_lpf_hz",
             dterm_lowpass_dyn_hz      : "dterm_lpf_dyn_hz",
             dterm_lowpass2_hz         : "dterm_lpf2_hz",
-            dterm_setpoint_weight     : "dtermSetpointWeight",  
+            dterm_setpoint_weight     : "dtermSetpointWeight",
             digital_idle_value        : "digitalIdleOffset",
             dshot_idle_value          : "digitalIdleOffset",
             gyro_hardware_lpf         : "gyro_lpf",
@@ -428,19 +428,19 @@ var FlightLogParser = function(logData) {
 
     /**
      * Translates the name of a field to the parameter in sysConfig object equivalent
-     * 
+     *
      * fieldName Name of the field to translate
      * returns The equivalent in the sysConfig object or the fieldName if not found
      */
     function translateFieldName(fieldName) {
-        var translation = translationValues[fieldName]; 
+        var translation = translationValues[fieldName];
         if (typeof translation !== 'undefined') {
         	return translation;
         } else {
         	return fieldName;
         }
     }
-    
+
     function parseHeaderLine() {
         var
             COLON = ":".charCodeAt(0),
@@ -475,9 +475,9 @@ var FlightLogParser = function(logData) {
         fieldValue = asciiArrayToString(stream.data.subarray(separatorPos + 1, lineEnd));
 
         // Translate the fieldName to the sysConfig parameter name. The fieldName has been changing between versions
-        // In this way is easier to maintain the code        
+        // In this way is easier to maintain the code
         fieldName = translateFieldName(fieldName);
-        
+
         switch (fieldName) {
             case "I interval":
                 that.sysConfig.frameIntervalI = parseInt(fieldValue, 10);
@@ -635,7 +635,7 @@ var FlightLogParser = function(logData) {
 
 
             case "yawRateAccelLimit":
-            case "rateAccelLimit":            
+            case "rateAccelLimit":
                 if((that.sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(that.sysConfig.firmwareVersion, '3.1.0')) ||
                    (that.sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(that.sysConfig.firmwareVersion, '2.0.0'))) {
                     that.sysConfig[fieldName] = parseInt(fieldValue, 10)/1000;
@@ -715,7 +715,7 @@ var FlightLogParser = function(logData) {
             case "magPID":
                 that.sysConfig.magPID = parseCommaSeparatedString(fieldValue,3); //[parseInt(fieldValue, 10), null, null];
             break;
-            
+
             case "feedforward_weight":
                 // Add it to the end of the rollPID, pitchPID and yawPID
                 var ffValues = parseCommaSeparatedString(fieldValue);
@@ -803,6 +803,7 @@ var FlightLogParser = function(logData) {
             case "Product":
             case "Blackbox version":
             case "Firmware date":
+            case "Board information":
             case "Craft name":
             case "Log start datetime":
                 // These fields are not presently used for anything, ignore them here so we don't warn about unsupported headers
@@ -1496,7 +1497,7 @@ var FlightLogParser = function(logData) {
         }
 
         adjustFieldDefsList(that.sysConfig.firmwareType, that.sysConfig.firmwareVersion);
-        
+
         if (!isFrameDefComplete(this.frameDefs.I)) {
             throw "Log is missing required definitions for I frames, header may be corrupt";
         }

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -411,13 +411,14 @@ function HeaderDialog(dialog, onSave) {
 
     function renderSysConfig(sysConfig) {
 
-		activeSysConfig = sysConfig; // Store the current system configuration
+      activeSysConfig = sysConfig; // Store the current system configuration
 
-    	// Update the log header
+      // Update the log header
 
-    	$('h5.modal-title-revision').text( ((sysConfig['Firmware revision']!=null)?(' Rev : '  + sysConfig['Firmware revision']):''));
-    	$('h5.modal-title-date').text(     ((sysConfig['Firmware date']!=null)    ?(' Date : ' + sysConfig['Firmware date']    ):''));
-    	$('h5.modal-title-craft').text(    ((sysConfig['Craft name']!=null)       ?(' Name : ' + sysConfig['Craft name']    ):''));
+      $('h5.modal-title-revision').text((sysConfig['Firmware revision'] != null) ? ` Rev : ${sysConfig['Firmware revision']}` : '');
+      $('h5.modal-title-board-info').text((sysConfig['Board information'] != null) ? ` Board : ${sysConfig['Board information']}` : '');
+      $('h5.modal-title-date').text((sysConfig['Firmware date'] != null) ? ` Date : ${sysConfig['Firmware date']}` : '');
+      $('h5.modal-title-craft').text((sysConfig['Craft name'] != null) ? ` Name : ${sysConfig['Craft name']}` : '');
 
 		switch(sysConfig.firmwareType) {
 			case FIRMWARE_TYPE_BETAFLIGHT:
@@ -448,7 +449,7 @@ function HeaderDialog(dialog, onSave) {
 
 		if((sysConfig.firmware >= 3.0 && sysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT) ||
 		   (sysConfig.firmware >= 2.0 && sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT)) {
-		   
+
 			PID_CONTROLLER_TYPE = ([
 					'LEGACY',
 					'BETAFLIGHT'
@@ -458,7 +459,7 @@ function HeaderDialog(dialog, onSave) {
 					'UNUSED',
 					'MWREWRITE',
 					'LUXFLOAT'
-				]) 
+				])
 		}
 
     	renderSelect("pidController", sysConfig.pidController, PID_CONTROLLER_TYPE);
@@ -535,7 +536,7 @@ function HeaderDialog(dialog, onSave) {
 
         if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.4.0')) {
             renderSelect('gyro_hardware_lpf'       ,sysConfig.gyro_lpf, GYRO_HARDWARE_LPF);
-            
+
         } else {
             renderSelect('gyro_hardware_lpf'       ,sysConfig.gyro_lpf, GYRO_LPF);
         }
@@ -721,7 +722,7 @@ function HeaderDialog(dialog, onSave) {
         setCheckbox('rc_smoothing'				,sysConfig.rc_smoothing);
         setCheckbox('pidAtMinThrottle'			,sysConfig.pidAtMinThrottle);
         setCheckbox('use_integrated_yaw'        ,sysConfig.use_integrated_yaw);
-        
+
         /* Show Unknown Fields */
         renderUnknownHeaders(sysConfig.unknownHeaders);
 


### PR DESCRIPTION
UI updates to add board info to Blackbox log headers. Please see PR for firmware changes: https://github.com/betaflight/betaflight/pull/9372/files

It will look something like this:
![Annotation 2020-01-16 223905](https://user-images.githubusercontent.com/1767795/72536949-36a1d400-38b6-11ea-99ea-488388384a2c.png)
