### PR TITLE
Fix screenshot output

### DIFF
--- a/js/screenshot.js
+++ b/js/screenshot.js
@@ -2,24 +2,16 @@
 
 function makeScreenshot() {
     let el = document.querySelector("#screenshot-frame"),
-        elStyle = getComputedStyle(el),
-        options = {
-            /*
-            The element that contains the graph has `position: fixed` set with `top: 60px`.
-            This option ensures, that the image content won't overflow to the bottom.
-            */
-            scrollY: -1 * parseInt(elStyle.top),
-        },
         now = new Date(),
         timestamp = "" + now.getFullYear() +
             ("00" + (now.getMonth() + 1)).slice(-2) +
             ("00" + now.getDate()).slice(-2) + "-" +
-            ("00" + now.getHours()).slice(-2) + 
-            ("00" + now.getMinutes()).slice(-2) + 
+            ("00" + now.getHours()).slice(-2) +
+            ("00" + now.getMinutes()).slice(-2) +
             ("00" + now.getSeconds()).slice(-2),
-        defaultFilename = $(".log-filename").text().replace(".", "_") + "-" 
+        defaultFilename = $(".log-filename").text().replace(".", "_") + "-"
             + timestamp + ".png";
-    html2canvas(el, options).then(canvas => {
+    html2canvas(el).then(canvas => {
         window.canv = canvas;
         let anchor = document.createElement("a");
         anchor.download = defaultFilename;


### PR DESCRIPTION
Due to recent changes to the CSS the screenshot function got broken. This change fixes it (see images below):

Before:

![btfl_002_bbl-20200901-093510](https://user-images.githubusercontent.com/33358/91824840-b27d4080-ec3b-11ea-8ad4-3b67ed0ba7bf.png)

After the fix:

![btfl_all_bbl-20200901-094906](https://user-images.githubusercontent.com/33358/91824877-c032c600-ec3b-11ea-9c62-9991f336dc44.png)
