### PR TITLE
support firmware rpm filter name changes, minor cleanups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,23 +1205,22 @@
                                         <tbody>
                                             <tr>
                                                 <td name='gyro_soft_dyn_type' colspan="2">
-                                                    <label>Lowpass Dyn Filter<br>Type 1</label>
+                                                    <label>Lowpass Dyn Filter<br>Type</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
-                                            </tr>
-
-                                            <tr>
                                                 <td name="gyro_soft_dyn_min_hz">
-                                                    <label>Lowpass Dyn Filter<br>Min Cutoff 1 (Hz)</label>
+                                                    <label>Lowpass Dyn Filter<br>Min Cutoff (Hz)</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="gyro_soft_dyn_max_hz">
-                                                    <label>Lowpass Dyn Filter<br>Max Cutoff 1 (Hz)</label>
+                                                    <label>Lowpass Dyn Filter<br>Max Cutoff (Hz)</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
+                                            </tr>
 
+                                            <tr>
                                                 <td name='gyro_soft_type'>
                                                     <label>Lowpass Filter<br>Type 1</label>
                                                     <select>
@@ -1243,6 +1242,7 @@
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
+
                                             <tr>
                                                 <td name='gyro_notch_hz'>
                                                     <label>Notch 1
@@ -1271,7 +1271,7 @@
                                                <tr>
                                                 <th scope="row" colspan="4">Dynamic notch filters</th>
                                                </tr>
-                                           </thead>
+                                            </thead>
                                                 <td name='dynNotchCount'>
                                                     <label>Count/Width</label>
                                                     <input type="number" step="1" min="0" max="10" />
@@ -1289,32 +1289,42 @@
                                                     <input type="number" step="1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
+                                        </tbody>
+                                    </table>
 
-                                            <tr class='dshot_bidir_required'>
+                                    <table class="parameter cf">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="5">RPM filters</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr class="dshot_bidir_required">
+                                            <thead>
                                                 <td name='gyro_rpm_notch_harmonics'>
-                                                    <label>RPM Notch
-                                                           <br>Harmonics</label>
+                                                    <label>Harmonics</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="gyro_rpm_notch_q">
-                                                    <label>RPM Notch
-                                                        <br>Q</label>
+                                                    <label>Q</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                                 <td name='gyro_rpm_notch_min'>
-                                                    <label>RPM Notch
-                                                        <br>Min(Hz)</label>
+                                                    <label>Min(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name='rpm_filter_fade_range_hz'>
+                                                    <label>Fade Range</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name='rpm_notch_lpf'>
-                                                    <label>RPM Notch
-                                                        <br>Lpf</label>
+                                                    <label>Lowpass</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
-
                                         </tbody>
                                     </table>
+
                                     <table class="parameter cf">
                                         <thead>
                                             <tr>
@@ -1383,8 +1393,11 @@
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
-
-                                            <tr class='dshot_bidir_required'>
+                                        </tbody>
+                                    </table>
+                                    <table class="parameter cf">
+                                        <tbody>
+                                            <tr class="dshot_bidir_required">
                                                 <td name='dterm_rpm_notch_harmonics'>
                                                     <label>RPM Notch
                                                            <br>Harmonics</label>
@@ -1401,7 +1414,6 @@
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
-
                                         </tbody>
                                     </table>
                                     <table class="parameter cf">
@@ -1828,7 +1840,20 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="motorOutputLow">
+                                                        <label>D-Shot Motor Low</label>
+                                                        <input type="number" step="10" min="0" max="2047" />
+                                                    </td>
+                                                    <td name="motorOutputHigh">
+                                                        <label>D-Shot Motor High</label>
+                                                        <input type="number" step="10" min="0" max="2047" />
+                                                    </td>
                                                 </tr>
                                             </tbody>
                                         </table>
@@ -1879,18 +1904,9 @@
                                                 </tr>
                                             </tbody>
                                         </table>
+
                                         <table class="parameter cf">
                                             <tbody>
-                                                <tr>
-                                                    <td name="motorOutputLow">
-                                                        <label>D-Shot Motor Low</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
-                                                    </td>
-                                                    <td name="motorOutputHigh">
-                                                        <label>D-Shot Motor High</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
-                                                    </td>
-                                                </tr>
                                                 <tr>
                                                     <td name="digitalIdleOffset">
                                                         <label>D-Shot Offset (%)</label>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -195,8 +195,9 @@ var FlightLogParser = function(logData) {
             deviceUID: null
         },
 
-        // These are now part of the blackbox log header, but they are in addition to the standard logger.
-        // each name should match a field in blackbox.c of the current firmware
+        // Blackbox log header parameter names.
+        // each name should exist in the blackbox log of the current firmware, or
+        // be an older name which is translated into a current name in the table below
 
         defaultSysConfigExtension = {
             abs_control_gain:null,                  // Aboslute control gain
@@ -252,6 +253,7 @@ var FlightLogParser = function(logData) {
             gyro_rpm_notch_q:null,                  // Value of Q in the gyro rpm filter
             gyro_rpm_notch_min:null,                // Min Hz for the gyro rpm filter
             rpm_notch_lpf:null,                     // Cutoff for smoothing rpm filter data
+            rpm_filter_fade_range_hz:null,          // RPM filter fade range in hz above the min hz
             dterm_rpm_notch_harmonics:null,         // Number of Harmonics in the dterm rpm filter
             dterm_rpm_notch_q:null,                 // Value of Q in the dterm rpm filter
             dterm_rpm_notch_min:null,               // Min Hz for the dterm rpm filter
@@ -326,8 +328,8 @@ var FlightLogParser = function(logData) {
         },
 
         // Translation of the field values name to the sysConfig var where it must be stored
-        // on the left are field names from older versions of blackbox.c
-        // on the right are names from the list above
+        // on the left are field names from the latest versions of blackbox.c
+        // on the right are older field names that must exist in the list above
 
         translationValues = {
             acc_limit_yaw             : "yawRateAccelLimit",
@@ -373,7 +375,11 @@ var FlightLogParser = function(logData) {
             feedforward_transition    : "ff_transition",
             feedforward_weight        : "ff_weight",
             rc_smoothing_auto_factor  : "rc_smoothing_auto_factor_setpoint",
-            rc_smoothing_type         : "rc_smoothing_mode"
+            rc_smoothing_type         : "rc_smoothing_mode",
+            rpm_filter_harmonics      : "gyro_rpm_notch_harmonics",
+            rpm_filter_q              : "gyro_rpm_notch_q",
+            rpm_filter_min_hz         : "gyro_rpm_notch_min",
+            rpm_filter_lpf_hz         : "rpm_notch_lpf"
         },
 
         frameTypes,
@@ -641,6 +647,7 @@ var FlightLogParser = function(logData) {
             case "gyro_rpm_notch_q":
             case "gyro_rpm_notch_min":
             case "rpm_notch_lpf":
+            case "rpm_filter_fade_range_hz":
             case "dterm_rpm_notch_harmonics":
             case "dterm_rpm_notch_q":
             case "dterm_rpm_notch_min":

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -544,53 +544,53 @@ function HeaderDialog(dialog, onSave) {
         populatePID('levelPID'					, sysConfig.levelPID);
 
         // Fill in data from for the rates object
-        setParameter('rcRollRate'               ,sysConfig.rc_rates[0],2);
-        setParameter('rcRollExpo'               ,sysConfig.rc_expo[0],2);
-        setParameter('rcPitchRate'              ,sysConfig.rc_rates[1],2);
-        setParameter('rcPitchExpo'              ,sysConfig.rc_expo[1],2);
-        setParameter('rcYawRate'                ,sysConfig.rc_rates[2],2);
-        setParameter('rcYawExpo'                ,sysConfig.rc_expo[2],2);
-        setParameter('vbatscale'				,sysConfig.vbatscale,0);
-        setParameter('vbatref'					,sysConfig.vbatref,0);
-        setParameter('vbatmincellvoltage'		,sysConfig.vbatmincellvoltage,1);
-        setParameter('vbatmaxcellvoltage'		,sysConfig.vbatmaxcellvoltage,1);
-        setParameter('vbatwarningcellvoltage'	,sysConfig.vbatwarningcellvoltage,1);
-        setParameter('minthrottle'				,sysConfig.minthrottle,0);
-        setParameter('maxthrottle'				,sysConfig.maxthrottle,0);
-        setParameter('currentMeterOffset'		,sysConfig.currentMeterOffset,0);
-        setParameter('currentMeterScale'		,sysConfig.currentMeterScale,0);
-        setParameter('thrMid'					,sysConfig.thrMid,2);
-        setParameter('thrExpo'					,sysConfig.thrExpo,2);
-        setParameter('dynThrPID'				,sysConfig.dynThrPID,2);
-        setParameter('tpa-breakpoint'			,sysConfig.tpa_breakpoint,0);
-		setParameter('superExpoFactor'			,sysConfig.superExpoFactor,2);
-		setParameter('superExpoFactorYaw'		,sysConfig.superExpoFactorYaw,2);
+        setParameter('rcRollRate'               ,sysConfig.rc_rates[0], 2);
+        setParameter('rcRollExpo'               ,sysConfig.rc_expo[0], 2);
+        setParameter('rcPitchRate'              ,sysConfig.rc_rates[1], 2);
+        setParameter('rcPitchExpo'              ,sysConfig.rc_expo[1], 2);
+        setParameter('rcYawRate'                ,sysConfig.rc_rates[2], 2);
+        setParameter('rcYawExpo'                ,sysConfig.rc_expo[2], 2);
+        setParameter('vbatscale'				,sysConfig.vbatscale, 0);
+        setParameter('vbatref'					,sysConfig.vbatref, 0);
+        setParameter('vbatmincellvoltage'		,sysConfig.vbatmincellvoltage, 1);
+        setParameter('vbatmaxcellvoltage'		,sysConfig.vbatmaxcellvoltage, 1);
+        setParameter('vbatwarningcellvoltage'	,sysConfig.vbatwarningcellvoltage, 1);
+        setParameter('minthrottle'				,sysConfig.minthrottle, 0);
+        setParameter('maxthrottle'				,sysConfig.maxthrottle, 0);
+        setParameter('currentMeterOffset'		,sysConfig.currentMeterOffset, 0);
+        setParameter('currentMeterScale'		,sysConfig.currentMeterScale, 0);
+        setParameter('thrMid'					,sysConfig.thrMid, 2);
+        setParameter('thrExpo'					,sysConfig.thrExpo, 2);
+        setParameter('dynThrPID'				,sysConfig.dynThrPID, 2);
+        setParameter('tpa-breakpoint'			,sysConfig.tpa_breakpoint, 0);
+		setParameter('superExpoFactor'			,sysConfig.superExpoFactor, 2);
+		setParameter('superExpoFactorYaw'		,sysConfig.superExpoFactorYaw, 2);
 
 		if (sysConfig.firmwareType == FIRMWARE_TYPE_INAV) {
-			setParameter('rates[0]'				,sysConfig.rates[0] * 10,0);
-			setParameter('rates[1]'				,sysConfig.rates[1] * 10,0);
-			setParameter('rates[2]'				,sysConfig.rates[2] * 10,0);
+			setParameter('rates[0]'				,sysConfig.rates[0] * 10, 0);
+			setParameter('rates[1]'				,sysConfig.rates[1] * 10, 0);
+			setParameter('rates[2]'				,sysConfig.rates[2] * 10, 0);
 		} else {
-			setParameter('rates[0]'				,sysConfig.rates[0],2);
-	        setParameter('rates[1]'				,sysConfig.rates[1],2);
-	        setParameter('rates[2]'				,sysConfig.rates[2],2);
+			setParameter('rates[0]'				,sysConfig.rates[0], 2);
+	        setParameter('rates[1]'				,sysConfig.rates[1], 2);
+	        setParameter('rates[2]'				,sysConfig.rates[2], 2);
 		}
 
-        setParameter('loopTime'					,sysConfig.looptime,0);
-        setParameter('gyro_sync_denom'			,sysConfig.gyro_sync_denom,0);
-        setParameter('pid_process_denom'		,sysConfig.pid_process_denom,0);
-        setParameter('yaw_p_limit'				,sysConfig.yaw_p_limit,0);
-        setParameter('dterm_average_count'		,sysConfig.dterm_average_count,0);
+        setParameter('loopTime'					,sysConfig.looptime, 0);
+        setParameter('gyro_sync_denom'			,sysConfig.gyro_sync_denom, 0);
+        setParameter('pid_process_denom'		,sysConfig.pid_process_denom, 0);
+        setParameter('yaw_p_limit'				,sysConfig.yaw_p_limit, 0);
+        setParameter('dterm_average_count'		,sysConfig.dterm_average_count, 0);
     	renderSelect('dynamic_pterm'			,sysConfig.dynamic_pterm, OFF_ON);
-        setParameter('rollPitchItermResetRate'	,sysConfig.rollPitchItermResetRate,0);
-        setParameter('yawItermResetRate'		,sysConfig.yawItermResetRate,0);
-        setParameter('rollPitchItermIgnoreRate'	,sysConfig.rollPitchItermIgnoreRate,0);
-        setParameter('yawItermIgnoreRate'		,sysConfig.yawItermIgnoreRate,0);
-        setParameter('itermWindupPointPercent'  ,sysConfig.itermWindupPointPercent,0);
-        setParameter('dterm_cut_hz'				,sysConfig.dterm_cut_hz,2);
-        setParameter('iterm_reset_offset'		,sysConfig.iterm_reset_offset,0);
-        setParameter('deadband'					,sysConfig.deadband,0);
-        setParameter('yaw_deadband'				,sysConfig.yaw_deadband,0);
+        setParameter('rollPitchItermResetRate'	,sysConfig.rollPitchItermResetRate, 0);
+        setParameter('yawItermResetRate'		,sysConfig.yawItermResetRate, 0);
+        setParameter('rollPitchItermIgnoreRate'	,sysConfig.rollPitchItermIgnoreRate, 0);
+        setParameter('yawItermIgnoreRate'		,sysConfig.yawItermIgnoreRate, 0);
+        setParameter('itermWindupPointPercent'  ,sysConfig.itermWindupPointPercent, 0);
+        setParameter('dterm_cut_hz'				,sysConfig.dterm_cut_hz, 2);
+        setParameter('iterm_reset_offset'		,sysConfig.iterm_reset_offset, 0);
+        setParameter('deadband'					,sysConfig.deadband, 0);
+        setParameter('yaw_deadband'				,sysConfig.yaw_deadband, 0);
 
         if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.4.0')) {
             renderSelect('gyro_hardware_lpf'       ,sysConfig.gyro_lpf, GYRO_HARDWARE_LPF);
@@ -600,53 +600,53 @@ function HeaderDialog(dialog, onSave) {
         }
 
         renderSelect('gyro_32khz_hardware_lpf'  ,sysConfig.gyro_32khz_hardware_lpf, GYRO_32KHZ_HARDWARE_LPF);
-        setParameter('acc_lpf_hz'				,sysConfig.acc_lpf_hz,2);
-        setParameter('acc_cut_hz'				,sysConfig.acc_cut_hz,2);
+        setParameter('acc_lpf_hz'				,sysConfig.acc_lpf_hz, 2);
+        setParameter('acc_cut_hz'				,sysConfig.acc_cut_hz, 2);
 	    setParameter('airmode_activate_throttle',sysConfig.airmode_activate_throttle, 0);
 	    renderSelect('serialrx_provider'		,sysConfig.serialrx_provider, SERIALRX_PROVIDER);
 	    renderSelect('superExpoYawMode'		    ,sysConfig.superExpoYawMode, SUPER_EXPO_YAW);
     	renderSelect('dynamic_pid'				,sysConfig.dynamic_pid, OFF_ON);
 
 		if(isParameterValid('gyro_notch_hz_2')) {
-			setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz[0],0);
-			setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff[0],0);
-			setParameter('gyro_notch_hz_2'			,sysConfig.gyro_notch_hz[1],0);
-			setParameter('gyro_notch_cutoff_2'		,sysConfig.gyro_notch_cutoff[1],0);
+			setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz[0], 0);
+			setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff[0], 0);
+			setParameter('gyro_notch_hz_2'			,sysConfig.gyro_notch_hz[1], 0);
+			setParameter('gyro_notch_cutoff_2'		,sysConfig.gyro_notch_cutoff[1], 0);
 		} else {
 			setParameter('gyro_notch_hz'			,sysConfig.gyro_notch_hz, 0);
 			setParameter('gyro_notch_cutoff'		,sysConfig.gyro_notch_cutoff, 0);
-			setParameter('gyro_notch_hz_2'			,0,0); // this parameter does not exist in earlier versions
-			setParameter('gyro_notch_cutoff_2'		,0,0); // this parameter does not exist in earlier versions
+			setParameter('gyro_notch_hz_2'			,0, 0); // this parameter does not exist in earlier versions
+			setParameter('gyro_notch_cutoff_2'		,0, 0); // this parameter does not exist in earlier versions
 		}
-		setParameter('dterm_notch_hz'			,sysConfig.dterm_notch_hz,0);
-		setParameter('dterm_notch_cutoff'		,sysConfig.dterm_notch_cutoff,0);
-        setParameter('dterm_lpf2_hz'            ,sysConfig.dterm_lpf2_hz,0);
-		setParameter('dterm_lpf_hz'				,sysConfig.dterm_lpf_hz,0);
-		setParameter('yaw_lpf_hz'				,sysConfig.yaw_lpf_hz,0);
-		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz,0);
-		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
+		setParameter('dterm_notch_hz'			,sysConfig.dterm_notch_hz, 0);
+		setParameter('dterm_notch_cutoff'		,sysConfig.dterm_notch_cutoff, 0);
+        setParameter('dterm_lpf2_hz'            ,sysConfig.dterm_lpf2_hz, 0);
+		setParameter('dterm_lpf_hz'				,sysConfig.dterm_lpf_hz, 0);
+		setParameter('yaw_lpf_hz'				,sysConfig.yaw_lpf_hz, 0);
+		setParameter('gyro_lowpass_hz'			,sysConfig.gyro_lowpass_hz, 0);
+		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz, 0);
 
         if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
-            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_count,0);
+            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_count, 0);
         } else {
-            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_width_percent,0);
+            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_width_percent, 0);
         }
-        setParameter('dynNotchQ'                ,sysConfig.dyn_notch_q,0);
-        setParameter('dynNotchMinHz'            ,sysConfig.dyn_notch_min_hz,0);
+        setParameter('dynNotchQ'                ,sysConfig.dyn_notch_q, 0);
+        setParameter('dynNotchMinHz'            ,sysConfig.dyn_notch_min_hz, 0);
         setParameter('dynNotchMaxHz'            ,sysConfig.dyn_notch_max_hz, 0);
 
-        setParameter('gyro_rpm_notch_harmonics' ,sysConfig.gyro_rpm_notch_harmonics,0);
-        setParameter('gyro_rpm_notch_q'         ,sysConfig.gyro_rpm_notch_q,0);
-        setParameter('gyro_rpm_notch_min'       ,sysConfig.gyro_rpm_notch_min,0);
-        setParameter('rpm_notch_lpf'            ,sysConfig.rpm_notch_lpf,0);
+        setParameter('gyro_rpm_notch_harmonics' ,sysConfig.gyro_rpm_notch_harmonics, 0);
+        setParameter('gyro_rpm_notch_q'         ,sysConfig.gyro_rpm_notch_q, 0);
+        setParameter('gyro_rpm_notch_min'       ,sysConfig.gyro_rpm_notch_min, 0);
+        setParameter('rpm_notch_lpf'            ,sysConfig.rpm_notch_lpf, 0);
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
-            setParameter('rpm_filter_fade_range_hz' ,sysConfig.rpm_filter_fade_range_hz ,0);
+            setParameter('rpm_filter_fade_range_hz' ,sysConfig.rpm_filter_fade_range_hz , 0);
         } else {
-            setParameter('rpm_filter_fade_range_hz'  ,"0",0);
+            setParameter('rpm_filter_fade_range_hz'  ,"0", 0);
         }
-        setParameter('dterm_rpm_notch_harmonics',sysConfig.dterm_rpm_notch_harmonics,0);
-        setParameter('dterm_rpm_notch_q'        ,sysConfig.dterm_rpm_notch_q,0);
-        setParameter('dterm_rpm_notch_min'      ,sysConfig.dterm_rpm_notch_min,0);
+        setParameter('dterm_rpm_notch_harmonics',sysConfig.dterm_rpm_notch_harmonics, 0);
+        setParameter('dterm_rpm_notch_q'        ,sysConfig.dterm_rpm_notch_q, 0);
+        setParameter('dterm_rpm_notch_min'      ,sysConfig.dterm_rpm_notch_min, 0);
 
         $('.dshot_bidir_required').toggle(sysConfig.dshot_bidir == 1);
 
@@ -709,26 +709,26 @@ function HeaderDialog(dialog, onSave) {
 
     	renderSelect('unsynced_fast_pwm'		,sysConfig.unsynced_fast_pwm, MOTOR_SYNC);
     	renderSelect('fast_pwm_protocol'		,sysConfig.fast_pwm_protocol, FAST_PROTOCOL);
-        setParameter('motor_pwm_rate'		    ,sysConfig.motor_pwm_rate,0);
+        setParameter('motor_pwm_rate'		    ,sysConfig.motor_pwm_rate, 0);
         renderSelect('dshot_bidir'              ,sysConfig.dshot_bidir, OFF_ON);
 
         renderSelect('dterm_filter_type'		,sysConfig.dterm_filter_type, FILTER_TYPE);
-        setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight,2);
-        setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight,2);
+        setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight, 2);
+        setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight, 2);
 
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
             renderSelect('feedforwardAveraging'  ,sysConfig.ff_averaging, FF_AVERAGING);
-            setParameter('feedforwardSmoothing'  ,sysConfig.ff_smooth_factor,0);
-            setParameter('feedforwardJitter'     ,sysConfig.ff_jitter_factor,0);
-            setParameter('feedforwardMaxRate'    ,sysConfig.ff_max_rate_limit,0);
+            setParameter('feedforwardSmoothing'  ,sysConfig.ff_smooth_factor, 0);
+            setParameter('feedforwardJitter'     ,sysConfig.ff_jitter_factor, 0);
+            setParameter('feedforwardMaxRate'    ,sysConfig.ff_max_rate_limit, 0);
         } else {
-            setParameter('feedforwardAveraging'  ,"0",0);
-            setParameter('feedforwardSmoothing'  ,"0",0);
-            setParameter('feedforwardJitter'     ,"0",0);
-            setParameter('feedforwardMaxRate'    ,"0",0);
+            setParameter('feedforwardAveraging'  ,"0", 0);
+            setParameter('feedforwardSmoothing'  ,"0", 0);
+            setParameter('feedforwardJitter'     ,"0", 0);
+            setParameter('feedforwardMaxRate'    ,"0", 0);
         }
-        setParameter('feedforwardTransition'            ,sysConfig.ff_transition,2);
-        setParameter('feedforwardBoost'         ,sysConfig.ff_boost,0);
+        setParameter('feedforwardTransition'            ,sysConfig.ff_transition, 2);
+        setParameter('feedforwardBoost'         ,sysConfig.ff_boost, 0);
 
         setParameter('abs_control_gain'         ,sysConfig.abs_control_gain, 0);
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) {
@@ -741,25 +741,25 @@ function HeaderDialog(dialog, onSave) {
         renderSelect('gyro_soft_type'			,sysConfig.gyro_soft_type, FILTER_TYPE);
         renderSelect('gyro_soft2_type'          ,sysConfig.gyro_soft2_type, FILTER_TYPE);
         renderSelect('debug_mode'				,sysConfig.debug_mode, DEBUG_MODE);
-		setParameter('motorOutputLow'			,sysConfig.motorOutput[0],0);
-		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1],0);
-		setParameter('digitalIdleOffset'		,sysConfig.digitalIdleOffset,2);
+		setParameter('motorOutputLow'			,sysConfig.motorOutput[0], 0);
+		setParameter('motorOutputHigh'			,sysConfig.motorOutput[1], 0);
+		setParameter('digitalIdleOffset'		,sysConfig.digitalIdleOffset, 2);
         renderSelect('antiGravityMode'          ,sysConfig.anti_gravity_mode, ANTI_GRAVITY_MODE);
         if((activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '3.1.0')) ||
                 (activeSysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '2.0.0'))) {
-            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,3);
+            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain, 3);
         } else {
-            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain,0);
+            setParameter('antiGravityGain'      ,sysConfig.anti_gravity_gain, 0);
         }
-        setParameter('antiGravityThreshold'     ,sysConfig.anti_gravity_threshold,0);
+        setParameter('antiGravityThreshold'     ,sysConfig.anti_gravity_threshold, 0);
         if (sysConfig.anti_gravity_mode === ANTI_GRAVITY_MODE.indexOf('SMOOTH')) {
             $('.parameter td[name="antiGravityThreshold"]').css('display', 'none');
         }
-		setParameter('setpointRelaxRatio'		,sysConfig.setpointRelaxRatio,2);
-		setParameter('pidSumLimit'     			,sysConfig.pidSumLimit,0);
-        setParameter('pidSumLimitYaw'			,sysConfig.pidSumLimitYaw,0);
+		setParameter('setpointRelaxRatio'		,sysConfig.setpointRelaxRatio, 2);
+		setParameter('pidSumLimit'     			,sysConfig.pidSumLimit, 0);
+        setParameter('pidSumLimitYaw'			,sysConfig.pidSumLimitYaw, 0);
 
-        setParameter('vbat_sag_compensation'    ,sysConfig.vbat_sag_compensation,0);
+        setParameter('vbat_sag_compensation'    ,sysConfig.vbat_sag_compensation, 0);
 
         setParameter('dynamic_idle_min_rpm'     , sysConfig.dynamic_idle_min_rpm, 0);
 

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -110,6 +110,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'rc_smoothing_active_cutoffs_sp',    type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'rc_smoothing_active_cutoffs_thr',   type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dyn_notch_count'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rpm_filter_fade_range_hz'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'}
     ];
 
 	function isParameterValid(name) {
@@ -626,22 +627,26 @@ function HeaderDialog(dialog, onSave) {
 		setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
         if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
-            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_count        , 0);
+            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_count,0);
         } else {
-            setParameter('dynNotchCount'           ,sysConfig.dyn_notch_width_percent, 0);
+            setParameter('dynNotchCount'        ,sysConfig.dyn_notch_width_percent,0);
         }
-        setParameter('dynNotchQ'                   ,sysConfig.dyn_notch_q            , 0);
-        setParameter('dynNotchMinHz'               ,sysConfig.dyn_notch_min_hz       , 0);
-        setParameter('dynNotchMaxHz'               ,sysConfig.dyn_notch_max_hz       , 0);
+        setParameter('dynNotchQ'                ,sysConfig.dyn_notch_q,0);
+        setParameter('dynNotchMinHz'            ,sysConfig.dyn_notch_min_hz,0);
+        setParameter('dynNotchMaxHz'            ,sysConfig.dyn_notch_max_hz, 0);
 
-        setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics  , 0);
-        setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q          , 0);
-        setParameter('gyro_rpm_notch_min'      , sysConfig.gyro_rpm_notch_min        , 0);
-        setParameter('rpm_notch_lpf'           , sysConfig.rpm_notch_lpf             , 0);
-
-        setParameter('dterm_rpm_notch_harmonics', sysConfig.dterm_rpm_notch_harmonics, 0);
-        setParameter('dterm_rpm_notch_q'        , sysConfig.dterm_rpm_notch_q        , 0);
-        setParameter('dterm_rpm_notch_min'      , sysConfig.dterm_rpm_notch_min      , 0);
+        setParameter('gyro_rpm_notch_harmonics' ,sysConfig.gyro_rpm_notch_harmonics,0);
+        setParameter('gyro_rpm_notch_q'         ,sysConfig.gyro_rpm_notch_q,0);
+        setParameter('gyro_rpm_notch_min'       ,sysConfig.gyro_rpm_notch_min,0);
+        setParameter('rpm_notch_lpf'            ,sysConfig.rpm_notch_lpf,0);
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+            setParameter('rpm_filter_fade_range_hz' ,sysConfig.rpm_filter_fade_range_hz ,0);
+        } else {
+            setParameter('rpm_filter_fade_range_hz'  ,"0",0);
+        }
+        setParameter('dterm_rpm_notch_harmonics',sysConfig.dterm_rpm_notch_harmonics,0);
+        setParameter('dterm_rpm_notch_q'        ,sysConfig.dterm_rpm_notch_q,0);
+        setParameter('dterm_rpm_notch_min'      ,sysConfig.dterm_rpm_notch_min,0);
 
         $('.dshot_bidir_required').toggle(sysConfig.dshot_bidir == 1);
 


### PR DESCRIPTION
Changes:

- Supports the rpm filteringname changes from [10856](https://github.com/betaflight/betaflight/pull/10856).
- Includes `rpm_filter_fade_range_hz` parameter
- Tidies up the gyro lowpass filtering html
- Moves DShot min and max values to the Motors section, leaving idle values in the Throttle section.
- Updates comments in `flightlog_parser.js` about adding new parameters
- Whitespace tidy ups

Image showing `rpm_filter_fade_range` element:

![Screen Shot 2021-09-17 at 17 31 57](https://user-images.githubusercontent.com/11737748/133742867-e0202e04-816a-443b-8d7c-65cbf3f1a5e5.jpg)

Image showing the motor and throttle rearrangement
![Screen Shot 2021-09-17 at 17 22 23](https://user-images.githubusercontent.com/11737748/133743076-e877fa7f-34e8-4ff5-ae25-f4a83ddce526.jpg)
:
