### PR TITLE
display new multi dynamic notch values properly in log header for 4.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -1229,32 +1229,26 @@
                                             </tr>
 
                                             <tr class="dyn_filter_required">
-                                                <td name='dyn_notch_range'>
-                                                    <label>Dyn Notch
-                                                        <br>Range</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
+                                            <thead>
+                                               <tr>
+                                                <th colspan="4">Dynamic notch filters</th>
+                                               </tr>
+                                           </thead>
+                                                <td name='dynNotchCount'>
+                                                    <label>Count/Width</label>
+                                                    <input type="number" step="1" min="0" max="10" />
                                                 </td>
-                                                <td name="dyn_notch_width_percent">
-                                                    <label>Dyn Notch
-                                                        <br>Width (percent)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                <td name="dynNotchBandwidthHz">
+                                                    <label>Bandwidth/Q</label>
+                                                    <input type="number" step="1" min="0" max="255" />
                                                 </td>
-                                                <td name='dyn_notch_q'>
-                                                    <label>Dyn Notch
-                                                        <br>Q</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                <td name="dynNotchMinHz">
+                                                    <label>Min (Hz)</label>
+                                                    <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
-                                                <td name="dyn_notch_min_hz">
-                                                    <label>Dyn Notch
-                                                        <br>Min (Hz)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dyn_notch_max_hz">
-                                                    <label>Dyn Notch
-                                                        <br>Max (Hz)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                <td name="dynNotchMaxHz">
+                                                    <label>>Max (Hz)</label>
+                                                    <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
 

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -426,13 +426,6 @@ var
         "SETPOINT",
     ]),
 
-    DYN_NOTCH_RANGE = makeReadOnly([
-        "HIGH",
-        "MEDIUM",
-        "LOW",
-        "AUTO",
-    ]),
-
     FLIGHT_LOG_DISARM_REASON = makeReadOnly([
         "ARMING_DISABLED",
         "FAILSAFE",

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -309,6 +309,8 @@ var FlightLogParser = function(logData) {
             vbat_sag_compensation: null,
             gyro_to_use: null,
             dynamic_idle_min_rpm: null,
+            dyn_notch_count: null,                  // Number of dynamic notches 4.3
+            dyn_notch_bandwidth_hz: null,           // Width of each notch filter in Hz 4.3
             unknownHeaders : []                     // Unknown Extra Headers
         },
 
@@ -618,6 +620,8 @@ var FlightLogParser = function(logData) {
             case "dyn_notch_range":
             case "dyn_notch_width_percent":
             case "dyn_notch_q":
+            case "dyn_notch_count":
+            case "dyn_notch_bandwidth_hz":
             case "dyn_notch_min_hz":
             case "dyn_notch_max_hz":
             case "rates_type":

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -92,8 +92,8 @@ function HeaderDialog(dialog, onSave) {
         {name:'iterm_relax_type'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'iterm_relax_cutoff'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'dyn_notch_range'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.1.7'},
-        {name:'dyn_notch_width_percent'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
-        {name:'dyn_notch_q'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+        {name:'dyn_notch_width_percent'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
+        {name:'dyn_notch_q'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
         {name:'dyn_notch_min_hz'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'dyn_notch_max_hz'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
         {name:'rates_type'                   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
@@ -101,6 +101,8 @@ function HeaderDialog(dialog, onSave) {
         {name:'vbat_sag_compensation'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'gyro_to_use'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dynamic_idle_min_rpm'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_notch_count'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_notch_bandwidth_hz'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -616,11 +618,15 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
 		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
-        renderSelect('dyn_notch_range'         ,sysConfig.dyn_notch_range        , DYN_NOTCH_RANGE);
-        setParameter('dyn_notch_width_percent' ,sysConfig.dyn_notch_width_percent, 0);
-        setParameter('dyn_notch_q'             ,sysConfig.dyn_notch_q            , 0);
-        setParameter('dyn_notch_min_hz'        ,sysConfig.dyn_notch_min_hz       , 0);
-        setParameter('dyn_notch_max_hz'        ,sysConfig.dyn_notch_max_hz       , 0);
+        if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_count        , 0);
+            setParameter('dynNotchBandwidthHz'     ,sysConfig.dyn_notch_bandwidth_hz , 0);
+        } else {
+            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_width_percent, 0);
+            setParameter('dynNotchBandwidthHz'     ,sysConfig.dyn_notch_q            , 0);
+        }
+        setParameter('dynNotchMinHz'               ,sysConfig.dyn_notch_min_hz        , 0);
+        setParameter('dynNotchMaxHz'               ,sysConfig.dyn_notch_max_hz        , 0);
 
         setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics, 0);
         setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q        , 0);


### PR DESCRIPTION
The dynamic notch has changed recently.  This PR idisplays the new values in the gyro filters section of the log.

I thought it might be worth exploring using the same html fields for the old values that are replaced, since they are, sort of, comparable.

The old dynamic notch width parameter determined whether there was one or two notches while the new count parameter sets the actual number of notches.  Likewise the old Q factor determined notch bandwidth, and the new bandwidth parameter sets it directly.  

Hence I am using the one html field for count / width, and the other for bandwidth / Q, depending on the version of the flight code.

The alternative is to force zeroes for count and bandwidth for <4.3, and put the older fields into the unrecognised headers.

I appreciate feedback on this.