### PR TITLE
update feedforward log headers for 4.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,17 +915,47 @@
                                     </table>
 
                                     <table class="parameter cf">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="5">Feedforward</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td name="feedforwardTransition" class="bf-only">
+                                                    <label>Transition
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0.01" min="0" max="999" />
+                                                </td>
+                                                <td name="feedforwardAveraging" class="bf-only">
+                                                    <label>Averaging
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardSmoothing" class="bf-only">
+                                                    <label>Smoothing
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardJitter" class="bf-only">
+                                                    <label>Jitter
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardBoost" class="bf-only">
+                                                    <label>Boost
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <table class="parameter cf">
                                         <tbody>
                                             <tr>
                                                 <td name="ptermSRateWeight" class="bf-only">
                                                     <label>P-Term
                                                         <br>&nbsp;
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="feedforward_transition" class="bf-only">
-                                                    <label>Feedforward
-                                                        <br>Transition
                                                         <br/>&nbsp;</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
                                                 </td>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -220,7 +220,7 @@ var FlightLogParser = function(logData) {
             rollPID:[null, null, null],             // Roll [P, I, D]
             pitchPID:[null, null, null],            // Pitch[P, I, D]
             yawPID:[null, null, null],              // Yaw  [P, I, D]
-            feedforward_transition:null,            // Feedforward transition
+            feedforward_transition:null,            // Feedforward transition old
             altPID:[null, null, null],              // Altitude Hold [P, I, D]
             posPID:[null, null, null],              // Position Hold [P, I, D]
             posrPID:[null, null, null],             // Position Rate [P, I, D]
@@ -309,6 +309,12 @@ var FlightLogParser = function(logData) {
             vbat_sag_compensation: null,
             gyro_to_use: null,
             dynamic_idle_min_rpm: null,
+            ff_transition: null,
+            ff_averaging: null,
+            ff_smooth_factor: null,
+            ff_jitter_factor: null,
+            ff_boost: null,
+
             unknownHeaders : []                     // Unknown Extra Headers
         },
 
@@ -595,6 +601,11 @@ var FlightLogParser = function(logData) {
             case "ptermSRateWeight":
             case "setpointRelaxRatio":
             case "feedforward_transition":
+            case "ff_transition":
+            case "ff_averaging":
+            case "ff_smooth_factor":
+            case "ff_jitter_factor":
+            case "ff_boost":
             case "dtermSetpointWeight":
             case "gyro_soft_type":
             case "gyro_soft2_type":
@@ -727,6 +738,13 @@ var FlightLogParser = function(logData) {
                 that.sysConfig.magPID = parseCommaSeparatedString(fieldValue,3); //[parseInt(fieldValue, 10), null, null];
             break;
 
+            case "ff_weight":
+                // Add it to the end of the rollPID, pitchPID and yawPID
+                var ffValues = parseCommaSeparatedString(fieldValue);
+                that.sysConfig["rollPID"].push(ffValues[0]);
+                that.sysConfig["pitchPID"].push(ffValues[1]);
+                that.sysConfig["yawPID"].push(ffValues[2]);
+            break;
             case "feedforward_weight":
                 // Add it to the end of the rollPID, pitchPID and yawPID
                 var ffValues = parseCommaSeparatedString(fieldValue);
@@ -734,6 +752,7 @@ var FlightLogParser = function(logData) {
                 that.sysConfig["pitchPID"].push(ffValues[1]);
                 that.sysConfig["yawPID"].push(ffValues[2]);
             break;
+
             /* End of CSV packed values */
 
             case "vbatcellvoltage":

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -67,7 +67,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'pidSumLimit'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
         {name:'pidSumLimitYaw'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
         {name:'rc_smoothing_type'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
-        {name:'feedforward_transition'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+        {name:'feedforward_transition'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'4.2.999'},
         {name:'antiGravityMode'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
         {name:'rc_smoothing_cutoffs_1'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
         {name:'rc_smoothing_cutoffs_2'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
@@ -101,6 +101,11 @@ function HeaderDialog(dialog, onSave) {
         {name:'vbat_sag_compensation'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'gyro_to_use'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dynamic_idle_min_rpm'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_transition'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_averaging'                 , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_smooth_factor'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_jitter_factor'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_boost'                     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -692,7 +697,20 @@ function HeaderDialog(dialog, onSave) {
         renderSelect('dterm_filter_type'		,sysConfig.dterm_filter_type, FILTER_TYPE);
         setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight,2);
         setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight,2);
-        setParameter('feedforward_transition'   ,sysConfig.feedforward_transition,2);
+
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            setParameter('feedforwardTransition' ,sysConfig.ff_transition,2);
+            setParameter('feedforwardAveraging'  ,sysConfig.ff_averaging,0);
+            setParameter('feedforwardSmoothing'  ,sysConfig.ff_smooth_factor,0);
+            setParameter('feedforwardJitter'     ,sysConfig.ff_jitter_factor,0);
+        } else {
+            setParameter('feedforwardTransition' ,sysConfig.feedforward_transition,2);
+            setParameter('feedforwardAveraging'  ,"0",0);
+            setParameter('feedforwardSmoothing'  ,"0",0);
+            setParameter('feedforwardJitter'     ,"0",0);
+        }
+        setParameter('feedforwardBoost'      ,sysConfig.ff_boost,0);
+
         setParameter('abs_control_gain'         ,sysConfig.abs_control_gain, 0);
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) {
             setParameterFloat('yawRateAccelLimit', sysConfig.yawRateAccelLimit, 2);


### PR DESCRIPTION
This correctly displays the new feedforward fields and name changes that will end up in 4.3 from [#01723](https://github.com/betaflight/betaflight/pull/10723)

Previously only feedforward transition was shown; the extra feedforward sub parameters were shown only in the Unknown Headers section.  

This shows all 4.3  feedforward parameters in a box. 

The only common feed forward fields from 4.2 to 4.3 are transition and boost.  When showing a 4.2 and earlier log, the new fields for averaging, smoothing and  jitter are set to 0, and the older parameter names and values are shown in the Unknown Header Fields section.