### PR TITLE
Add a shadow to the text of the Spectrum graph

### DIFF
--- a/js/graph_spectrum_plot.js
+++ b/js/graph_spectrum_plot.js
@@ -478,6 +478,9 @@ GraphSpectrumPlot._drawNotCachedElements = function() {
 };
 
 GraphSpectrumPlot._drawAxisLabel = function(canvasCtx, axisLabel, X, Y, align, baseline) {
+
+    canvasCtx.save();
+
     canvasCtx.font = `${((this._isFullScreen)? this._drawingParams.fontSizeFrameLabelFullscreen : this._drawingParams.fontSizeFrameLabel)}pt ${DEFAULT_FONT_FACE}`;
     canvasCtx.fillStyle = "rgba(255,255,255,0.9)";
     if(align) {
@@ -490,7 +493,13 @@ GraphSpectrumPlot._drawAxisLabel = function(canvasCtx, axisLabel, X, Y, align, b
     } else {
         canvasCtx.textBaseline = 'alphabetic';
     }
+    canvasCtx.shadowColor = 'black';
+    canvasCtx.strokeStyle = 'black';
+    canvasCtx.shadowBlur = 3;
+    canvasCtx.strokeText(axisLabel, X, Y);
     canvasCtx.fillText(axisLabel, X, Y);
+
+    canvasCtx.restore();
 };
 
 GraphSpectrumPlot._drawHorizontalGridLines = function(canvasCtx, maxValue, LEFT, TOP, WIDTH, HEIGHT, MARGIN_UP_LABEL, unitsLabel) {


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/423

Adds a black shadow and stroke to all the labels in the Spectrum graph.

Is difficult to see, but some images:
![image](https://user-images.githubusercontent.com/2673520/85415233-5b892a00-b56d-11ea-8bc0-80fca766204a.png)

![image](https://user-images.githubusercontent.com/2673520/85415554-bae73a00-b56d-11ea-9d6b-67c4141016be.png)

Let's hope that now it will be visible enough without breaking other things...
