### PR TITLE
Remember position and size of the window

### DIFF
--- a/chromeBackground.js
+++ b/chromeBackground.js
@@ -1,10 +1,9 @@
 'use strict';
 
 function startApplication() {
-    const timestampId = Date.now();
     chrome.app.window.create('index.html',
     {
-        id: `main${timestampId}`,
+        id: 'main',
         frame: 'chrome',
         innerBounds : {
             'width' : 1340,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "release": "gulp release"
   },
   "window": {
+    "id": "main",
     "show": true,
     "icon": "images/bf_icon_128.png",    
     "min_width": 1340,


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/377

Remembers the window size and position. At least for the first window. If you open more than one only the first is respected. I think is enough.