### PR TITLE
Fix open window association with --disable-features=nw2

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2075,22 +2075,21 @@ function BlackboxLogViewer() {
 
                     // All the windows opened try to open the new blackbox,
                     // so we limit it to one of them, the first in the list for example
-                    gui.Window.getAll(function(windows) {
+                    const windows = chrome.app.window.getAll();
 
-                        const firstWindow = windows[0];
-                        const currentWindow = gui.Window.get();
+                    const firstWindowId = windows[0].id;
+                    const currentWindowId = chrome.app.window.current().id;
 
-                        if (currentWindow.window === firstWindow.window) {
-                            const filePathToOpenExpression = /.*"([^"]*)"$/;
-                            const fileToOpen = path.match(filePathToOpenExpression);
+                    if (currentWindowId === firstWindowId) {
 
-                            if (fileToOpen.length > 1) {
-                                const fullPathFile = fileToOpen[1];
-                                createNewBlackboxWindow([fullPathFile]);
-                            }
+                        const filePathToOpenExpression = /.*"([^"]*)"$/;
+                        const fileToOpen = path.match(filePathToOpenExpression);
+
+                        if (fileToOpen.length > 1) {
+                            const fullPathFile = fileToOpen[1];
+                            createNewBlackboxWindow([fullPathFile]);
                         }
-                    });
-
+                    }
                 });
             }
         }


### PR DESCRIPTION
The opening of a more than one Blackbox windows when double click on the blackbox log file is broken.

The Chrome compatibility is hitting us again...

If was broken here https://github.com/betaflight/blackbox-log-viewer/pull/456 when we disabled de features of nw2 because the export video was broken in https://github.com/betaflight/blackbox-log-viewer/pull/450

I have returned to the old code and now it works. But we need to remember to revert this when we remove the nw2 disable parameter.

Another fast solution for this problem is to modify the export video code here:

https://github.com/betaflight/blackbox-log-viewer/blob/bbd9a7b09f7e6ff3038e7b200d721258d16f5ce8/js/flightlog_video_renderer.js#L91-L93

Adding a `!isNW()` to the condition, but this makes the video to be loaded into memory before exporting. I think is better to write directly to disk.
