### PR TITLE
Show the effective motor percentage with dynamic idle in the legacy motor graph.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1856,10 +1856,6 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <td name="digitalIdleOffset">
-                                                        <label>D-Shot Offset (%)</label>
-                                                        <input type="number" step="0.01" min="0" max="1" />
-                                                    </td>
                                                     <td name="motorOutputLow">
                                                         <label>D-Shot Motor Low</label>
                                                         <input type="number" step="10" min="0" max="2047" />
@@ -1867,6 +1863,16 @@
                                                     <td name="motorOutputHigh">
                                                         <label>D-Shot Motor High</label>
                                                         <input type="number" step="10" min="0" max="2047" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="digitalIdleOffset">
+                                                        <label>D-Shot Offset (%)</label>
+                                                        <input type="number" step="0.01" min="0" max="1" />
+                                                    </td>
+                                                    <td name="dynamic_idle_min_rpm">
+                                                        <label>Dynamic Idle Min RPM (* 100)</label>
+                                                        <input type="number" step="1" min="0" max="100" />
                                                     </td>
                                                 </tr>
                                             </tbody>

--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -1171,9 +1171,9 @@ FlightLog.prototype.rcCommandRawToThrottle = function(value) {
 };
 
 FlightLog.prototype.rcMotorRawToPctEffective = function(value) {
-
     // Motor displayed as percentage
-    return Math.min(Math.max(((value - this.getSysConfig().motorOutput[0]) / (this.getSysConfig().motorOutput[1] - this.getSysConfig().motorOutput[0])) * 100.0, 0.0),100.0);
+    const minValue = (this.isDigitalProtocol() && this.getSysConfig().dynamic_idle_min_rpm > 0) ? this.getSysConfig().digitalIdleOffset : this.getSysConfig().motorOutput[0];
+    return Math.min((value - minValue) / (this.getSysConfig().motorOutput[1] - minValue) * 100.0, 100.0);
 
 };
 

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -308,6 +308,7 @@ var FlightLogParser = function(logData) {
             fields_disabled_mask: null,
             vbat_sag_compensation: null,
             gyro_to_use: null,
+            dynamic_idle_min_rpm: null,
             unknownHeaders : []                     // Unknown Extra Headers
         },
 
@@ -624,6 +625,7 @@ var FlightLogParser = function(logData) {
             case "fields_disabled_mask":
             case "motor_pwm_protocol":
             case "gyro_to_use":
+            case "dynamic_idle_min_rpm":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
             case "rc_expo":

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -564,6 +564,7 @@ GraphConfig.load = function(config) {
         
         if (!flightLog.isFieldDisabled().MOTORS) {
             EXAMPLE_GRAPHS.push({label: "Motors",fields: ["motor[all]", "servo[5]"]});
+            EXAMPLE_GRAPHS.push({label: "Motors (Legacy)",fields: ["motorLegacy[all]", "servo[5]"]});
         }
         if (!flightLog.isFieldDisabled().GYRO) {
             EXAMPLE_GRAPHS.push({label: "Gyros",fields: ["gyroADC[all]"]});

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -100,6 +100,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'fields_disabled_mask'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'vbat_sag_compensation'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'gyro_to_use'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dynamic_idle_min_rpm'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -722,6 +723,8 @@ function HeaderDialog(dialog, onSave) {
         setParameter('pidSumLimitYaw'			,sysConfig.pidSumLimitYaw,0);
 
         setParameter('vbat_sag_compensation'    ,sysConfig.vbat_sag_compensation,0);
+
+        setParameter('dynamic_idle_min_rpm'     , sysConfig.dynamic_idle_min_rpm, 0);
 
         // Dynamic filters of Betaflight 4.0
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0') &&


### PR DESCRIPTION
Shows the motor output percentage as percentage of the configured motor output range (between digital idle offset and maximum output range). This means that the percentage will become negative whenever dynamic idle is active, making this easy to spot.

Old:

![image](https://user-images.githubusercontent.com/4742747/100549830-3a75f380-32da-11eb-8fe2-2db9eaeccd35.png)

New:

![image](https://user-images.githubusercontent.com/4742747/100549803-01d61a00-32da-11eb-82d1-af497de4040e.png)

Also added the dynamic idle min RPM value to the header info popup:

![Screenshot from 2020-11-29 18-54-27](https://user-images.githubusercontent.com/4742747/100549880-a48e9880-32da-11eb-876b-8b73a7e6d2d3.png)

