### PR TITLE
Fix axisError calculation

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -669,7 +669,7 @@ function FlightLog(logData) {
                     if (axisPID && gyroADC) {
                         for (var axis = 0; axis < 3; axis++) {
                             let gyroADCdegrees = (gyroADC[axis] !== undefined ? that.gyroRawToDegreesPerSecond(srcFrame[gyroADC[axis]]) : 0);
-                            destFrame[fieldIndex++] = gyroADCdegrees - destFrame[fieldIndexRcCommands + axis];
+                            destFrame[fieldIndex++] = destFrame[fieldIndexRcCommands + axis] - gyroADCdegrees;
                         }
                     }
 


### PR DESCRIPTION
Currently the sign of the axisError[axis] is reversed. 

Error data should be :
`error = setpoint - gyroADC`

The image showed this issue. 
- Left is calculating error on pitch axis via the equation of `error = setpoint - gyroADC`, and a plot shows how it looks like.
- Right is csv file exported from the BBE on the same log.

And it seems that the two pieces of error data have different signs.
![image](https://user-images.githubusercontent.com/31283897/106435260-9bbe6c80-64ad-11eb-8b3b-294a745365d3.png)

I can share this script (Jupyter notebook) if you need.