### PR TITLE
Default view to not show craft or sticks overlaid over waveforms

### DIFF
--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -45,10 +45,10 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 		stickInvertYaw		: false,			// Invert yaw in stick display?
         legendUnits			: true,	            // Show units on legend?
 		gapless				: false,
-        drawCraft           : "3D", 
+        drawCraft           : false, 
         hasCraft            : true,
 		drawPidTable		: true, 
-        drawSticks          : true, 
+        drawSticks          : false, 
 		drawTime			: true,
 		drawEvents			: true,
 		drawAnalyser		: true,             // add an analyser option


### PR DESCRIPTION
Simple PR so that, when opened for the first time, craft and sticks are not overlaid over the waveforms.

My take is that for most tuning purposes, these images just get in the way of looking at the waveforms, and most users would turn them off if they knew how.

If a person wants them on, for a specific reason, they can still turn them on.