### PR TITLE
Updates to log viewer for 4.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,17 +915,55 @@
                                     </table>
 
                                     <table class="parameter cf">
+                                        <thead>
+                                            <tr>
+                                                <th scope="row" colspan="6">Feedforward</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td name="feedforwardTransition" class="bf-only">
+                                                    <label>Transition
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0.01" min="0" max="999" />
+                                                </td>
+                                                <td name="feedforwardAveraging" class="bf-only">
+                                                    <label>Averaging
+                                                        <br/>&nbsp;</label>
+                                                    <select>
+                                                        <!~~ list generated here ~~>
+                                                    </select>
+                                                </td>
+                                                <td name="feedforwardSmoothing" class="bf-only">
+                                                    <label>Smoothing
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardJitter" class="bf-only">
+                                                    <label>Jitter
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardBoost" class="bf-only">
+                                                    <label>Boost
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                                <td name="feedforwardMaxRate" class="bf-only">
+                                                    <label>MaxRate
+                                                        <br/>&nbsp;</label>
+                                                    <input type="number" step="0" min="0" max="100" />
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <table class="parameter cf">
+                                        <caption>Misc</caption>
                                         <tbody>
                                             <tr>
                                                 <td name="ptermSRateWeight" class="bf-only">
                                                     <label>P-Term
                                                         <br>&nbsp;
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="feedforward_transition" class="bf-only">
-                                                    <label>Feedforward
-                                                        <br>Transition
                                                         <br/>&nbsp;</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
                                                 </td>
@@ -1229,32 +1267,26 @@
                                             </tr>
 
                                             <tr class="dyn_filter_required">
-                                                <td name='dyn_notch_range'>
-                                                    <label>Dyn Notch
-                                                        <br>Range</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="4">Dynamic notch filters</th>
+                                               </tr>
+                                           </thead>
+                                                <td name='dynNotchCount'>
+                                                    <label>Count/Width</label>
+                                                    <input type="number" step="1" min="0" max="10" />
                                                 </td>
-                                                <td name="dyn_notch_width_percent">
-                                                    <label>Dyn Notch
-                                                        <br>Width (percent)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                <td name="dynNotchQ">
+                                                    <label>Q factor</label>
+                                                    <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
-                                                <td name='dyn_notch_q'>
-                                                    <label>Dyn Notch
-                                                        <br>Q</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                <td name="dynNotchMinHz">
+                                                    <label>Min (Hz)</label>
+                                                    <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
-                                                <td name="dyn_notch_min_hz">
-                                                    <label>Dyn Notch
-                                                        <br>Min (Hz)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dyn_notch_max_hz">
-                                                    <label>Dyn Notch
-                                                        <br>Max (Hz)</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
+                                                <td name="dynNotchMaxHz">
+                                                    <label>>Max (Hz)</label>
+                                                    <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
 
@@ -1272,6 +1304,11 @@
                                                 <td name='gyro_rpm_notch_min'>
                                                     <label>RPM Notch
                                                         <br>Min(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name='rpm_notch_lpf'>
+                                                    <label>RPM Notch
+                                                        <br>Lpf</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
@@ -1685,73 +1722,58 @@
                                                     <th colspan="5">RC Smoothing</th>
                                                 </tr>
                                                 <tr>
-                                                    <td name='rc_smoothing_type'>
-                                                        <label>Type</label>
+                                                    <td name='rcSmoothingMode'>
+                                                        <label>On/Off</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    <td name='rc_interpolation'>
-                                                        <label>Interpolation</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                    <td name="rc_interpolation_interval">
-                                                        <label>Interval (ms)</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
-                                                    </td>
-                                                    <td name="rc_smoothing_cutoffs_1">
-                                                        <label>Input Hz</label>
-                                                        <input type="number" step="1" min="0" max="255" />
-                                                    </td>
-                                                    <td name="rc_smoothing_cutoffs_2">
-                                                        <label>Derivative Hz</label>
-                                                        <input type="number" step="1" min="0" max="255" />
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td name="rc_smoothing_rx_average">
+                                                    <td name="rcSmoothingRxAverage">
                                                         <label>RX Average (ms)</label>
                                                         <input type="number" step="0.1" min="0"/>
                                                     </td>
-                                                    <td name='rc_smoothing_filter_type_1'>
-                                                        <label>Input Type</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                    <td name='rc_smoothing_filter_type_2'>
-                                                        <label>Derivative Type</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td name='rc_smoothing_auto_factor'>
-                                                        <label>Auto factor</label>
-                                                        <input type="number" step="1" min="0"/>
-                                                    </td>
-                                                    <td name='rc_smoothing_active_cutoffs_1'>
-                                                        <label>Active Cutoff 1</label>
-                                                        <input type="number" step="1" min="0"/>
-                                                    </td>
-                                                    <td name='rc_smoothing_active_cutoffs_2'>
-                                                        <label>Active Cutoff 2</label>
-                                                        <input type="number" step="1" min="0"/>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td name="rc_interpolation_channels">
-                                                        <label>Channels</label>
-                                                        <input type="number" step="1" min="0"/>
-                                                    </td>
-                                                    <td name='rc_smoothing_debug_axis'>
+                                                    <td name='rcSmoothingDebugAxis'>
                                                         <label>Debug Axis</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td colspan="2" name='rcSmoothingAutoFactorSetpoint'>
+                                                        <label>Setpoint auto fact</label>
+                                                        <input type="number" step="1" min="0" max="250" />
+                                                    </td>
+                                                    <td name="rcSmoothingAutoFactorThrottle">
+                                                        <label>Throttle auto fact</label>
+                                                        <input type="number" step="1" min="0" max="250" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="rcSmoothingSetpointHz">
+                                                        <label>Setpoint cutoff Hz</label>
+                                                        <input type="number" step="1" min="0" max="255" />
+                                                    </td>
+                                                    <td name="rcSmoothingFeedforwardHz">
+                                                        <label>Feedforward cutoff Hz</label>
+                                                        <input type="number" step="1" min="0" max="255" />
+                                                    </td>
+                                                    <td name="rcSmoothingThrottleHz">
+                                                        <label>Throttle cutoff Hz</label>
+                                                        <input type="number" step="1" min="0" max="255" />
+                                                </tr>
+                                                <tr>
+                                                    <td name='rcSmoothingActiveCutoffsSp'>
+                                                        <label>Active Cutoff Setpoint</label>
+                                                        <input type="number" step="1" min="0"/>
+                                                    </td>
+                                                    <td name='rcSmoothingActiveCutoffsFf'>
+                                                        <label>Active Cutoff FF</label>
+                                                        <input type="number" step="1" min="0"/>
+                                                    </td>
+                                                    <td name='rcSmoothingActiveCutoffsThr'>
+                                                        <label>Active Cutoff Throttle</label>
+                                                        <input type="number" step="1" min="0"/>
                                                     </td>
                                                 </tr>
                                             </tbody>

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -231,9 +231,13 @@ var
     ]),
 
     RC_SMOOTHING_DERIVATIVE_TYPE = makeReadOnly([
-        "OFF", 
         "PT1", 
         "BIQUAD"
+    ]),
+
+    RC_SMOOTHING_MODE = makeReadOnly([
+        "OFF", 
+        "ON"
     ]),
 
     RC_SMOOTHING_DEBUG_AXIS = makeReadOnly([
@@ -251,9 +255,10 @@ var
     ]),
 
     FILTER_TYPE = makeReadOnly([
-            "PT1",
-            "BIQUAD",
-            "FIR",
+        "PT1",
+        "BIQUAD",
+        "PT2",
+        "PT3",
     ]),
 
     DEBUG_MODE = [],
@@ -457,6 +462,13 @@ var
         "FIRST",
         "SECOND",
         "BOTH",
+    ]),
+
+    FF_AVERAGING = makeReadOnly([
+        "OFF",
+        "2_POINT",
+        "3_POINT",
+        "4_POINT",
     ]);
 
 function adjustFieldDefsList(firmwareType, firmwareVersion) {

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -34,8 +34,8 @@ function HeaderDialog(dialog, onSave) {
         {name:'dterm_lpf2_hz'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
         {name:'dterm_notch_hz'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'dterm_notch_cutoff'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
-        {name:'rc_interpolation'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
-        {name:'rc_interpolation_interval'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+        {name:'rc_interpolation'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'4.2.999'},
+        {name:'rc_interpolation_interval'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'4.2.999'},
         {name:'gyro_sync_denom'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'pid_process_denom'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'unsynced_fast_pwm'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
@@ -66,24 +66,17 @@ function HeaderDialog(dialog, onSave) {
         {name:'itermWindupPointPercent'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.1.0', max:'999.9.9'},
         {name:'pidSumLimit'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
         {name:'pidSumLimitYaw'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.3.0', max:'999.9.9'},
-        {name:'rc_smoothing_type'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'999.9.9'},
-        {name:'feedforward_transition'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+        {name:'rc_smoothing_type'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.4.0', max:'4.2.999'},
         {name:'antiGravityMode'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
-        {name:'rc_smoothing_cutoffs_1'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
-        {name:'rc_smoothing_cutoffs_2'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
-        {name:'rc_smoothing_filter_type_1'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
-        {name:'rc_smoothing_filter_type_1'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
         {name:'rc_smoothing_rx_average'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
         {name:'rc_smoothing_debug_axis'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
         {name:'abs_control_gain'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
         {name:'use_integrated_yaw'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
-        {name:'rc_smoothing_auto_factor'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
-        {name:'rc_smoothing_active_cutoffs_1', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
-        {name:'rc_smoothing_active_cutoffs_2', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
-        {name:'rc_interpolation_channels'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'999.9.9'},
+        {name:'rc_interpolation_channels'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.0.0', max:'4.2.999'},
         {name:'gyro_rpm_notch_harmonics'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'gyro_rpm_notch_q'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'gyro_rpm_notch_min'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+        {name:'rpm_notch_lpf'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
         {name:'dterm_rpm_notch_harmonics'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
         {name:'dterm_rpm_notch_q'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
         {name:'dterm_rpm_notch_min'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
@@ -92,7 +85,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'iterm_relax_type'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'iterm_relax_cutoff'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'dyn_notch_range'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.1.7'},
-        {name:'dyn_notch_width_percent'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
+        {name:'dyn_notch_width_percent'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'4.2.999'},
         {name:'dyn_notch_q'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'dyn_notch_min_hz'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.1.0', max:'999.9.9'},
         {name:'dyn_notch_max_hz'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
@@ -102,6 +95,21 @@ function HeaderDialog(dialog, onSave) {
         {name:'gyro_to_use'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dynamic_idle_min_rpm'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'motor_poles'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_transition'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.5.0', max:'999.9.9'},
+        {name:'ff_averaging'                 , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_smooth_factor'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_jitter_factor'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_boost'                     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'ff_max_rate_limit'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_mode'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_feedforward_hz'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_setpoint_hz'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_auto_factor_setpoint', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_auto_factor_throttle', type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_active_cutoffs_ff',    type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_active_cutoffs_sp',    type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rc_smoothing_active_cutoffs_thr',   type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_notch_count'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -617,15 +625,19 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
 		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
-        renderSelect('dyn_notch_range'         ,sysConfig.dyn_notch_range        , DYN_NOTCH_RANGE);
-        setParameter('dyn_notch_width_percent' ,sysConfig.dyn_notch_width_percent, 0);
-        setParameter('dyn_notch_q'             ,sysConfig.dyn_notch_q            , 0);
-        setParameter('dyn_notch_min_hz'        ,sysConfig.dyn_notch_min_hz       , 0);
-        setParameter('dyn_notch_max_hz'        ,sysConfig.dyn_notch_max_hz       , 0);
+        if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_count        , 0);
+        } else {
+            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_width_percent, 0);
+        }
+        setParameter('dynNotchQ'                   ,sysConfig.dyn_notch_q            , 0);
+        setParameter('dynNotchMinHz'               ,sysConfig.dyn_notch_min_hz       , 0);
+        setParameter('dynNotchMaxHz'               ,sysConfig.dyn_notch_max_hz       , 0);
 
-        setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics, 0);
-        setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q        , 0);
-        setParameter('gyro_rpm_notch_min'      , sysConfig.gyro_rpm_notch_min      , 0);
+        setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics  , 0);
+        setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q          , 0);
+        setParameter('gyro_rpm_notch_min'      , sysConfig.gyro_rpm_notch_min        , 0);
+        setParameter('rpm_notch_lpf'           , sysConfig.rpm_notch_lpf             , 0);
 
         setParameter('dterm_rpm_notch_harmonics', sysConfig.dterm_rpm_notch_harmonics, 0);
         setParameter('dterm_rpm_notch_q'        , sysConfig.dterm_rpm_notch_q        , 0);
@@ -633,35 +645,40 @@ function HeaderDialog(dialog, onSave) {
 
         $('.dshot_bidir_required').toggle(sysConfig.dshot_bidir == 1);
 
-        renderSelect('rc_smoothing_type'          ,sysConfig.rc_smoothing_type, RC_SMOOTHING_TYPE);
-        renderSelect('rc_interpolation'           ,sysConfig.rc_interpolation, RC_INTERPOLATION);
-        setParameter('rc_interpolation_interval'  ,sysConfig.rc_interpolation_interval,0);
-        setParameter('rc_smoothing_cutoffs_1'     ,sysConfig.rc_smoothing_cutoffs[0], 0);
-        setParameter('rc_smoothing_cutoffs_2'     ,sysConfig.rc_smoothing_cutoffs[1], 0);
-        renderSelect('rc_smoothing_filter_type_1' ,sysConfig.rc_smoothing_filter_type[0], RC_SMOOTHING_INPUT_TYPE);
-        renderSelect('rc_smoothing_filter_type_2' ,sysConfig.rc_smoothing_filter_type[1], RC_SMOOTHING_DERIVATIVE_TYPE);
-        setParameter('rc_smoothing_rx_average'    ,sysConfig.rc_smoothing_rx_average, 3);
-        setParameter('rc_smoothing_auto_factor'    ,sysConfig.rc_smoothing_auto_factor, 0);
-        setParameter('rc_smoothing_active_cutoffs_1',sysConfig.rc_smoothing_active_cutoffs[0], 0);
-        setParameter('rc_smoothing_active_cutoffs_2',sysConfig.rc_smoothing_active_cutoffs[1], 0);
-        setParameter('rc_interpolation_channels'  ,sysConfig.rc_interpolation_channels, 0);
-        renderSelect('rc_smoothing_debug_axis'    ,sysConfig.rc_smoothing_filter_type[1], RC_SMOOTHING_DEBUG_AXIS);
+        setParameter('rcSmoothingRxAverage'         ,sysConfig.rc_smoothing_rx_average, 3);
+        renderSelect('rcSmoothingDebugAxis'         ,sysConfig.rc_smoothing_debug_axis, RC_SMOOTHING_DEBUG_AXIS);
 
-        if (sysConfig.rc_smoothing_type === RC_SMOOTHING_TYPE.indexOf('FILTER')) {
-            $('.parameter td[name="rc_interpolation"]').css('display', 'none');
-            $('.parameter td[name="rc_interpolation_interval"]').css('display', 'none');
+        if (activeSysConfig.firmwareType === FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            renderSelect('rcSmoothingMode'              ,sysConfig.rc_smoothing_mode, RC_SMOOTHING_MODE);
+            setParameter('rcSmoothingFeedforwardHz'     ,sysConfig.rc_smoothing_feedforward_hz, 0);
+            setParameter('rcSmoothingSetpointHz'        ,sysConfig.rc_smoothing_setpoint_hz, 0);
+            setParameter('rcSmoothingAutoFactorSetpoint',sysConfig.rc_smoothing_auto_factor_setpoint, 0)
+            setParameter('rcSmoothingThrottleHz'        ,sysConfig.rc_smoothing_throttle_hz, 0);
+            setParameter('rcSmoothingAutoFactorThrottle',sysConfig.rc_smoothing_auto_factor_throttle, 0);
+            setParameter('rcSmoothingActiveCutoffsFf'   ,sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[0], 0);
+            setParameter('rcSmoothingActiveCutoffsSp'   ,sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[1], 0);
+            setParameter('rcSmoothingActiveCutoffsThr'  ,sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[2], 0);
+        } else if (activeSysConfig.firmwareType === FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '3.4.0')) {
+            renderSelect('rcSmoothingMode'              ,sysConfig.rc_smoothing_mode, RC_SMOOTHING_TYPE);
+            setParameter('rcSmoothingFeedforwardHz'     ,sysConfig.rc_smoothing_cutoffs[0], 0);
+            setParameter('rcSmoothingSetpointHz'        ,sysConfig.rc_smoothing_cutoffs[1], 0);
+            setParameter('rcSmoothingAutoFactorSetpoint',sysConfig.rc_smoothing_auto_factor_setpoint, 0);
+            setParameter('rcSmoothingThrottleHz'        ,sysConfig.rc_smoothing_cutoffs[1], 0);
+            setParameter('rcSmoothingAutoFactorThrottle',sysConfig.rc_smoothing_auto_factor_setpoint, 0);
+            setParameter('rcSmoothingActiveCutoffsFf'   ,sysConfig.rc_smoothing_active_cutoffs[0], 0);
+            setParameter('rcSmoothingActiveCutoffsSp'   ,sysConfig.rc_smoothing_active_cutoffs[1], 0);
+            setParameter('rcSmoothingActiveCutoffsThr'  ,sysConfig.rc_smoothing_active_cutoffs[1], 0);
         } else {
-            $('.parameter td[name="rc_smoothing_type"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_cutoffs_1"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_cutoffs_2"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_filter_type_1"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_filter_type_2"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_rx_average"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_debug_axis"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_auto_factor"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_active_cutoffs_1"]').css('display', 'none');
-            $('.parameter td[name="rc_smoothing_active_cutoffs_2"]').css('display', 'none');
-        }
+            renderSelect('rcSmoothingMode'              ,"0", 0);
+            setParameter('rcSmoothingFeedforwardHz'     ,"0", 0);
+            setParameter('rcSmoothingSetpointHz'        ,"0", 0);
+            setParameter('rcSmoothingAutoFactorSetpoint',"0", 0);
+            setParameter('rcSmoothingThrottleHz'        ,"0", 0);
+            setParameter('rcSmoothingAutoFactorThrottle',"0", 0);
+            setParameter('rcSmoothingActiveCutoffsFf'   ,"0", 0);
+            setParameter('rcSmoothingActiveCutoffsSp'   ,"0", 0);
+            setParameter('rcSmoothingActiveCutoffsThr'  ,"0", 0);
+       }
 
         // D_MIN and rate_limits
         if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0')) {
@@ -693,7 +710,21 @@ function HeaderDialog(dialog, onSave) {
         renderSelect('dterm_filter_type'		,sysConfig.dterm_filter_type, FILTER_TYPE);
         setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight,2);
         setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight,2);
-        setParameter('feedforward_transition'   ,sysConfig.feedforward_transition,2);
+
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            renderSelect('feedforwardAveraging'  ,sysConfig.ff_averaging, FF_AVERAGING);
+            setParameter('feedforwardSmoothing'  ,sysConfig.ff_smooth_factor,0);
+            setParameter('feedforwardJitter'     ,sysConfig.ff_jitter_factor,0);
+            setParameter('feedforwardMaxRate'    ,sysConfig.ff_max_rate_limit,0);
+        } else {
+            setParameter('feedforwardAveraging'  ,"0",0);
+            setParameter('feedforwardSmoothing'  ,"0",0);
+            setParameter('feedforwardJitter'     ,"0",0);
+            setParameter('feedforwardMaxRate'    ,"0",0);
+        }
+        setParameter('feedforwardTransition'            ,sysConfig.ff_transition,2);
+        setParameter('feedforwardBoost'         ,sysConfig.ff_boost,0);
+
         setParameter('abs_control_gain'         ,sysConfig.abs_control_gain, 0);
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) {
             setParameterFloat('yawRateAccelLimit', sysConfig.yawRateAccelLimit, 2);


### PR DESCRIPTION
Adds log header support for the new dynamic notch, rc_smoothing, and feedforward fields in 4.3 after inclusion of firmware PR #10723

A 4.2 or earlier log will display values in the appropriate boxes where possible, or in the 'unknown fields' box at the bottom.

This shows how the feedforward part of a log header appears with a 4.3 log

![Screen Shot 2021-07-05 at 07 31 27](https://user-images.githubusercontent.com/11737748/124400051-09bfd600-dd63-11eb-938d-07a9de5ad582.jpg)

And here how the dynamic notch values look for 4.3

![Screen Shot 2021-07-05 at 07 31 55](https://user-images.githubusercontent.com/11737748/124400066-2956fe80-dd63-11eb-893e-b880b5ad5c02.jpg)

And rcSmoothing:

![Screen Shot 2021-07-05 at 07 30 31](https://user-images.githubusercontent.com/11737748/124400085-4db2db00-dd63-11eb-9507-5386db2440d2.jpg)

This supersedes the individual PRs #510 and #511.