### PR TITLE
update feedforward field defs and graphs for 4.3

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -410,11 +410,11 @@ function FlightLogFieldPresenter() {
             'debug[3]':'Not Used',
         },
         'FF_INTERPOLATED' : {
-            'debug[all]':'FF Interpolated', 
-            'debug[0]':'Setpoint Delta Impl [Roll]',
-            'debug[1]':'Boost Amount',
-            'debug[2]':'Boost Amount Clip [Roll]',
-            'debug[3]':'Clip',
+            'debug[all]':'FF Interpolated [roll]', 
+            'debug[0]':'Setpoint Delta Impl [roll]',
+            'debug[1]':'Boost amount [roll]',
+            'debug[2]':'Boost amount, clipped [roll]',
+            'debug[3]':'Clip amount [roll]',
         },
         'RTH' : {
             'debug[all]':'RTH',
@@ -431,12 +431,22 @@ function FlightLogFieldPresenter() {
 
         DEBUG_FRIENDLY_FIELD_NAMES = {...DEBUG_FRIENDLY_FIELD_NAMES_INITIAL};
 
+        if (firmwareType === FIRMWARE_TYPE_BETAFLIGHT && semver.gte(firmwareVersion, '4.2.0')) {
+            DEBUG_FRIENDLY_FIELD_NAMES.FF_INTERPOLATED = {
+                'debug[all]':'FF_Interpolated [roll]',
+                'debug[0]':'Setpoint Delta [roll]',
+                'debug[1]':'Acceleration [roll]',
+                'debug[2]':'Acceleration, clipped [roll]',
+                'debug[3]':'Duplicate Counter [roll]',
+            };
+        }
         if (firmwareType === FIRMWARE_TYPE_BETAFLIGHT && semver.gte(firmwareVersion, '4.3.0')) {
             DEBUG_FRIENDLY_FIELD_NAMES.FF_INTERPOLATED = {
-                'debug[0]':'Raw FF Derivative [Roll]',
-                'debug[1]':'Cleaned FF Derivative ',
-                'debug[2]':'Cleaned Boost Amount [Roll]',
-                'debug[3]':'Duplicate Marker',
+                'debug[all]':'Feedforward [roll]',
+                'debug[0]':'Setpoint, interpolated [roll]',
+                'debug[1]':'Delta, smoothed [roll]',
+                'debug[2]':'Boost, smoothed [roll]',
+                'debug[3]':'rcCommand Delta [roll]',
             };
         }
     };

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -535,6 +535,25 @@ GraphConfig.load = function(config) {
                                 return getCurveForMinMaxFieldsZeroOffset(fieldName);
                         }
                         break;
+                    case 'FF_INTERPOLATED':
+                        switch (fieldName) {
+                            case 'debug[0]': // in 4.3 is interpolated setpoint
+                            return {
+                                offset: 0,
+                                power: 1.0,
+                                inputRange: maxDegreesSecond(gyroScaleMargin),
+                                outputRange: 1.0
+                            };
+                            case 'debug[1]': // feedforward delta element
+                            case 'debug[2]': // feedforward boost element
+                            return {
+                                offset: 0,
+                                power: 1.0,
+                                inputRange: 1000,
+                                outputRange: 1.0
+                            };
+                        }
+                        break;
                 }
             }
             // if not found above then


### PR DESCRIPTION
This PR builds on https://github.com/betaflight/blackbox-log-viewer/pull/514 , and are intended to sync with changes in firmware https://github.com/betaflight/betaflight/pull/10805, where the debugs are re-ordered.

The intent is to:

- correctly set the feedforward field names for 4.1, 4.2 and 4.3
- appended `[roll]` to each because all values are from roll only
- correctly, sets the debugs 0-2 to be 'centered'
- scales the (interpolated but not smoothed) setpoint trace to match that of normal setpoint
- for 4.3, makes the debug group name appear as `Feedforward [roll]` to match the firmware name as proposed in https://github.com/betaflight/betaflight/pull/10805

It all works fine, as far as I can tell. 

This images shows the various debugs, and how they can appear in 4.3 over https://github.com/betaflight/betaflight/pull/10805

It is now quite easy to see the contribution made by boost to the overall feedforward signal, which is simply the rcSmoothed sum of delta and boost.  

By overlaying the `Setpoint, interpolated` graph from this debug with normal setpoint we can:

- identify the rcSmoothing delay, if any
- determine if a 'gap' in normal setpoint is caused by not receiving a packet or by receiving a duplicate; a duplicate will cause a flat spot in plain setpoint but not in `Setpoint, interpolated`, whereas a non-received (dropped) packet causes a flat spot in both.

![Screen Shot 2021-06-23 at 12 17 12](https://user-images.githubusercontent.com/11737748/123048693-06168000-d442-11eb-829b-937400c84ecf.jpg)
