### PR TITLE
Fix DUAL_GYRO_SCALED debug mode graph

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -389,6 +389,7 @@ GraphConfig.load = function(config) {
                     case 'DUAL_GYRO_COMBINED':
                     case 'DUAL_GYRO_DIFF':
                     case 'DUAL_GYRO_RAW':
+                    case 'DUAL_GYRO_SCALED':
                     case 'NOTCH':
                     case 'AC_CORRECTION':
                     case 'AC_ERROR':


### PR DESCRIPTION
Fixes https://github.com/betaflight/blackbox-log-viewer/issues/519

When the `DUAL_GYRO_SCALED` debug mode was added, it was not added a "scale" representation for it. This fixes it.