### PR TITLE
Temporary remove FileWriter support when exporting video

### DIFF
--- a/js/flightlog_video_renderer.js
+++ b/js/flightlog_video_renderer.js
@@ -89,7 +89,10 @@ function FlightLogVideoRenderer(flightLog, logParameters, videoOptions, events) 
     }
     
     function supportsFileWriter() {
-        return !!(chrome && chrome.fileSystem);
+        // FIXME: a bug in the WebM library does not detect the FileWriter correctly. I keep the code and only comment it waiting for a fix...
+        // More info here: https://github.com/betaflight/blackbox-log-viewer/issues/492 and https://github.com/thenickdude/webm-writer-js/issues/31
+        return false;
+        //return !!(chrome && chrome.fileSystem);
     }
     
     /**


### PR DESCRIPTION
Workaround for https://github.com/betaflight/blackbox-log-viewer/issues/492

Since some update of our code (I suppose some new Node version or similar), the `FileWriter` `constructor.name` does not contain the `FileWriter` value anymore, now it contains `EventTarget`. This produces the behaviour of the issue.

I've opened an issue in the library to see if we can get a real fix for that: https://github.com/thenickdude/webm-writer-js/issues/31 because it is a good idea to stream to disk directly and not to memory.

But until then, this PR removes the `FileWriter` support and uses the "on memory" stream of the video.