### PR TITLE
Allow window resizing down to 800x600

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,8 +5,16 @@ var userSettings = {};
 
 var VIEWER_VERSION = getManifestVersion(); // Current version
 
-const INNER_BOUNDS_WIDTH  = 1340;
-const INNER_BOUNDS_HEIGHT = 900;
+// these values set the initial dimensions of a secondary window
+// which always opens at the centre of the user's screen
+const NEW_WINDOW_WIDTH  = 1000;
+const NEW_WINDOW_HEIGHT  = 760;
+
+// these values set the minimum resize dimensions of a secondary window
+// minimum resize dimensions of the initial window are set in package.json
+const INNER_BOUNDS_WIDTH  = 740;
+const INNER_BOUNDS_HEIGHT = 480;
+
 const INITIAL_APP_PAGE = "index.html";
 
 function BlackboxLogViewer() {
@@ -113,6 +121,8 @@ function BlackboxLogViewer() {
             const gui = require('nw.gui');
             gui.Window.open(INITIAL_APP_PAGE,
             {
+                'width'  : NEW_WINDOW_WIDTH,
+                'height' : NEW_WINDOW_HEIGHT,
                 'min_width'  : INNER_BOUNDS_WIDTH,
                 'min_height' : INNER_BOUNDS_HEIGHT,
             },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "id": "main",
     "show": true,
     "icon": "images/bf_icon_128.png",
-    "min_width": 1340,
-    "min_height": 920
+    "min_width": 740,
+    "min_height": 480
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is a quick and dirty one that allows re-sizing of Blackbox windows down to 800x600, so that I can easily view multiple log windows at once.  Currently they cannot be made any smaller than 134x900.

I'm sure this is not the most elegant solution, but it works.  I targeted all the instances of 1340x900 I could find :-)

The `chrome.background.js` file may not be required, I don't know what it does.

The behaviour isn't ideal on my Mac.  The initial window on launching BBE opens fairly large, but all new windows (after clicking the 'new window' button are 800x600, centred.  They don't need to be that small on opening, could open the same size as the initial window, that would be fine.

I don't mind if windows open at 1340x900, I just wanted to be able to drag them to a smaller size; 800x600 allows quite a few windows open at once on a good screen, making it easy to compare multiple files at once.

Thanks!

PS: the window size changes may have been initiated  in https://github.com/betaflight/blackbox-log-viewer/pull/450