### PR TITLE
Generate win64 version for Windows by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ If no platform is provided, only for the platform you are builing from will be b
 
 * **MacOS X** use `yarn gulp <task-name> --osx64`
 * **Linux** use `yarn gulp <task-name> --linux64`
-* **Windows** use `yarn gulp <task-name> --win32`
+* **Windows** use `yarn gulp <task-name> --win64`
 
-You can also use multiple platforms e.g. `yarn gulp <taskname> --osx64 --linux64`. Other platforms like `--win64` and `--linux32` can be used too, but they are not officially supported, so use them at your own risk.
+You can also use multiple platforms e.g. `yarn gulp <taskname> --osx64 --linux64`. Other platforms like `--win32` and `--linux32` can be used too, but they are not officially supported, so use them at your own risk.
 
 #### macOS DMG installation background image
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,11 +53,11 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: yarn gulp release --win32
-      displayName: 'Run yarn release for win32'
+    - script: yarn gulp release --win64
+      displayName: 'Run yarn release for win64'
       condition: and(succeeded(), eq('${{ parameters.releaseBuild }}', true))
-    - script: yarn gulp debug-release --win32
-      displayName: 'Run yarn debug release for win32'
+    - script: yarn gulp debug-release --win64
+      displayName: 'Run yarn debug release for win64'
       condition: and(succeeded(), eq('${{ parameters.releaseBuild }}', false))
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows release'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ function getDefaultPlatform() {
 
         break;
     case 'win32':
-        defaultPlatform = 'win32';
+        defaultPlatform = 'win64';
 
         break;
 


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/501

This PR changes the generation of the Windows installer from win32 to win64 by default.

If this PR is ok, I will do the same for the Configurator when this is merged.

