### PR TITLE
Hanning window applied to input data (fftInput, not fftOutput)

### DIFF
--- a/js/graph_spectrum_calc.js
+++ b/js/graph_spectrum_calc.js
@@ -87,12 +87,13 @@ GraphSpectrumCalc.dataLoadFrequencyVsThrottle = function() {
         
         var fftInput = flightSamples.samples.slice(fftChunkIndex, fftChunkIndex + fftChunkLength);
         var fftOutput = new Float64Array(fftChunkLength * 2);
+        
+        // Hanning window applied to input data
+        if(userSettings.analyserHanning) {
+            this._hanningWindow(fftInput, fftChunkLength);
+        }
 
         fft.simple(fftOutput, fftInput, 'real');
-
-        if(userSettings.analyserHanning) {
-            this._hanningWindow(fftOutput, fftChunkLength * 2);
-        }
 
         fftOutput = fftOutput.slice(0, fftChunkLength);
 

--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -60,7 +60,7 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
         graphExpoOverride   : true,             // Ability to toggle Expo off=normal/ on=force 100%
         graphGridOverride   : true,             // Ability to toggle Grid off=normal/ on=force disabled
 		analyserSampleRate	: 2000/*Hz*/,  		// the loop time for the log
-		analyserHanning	    : false,  			// use a hanning window on the analyser sample data
+		analyserHanning	    : true,  			// use a hanning window on the analyser sample data
 		eraseBackground		: true,           	// Set to false if you want the graph to draw on top of an existing canvas image
 		spectrumType        : 0,                // By default, frequency Spectrum
 		overdrawSpectrumType: 0,                // By default, show all filters


### PR DESCRIPTION
This PR is a minor improvement of the Spectrum Graph (PR #322)

A Hanning window is a taper that "tapers" (i.e., smooths) the edges of data segments used for fft, so that the Fourier output does not contain artifacts from the sharp edges at the start and end of data segments. In PR #322, it was incorrectly applied to the output data (processed Fourier data), but in fact was never called, and should have instead been applied to the input data segments ('fftInput'). The result was occasional streak artifacts along the frequency domain (x-axis) of the 'Freq. vs Throttle' plots (see below). 

![Screen Shot 2021-01-04 at 3 48 31 PM](https://user-images.githubusercontent.com/17284912/103585617-5bb99900-4eb1-11eb-9a42-a4864f8fd8b4.png)

For this PR, I simply moved the Hanning window portion of the code before fft was computed and applied it to Input data ('fftInput') instead of output data ('fftOutput'). 'fftChunkLength * 2' was changed to just 'fftChunkLength' because it is the correct width for the Hanning window and did not need a multiplier. I also turned on the "use Hanning Window" in the user settings, which was previously off ('false') by default. The improvement of these changes to the spectrogram (using the exact same log file as above) can be seen below. 

![Screen Shot 2021-01-04 at 3 53 50 PM](https://user-images.githubusercontent.com/17284912/103586536-48a7c880-4eb3-11eb-9fb4-258390784995.png)

This is my first PR so my apologies if I've done something wrong here. Please let me know. thx -Brian