### PR TITLE
4.3 field support

### DIFF
--- a/css/header_dialog.css
+++ b/css/header_dialog.css
@@ -1,6 +1,6 @@
 /* Colums  START> */
 .cf_column {
-    min-height: 20px;
+    min-height: 18px;
     margin-bottom: 0;
 }
 
@@ -55,6 +55,7 @@
 input[type="number"]::-webkit-inner-spin-button {
     opacity: 1; /* required for chromium 33+ beta */
     margin-left: 5px;
+    margin-right: 5px;
 }
 
 .clear-both {
@@ -73,7 +74,7 @@ input[type="number"]::-webkit-inner-spin-button {
 .gui_box {
     border: 1px solid #ccc;
     border-radius: 4px;
-    background-color: #FFFFFF;
+    background-color: #ccc;
     float: left;
     width: calc(100% - 2px);
     margin-bottom: 10px;
@@ -81,14 +82,15 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 .gui_box_titlebar {
-    background-color: #e4e4e4;
+    background-color: #808080;
     border-radius: 3px 3px 0 0;
-    font-size: 13px;
+    font-size: 14px;
     width: 100%;
     height: 27px;
     padding-bottom: 0;
     float: left;
-    margin-bottom: 7px;
+    color: white;
+    margin-bottom: 0px;
     font-family: 'open_sanssemibold', Arial, serif;
 }
 
@@ -101,10 +103,12 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 .spacer_box {
-    padding: 10px;
-    margin-bottom: 3px;
+    padding: 0px;
+    margin: 0px;
+    width: 100%;
 }
 
+/* main title for each div*/
 .spacer_box_title {
     padding-left: 10px;
     padding-right: 10px;
@@ -113,6 +117,7 @@ input[type="number"]::-webkit-inner-spin-button {
     float: left;
 }
 
+/* space around each div*/
 .spacer_left {
     padding-left: 15px;
     float: left;
@@ -133,25 +138,35 @@ input[type="number"]::-webkit-inner-spin-button {
     border-top-right-radius: 3px;
 }
 
-.header-dialog .parameter label {
-    background-color: #828885;
-    padding: 4px;
+/* Parameter box titles */
+.header-dialog .parameter th {
+    background-color: #b0b0b0;
+    padding: 2px;
+    padding-left: 10px;
     border-left: 0 solid #ccc;
-    border-bottom: 1px solid #ccc;
-    font-weight: normal;
-    color: white;
+    font-weight: bold;
+    font-size: 14px;
+    color: #505050;
     text-align: left;
+}
+
+/* Parameter box other lines */
+.header-dialog .parameter label {
+    background-color: #d8d8d8;
+    padding: 0px;
+    margin: 0px;
+    border-left: 0 solid #ccc;
+    font-weight: normal;
+    font-size: 13px;
+    color: #505050;
+    text-align: center;
     width:100%;
 }
 
-.header-dialog .parameter th {
-    background-color: #828885;
-    padding: 4px;
-    border-left: 0 solid #ccc;
-    border-bottom: 1px solid #ccc;
-    font-weight: bold;
-    color: white;
-    text-align: left;
+/* Parameter box other rows */
+.header-dialog .cf tr {
+    background-color: #d8d8d8;
+    text-align: center;
 }
 
 .header-dialog .modal-dialog {
@@ -159,13 +174,8 @@ input[type="number"]::-webkit-inner-spin-button {
     min-width:954px;
 }
 
-.header-dialog .cf tr {
-    background-color: #DEDEDE;
-}
-
 .header-dialog .cf th {
     border-right: solid 1px silver;
-    height: 19px;
     font-weight: normal;
 }
 
@@ -184,17 +194,22 @@ input[type="number"]::-webkit-inner-spin-button {
     border-top-right-radius: 3px;
 }
 
+/* Box holding text inputs */
 .header-dialog .cf input {
-    margin: 4px;
     width: calc(100% - 10px);
     border: 1px solid silver;
     border-radius: 3px;
+    margin-left:5px;
 }
 
+/* Box holding drop down elements*/
 .header-dialog .cf select {
-    margin: 4px;
     width: calc(100% - 10px);
     border: 1px solid silver;
+    background-color: #FFFFFF;
+    color: black;
+    padding-top: 2px;
+    padding-bottom: 1px;
 }
 
 .header-dialog .parameter th:nth-child(2) {
@@ -214,7 +229,7 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 .header-dialog table {
-    float: left;
+    float: center;
     margin: 0;
     border-collapse: collapse;
     width: calc(100% - 1px);
@@ -226,13 +241,11 @@ input[type="number"]::-webkit-inner-spin-button {
 
 .header-dialog .parameter td+input {
     padding: 1px;
-    background-color:red;
     border-bottom: 0 solid #ccc;
 }
 
 .header-dialog table, .header-dialog table td {
     padding: 1px;
-    border-bottom: 0 solid #ccc;
 }
 
 .header-dialog table th {
@@ -245,7 +258,6 @@ input[type="number"]::-webkit-inner-spin-button {
     padding: 5px;
     text-align: left;
     border-right: 1px solid #ccc;
-    width: calc(100% - 1px);
 }
 
 .header-dialog .pid_titlebar th:first-child {
@@ -256,8 +268,9 @@ input[type="number"]::-webkit-inner-spin-button {
     border-right: none;
 }
 
+/* for labels in PID rows */
 .header-dialog table:not(.parameter) tr td:first-child {
-    text-align: left;
+    text-align: center;
     padding-left: 5px;
 }
 
@@ -270,25 +283,26 @@ input[type="number"]::-webkit-inner-spin-button {
     padding: 1px;
     width: 20%;
     border-right: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
 }
 
 .header-dialog table tr td {
-    text-align: left;
-    padding-left: 0;
+    text-align: center;
+    padding-left: ;
 }
 
+/* numeric inputs in tables */
 .header-dialog table input {
     display: block;
     width: calc(100% - 4px);
-    height: 20px;
-    line-height: 20px;
     text-align: right;
     border: 0 solid #ccc;
     border-radius: 0;
+    background-color: #F5F5F5;
 }
 
 .header-dialog .missing {
-	background:rgba(255,0,0,0.2);
+    background:rgba(255,0,0,0.2);
 }
 
 .header-dialog .static-features span {
@@ -311,8 +325,8 @@ input[type="number"]::-webkit-inner-spin-button {
 
 .header-dialog .controller select {
     width: calc(100% - 10px);
-    height: 20px;
-    line-height: 20px;
+    height: 18px;
+    line-height: 18px;
 }
 
 .header-dialog .profile {
@@ -325,7 +339,7 @@ input[type="number"]::-webkit-inner-spin-button {
 .header-dialog .profile .head {
     display: block;
     text-align: left;
-    line-height: 20px;
+    line-height: 18px;
     border-bottom: 1px solid #ccc;
     background-color: #828885;
     color: white;
@@ -337,8 +351,8 @@ input[type="number"]::-webkit-inner-spin-button {
 .header-dialog .profile select {
     width: 100%;
     padding-left: calc(100% - 35px);
-    height: 20px;
-    line-height: 20px;
+    height: 18px;
+    line-height: 18px;
 }
 
 .header-dialog .pid_tuning .name {
@@ -369,18 +383,18 @@ input[type="number"]::-webkit-inner-spin-button {
     width: 80%;
 }
 
+/* text in parameter boxes*/
 .header-dialog .parameter {
     float: right;
-    width: calc(100% - 2px);
-    margin-top: 10px;
     /* padding-left: 0; */
 }
 
+/*drop-down names display text*/
 html:not(.isCF) .cf-only,
 html:not(.isBF) .bf-only {
     /*display:none;*/
     /*visibility:hidden;*/
-    opacity:0.25;
+    /*opacity:0.25;*/
 }
 /*
 html:not(.isBF28) .bf-only {
@@ -399,9 +413,16 @@ html:not(.isBF28) .bf-only {
 }
 
 .header-dialog .spacer_box {
-    padding-bottom: 10px;
     float: left;
-    width: calc(100% - 5px);
+}
+
+.pid_labels th{
+    text-align: center;
+}
+
+.pid_labels th label{
+    font-weight: normal;
+    font-size: 12px;
 }
 
 .pid_mode {
@@ -414,7 +435,7 @@ html:not(.isBF28) .bf-only {
     padding: 8px 0 0 5px;
     font-size: 12px;
     border-bottom: 1px solid #ccc;
-    color: #828282;
+    color: #202020;
     font-family: 'open_sans', Arial, serif;
     background: #D6D6D6 linear-gradient(315deg, rgba(255, 255, 255, .2) 10%, transparent 10%, transparent 20%,
     rgba(255, 255, 255, .2) 20%, rgba(255, 255, 255, .2) 30%, transparent 30%, transparent 40%,
@@ -429,7 +450,8 @@ html:not(.isBF28) .bf-only {
     background-color: #828885;
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
-    height: 20px;
+    height: 18px;
+    padding: 30px;
 }
 
 .pid_titlebar td:first-child {
@@ -474,6 +496,7 @@ html:not(.isBF28) .bf-only {
     border-bottom: 1px solid #ddd;
     width: 100%;
     float: left;
+
 }
 
 .header-dialog .number:last-child {
@@ -484,13 +507,12 @@ html:not(.isBF28) .bf-only {
 .header-dialog .number input {
     width: 50px;
     padding-left: 3px;
-    height: 20px;
-    line-height: 20px;
     text-align: left;
     border: 1px solid silver;
     border-radius: 3px;
     margin-right: 11px;
     font-weight: normal;
+
 }
 
 .header-dialog .other  table td,
@@ -509,8 +531,6 @@ html:not(.isBF28) .bf-only {
 .header-dialog .static-features label{
     /* width: 70px; */
     /* padding-left: 3px; */
-    height: 20px;
-    line-height: 20px;
     text-align: left;
     border: 0 solid silver;
     border-radius: 3px;
@@ -523,21 +543,21 @@ html:not(.isBF28) .bf-only {
 .header-dialog .features span,
 .header-dialog .static-features span {
     padding-right: 3px;
-    height: 20px;
-    line-height: 20px;
+    height: 18px;
+    line-height: 18px;
     text-align: left;
     border: 0 solid silver;
     border-radius: 3px;
     margin-right: 11px;
     font-weight: normal;
     font-size: 11px;
-}
+    }
 
 .header-dialog .gui_box span {
     font-style: normal;
     font-family: 'open_sansregular', Arial, sans-serif;
     line-height: 19px;
-    color: #7d7d7d;
+    color: #404040;
     font-size: 11px;
 }
 

--- a/css/header_dialog.css
+++ b/css/header_dialog.css
@@ -53,10 +53,16 @@
 
 /* Default Parameter Entry Field */
 input[type="number"]::-webkit-inner-spin-button {
-    opacity: 1; /* required for chromium 33+ beta */
-    margin-left: 5px;
-    margin-right: 5px;
+    opacity: 0; /* 1 is required for chromium 33+ beta  to show the arrows / spinners */
+/*    margin-left: 5px;*/
 }
+
+/* Hide select dropdown arrow 
+select {
+    appearance: none;
+    padding-left: 5px;
+}
+*/
 
 .clear-both {
     clear: both;
@@ -159,8 +165,7 @@ input[type="number"]::-webkit-inner-spin-button {
     font-weight: normal;
     font-size: 13px;
     color: #505050;
-    text-align: center;
-    width:100%;
+                                text-align: center;
 }
 
 /* Parameter box other rows */
@@ -194,22 +199,26 @@ input[type="number"]::-webkit-inner-spin-button {
     border-top-right-radius: 3px;
 }
 
-/* Box holding text inputs */
+/* Box holding numeric inputs */
 .header-dialog .cf input {
     width: calc(100% - 10px);
     border: 1px solid silver;
     border-radius: 3px;
-    margin-left:5px;
+    margin-left: 2px;
+    text-align: center;
 }
 
-/* Box holding drop down elements*/
+/* Box holding text down elements */
 .header-dialog .cf select {
+    appearance: none; /* hide arrow at right*/
     width: calc(100% - 10px);
     border: 1px solid silver;
     background-color: #FFFFFF;
     color: black;
-    padding-top: 2px;
-    padding-bottom: 1px;
+    padding-top: 1px;
+    padding-left: 2px;
+    text-align: center;
+    text-align-last: center;
 }
 
 .header-dialog .parameter th:nth-child(2) {
@@ -295,7 +304,7 @@ input[type="number"]::-webkit-inner-spin-button {
 .header-dialog table input {
     display: block;
     width: calc(100% - 4px);
-    text-align: right;
+    text-align: center;
     border: 0 solid #ccc;
     border-radius: 0;
     background-color: #F5F5F5;
@@ -496,7 +505,6 @@ html:not(.isBF28) .bf-only {
     border-bottom: 1px solid #ddd;
     width: 100%;
     float: left;
-
 }
 
 .header-dialog .number:last-child {
@@ -507,12 +515,11 @@ html:not(.isBF28) .bf-only {
 .header-dialog .number input {
     width: 50px;
     padding-left: 3px;
-    text-align: left;
+    text-align: center;
     border: 1px solid silver;
     border-radius: 3px;
     margin-right: 11px;
     font-weight: normal;
-
 }
 
 .header-dialog .other  table td,
@@ -551,7 +558,7 @@ html:not(.isBF28) .bf-only {
     margin-right: 11px;
     font-weight: normal;
     font-size: 11px;
-    }
+}
 
 .header-dialog .gui_box span {
     font-style: normal;
@@ -562,7 +569,7 @@ html:not(.isBF28) .bf-only {
 }
 
 .noline {
-	border:0;
+    border:0;
 }
 
 .header-dialog .resetbt {

--- a/index.html
+++ b/index.html
@@ -885,7 +885,7 @@
                                     <table id="d_min" class="parameter cf">
                                         <thead>
                                             <tr>
-                                                <th colspan="5">D Min</th>
+                                                <th colspan="2">D Min</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -917,7 +917,7 @@
                                     <table class="parameter cf">
                                         <thead>
                                             <tr>
-                                                <th scope="row" colspan="6">Feedforward</th>
+                                                <th scope="row" colspan="2">Feedforward</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -963,39 +963,31 @@
                                             <tr>
                                                 <td name="ptermSRateWeight" class="bf-only">
                                                     <label>P-Term
-                                                        <br>&nbsp;
-                                                        <br/>&nbsp;</label>
+                                                        <br>&nbsp;</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
                                                 </td>
                                                 <td name="abs_control_gain" class="bf-only">
-                                                    <label>
-                                                        Absolute
-                                                        <br/>Control
-                                                        <br/>Gain
-                                                    </label>
+                                                    <label>Absolute Control
+                                                    <br/>&nbsp;</label>
                                                     <input type="number" step="1" min="0" max="999" />
                                                 </td>
                                                 <td name="setpointRelaxRatio" class="bf-only">
                                                     <label>Setpoint Relax
-                                                        <br>Ratio
-                                                        <br/>&nbsp;</label>
+                                                        <br>Ratio</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
                                                 </td>
                                                 <td name="dtermSetpointWeight" class="bf-only">
-                                                    <label>D-Term Setpoint
-                                                        <br>Weight
-                                                        <br/>&nbsp;</label>
+                                                    <label>D Setpoint
+                                                        <br>Weight</label>
                                                     <input type="number" step="0.01" min="0" max="999" />
                                                 </td>
                                                 <td name="rateAccelLimit" class="bf-only">
-                                                    <label>Roll/Pitch Rate
-                                                        <br>Acceleration
+                                                    <label>R/P Accel
                                                         <br>Limit</label>
                                                     <input type="number" step="1" min="0" max="999" />
                                                 </td>
                                                 <td name="yawRateAccelLimit" class="bf-only">
-                                                    <label>Yaw Rate
-                                                        <br>Acceleration
+                                                    <label>Yaw Accel
                                                         <br>Limit</label>
                                                     <input type="number" step="1" min="0" max="999" />
                                                 </td>
@@ -1139,10 +1131,10 @@
                                                     </label>
                                                 </td>
                                                 <td>
-                                                    <label>PID controller active at min-throttle</label>
+                                                    <label>PIDs active at min-throttle</label>
                                                 </td>
                                                 <td>
-                                                    <span>Stabilisation at zero throttle</span>
+                                                    <span>Zero throttle stability</span>
                                                 </td>
                                             </tr>
                                             <tr>
@@ -1155,10 +1147,10 @@
                                                     </label>
                                                 </td>
                                                 <td>
-                                                    <label>Use integrated yaw</label>
+                                                    <label>Integrated yaw</label>
                                                 </td>
                                                 <td>
-                                                    <span>Changes the yaw PID behaviour</span>
+                                                    <span>Adds roll to yaw</span>
                                                 </td>
                                             </tr>
 
@@ -1173,11 +1165,6 @@
                                 <div class="spacer_box">
 
                                     <table class="parameter cf">
-                                        <thead>
-                                               <tr>
-                                                   <th colspan="4">Gyro Hardware Lowpass Filters</th>
-                                               </tr>
-                                           </thead>
                                         <tbody>
                                             <tr>
                                                 <td name='gyro_hardware_lpf' colspan="2">
@@ -1199,69 +1186,92 @@
                                     <table class="parameter cf">
                                         <thead>
                                             <tr>
-                                                <th colspan="4">Gyro Software Filters</th>
+                                                <th colspan="5">Gyro Software Filters</th>
                                             </tr>
                                         </thead>
                                         <tbody>
+
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">Lowpass filters</th>
+                                               </tr>
+                                           </thead>
+
                                             <tr>
-                                                <td name='gyro_soft_dyn_type' colspan="2">
-                                                    <label>Lowpass Dyn Filter<br>Type 1</label>
+                                                <td name='gyro_soft_dyn_type'>
+                                                    <label>Dyn 1<br>Type</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
-                                            </tr>
 
-                                            <tr>
                                                 <td name="gyro_soft_dyn_min_hz">
-                                                    <label>Lowpass Dyn Filter<br>Min Cutoff 1 (Hz)</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="gyro_soft_dyn_max_hz">
-                                                    <label>Lowpass Dyn Filter<br>Max Cutoff 1 (Hz)</label>
+                                                    <label>Dyn 1 Min<br>
+                                                        Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
 
-                                                <td name='gyro_soft_type'>
-                                                    <label>Lowpass Filter<br>Type 1</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="gyro_lowpass_hz">
-                                                    <label>Lowpass Filter<br>Cutoff 1 (Hz)</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name='gyro_soft2_type'>
-                                                    <label>Lowpass Filter<br>Type 2</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="gyro_lowpass2_hz">
-                                                    <label>Lowpass Filter<br>Cutoff 2 (Hz)</label>
+                                                <td name="gyro_soft_dyn_max_hz">
+                                                    <label>Dyn 1 Max
+                                                        <br>Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
+
                                             <tr>
+                                                <td name='gyro_soft_type'>
+                                                    <label>Static 1
+                                                        <br>Filter type</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+
+                                                <td name="gyro_lowpass_hz">
+                                                    <label>Static 1
+                                                        <br>Cutoff 1 Hz</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+
+                                                <td name='gyro_soft2_type'>
+                                                    <label>Static 2
+                                                        <br> Filter type</label>
+                                                    <select>
+                                                        <!-- list generated here -->
+                                                    </select>
+                                                </td>
+
+                                                <td name="gyro_lowpass2_hz">
+                                                    <label>Static 2
+                                                        <br>Cutoff Hz</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">Static notch filters</th>
+                                               </tr>
+                                           </thead>
                                                 <td name='gyro_notch_hz'>
                                                     <label>Notch 1
-                                                        <br>(Hz)</label>
+                                                        <br>Center Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="gyro_notch_cutoff">
-                                                    <label>Notch
-                                                        <br>Cutoff 1 (Hz)</label>
+                                                    <label>Notch 1 
+                                                        <br>Cutoff Hz</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                                 <td name='gyro_notch_hz_2'>
                                                     <label>Notch 2
-                                                        <br>(Hz)</label>
+                                                        <br>Center Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="gyro_notch_cutoff_2">
-                                                    <label>Notch
-                                                        <br>Cutoff 2 (Hz)</label>
+                                                    <label>Notch 2
+                                                        <br>Cutoff Hz</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
@@ -1269,7 +1279,7 @@
                                             <tr class="dyn_filter_required">
                                             <thead>
                                                <tr>
-                                                <th scope="row" colspan="4">Dynamic notch filters</th>
+                                                <th scope="row" colspan="2">Dynamic notch filters</th>
                                                </tr>
                                            </thead>
                                                 <td name='dynNotchCount'>
@@ -1291,24 +1301,29 @@
                                             </tr>
 
                                             <tr class='dshot_bidir_required'>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">RPM filters</th>
+                                               </tr>
+                                           </thead>
                                                 <td name='gyro_rpm_notch_harmonics'>
-                                                    <label>RPM Notch
-                                                           <br>Harmonics</label>
+                                                    <label>Harmonics</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="gyro_rpm_notch_q">
-                                                    <label>RPM Notch
-                                                        <br>Q</label>
+                                                    <label>Q</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                                 <td name='gyro_rpm_notch_min'>
-                                                    <label>RPM Notch
-                                                        <br>Min(Hz)</label>
+                                                    <label>Min(Hz)</label>
+                                                    <input type="number" step="0.01" min="0" max="999.00" />
+                                                </td>
+                                                <td name='rpm_filter_fade_range_hz'>
+                                                    <label>FadeRng</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name='rpm_notch_lpf'>
-                                                    <label>RPM Notch
-                                                        <br>Lpf</label>
+                                                    <label>Lpf</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
@@ -1318,52 +1333,55 @@
                                     <table class="parameter cf">
                                         <thead>
                                             <tr>
-                                                <th colspan="4">D-Term Filters</th>
+                                                <th colspan="5">D-Term Filters</th>
                                             </tr>
                                         </thead>
                                         <tbody>
 
                                             <tr>
-                                                <td name='dterm_dyn_type' colspan="2">
-                                                    <label>Lowpass Dyn Filter<br>Type 1</label>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">Lowpass filters</th>
+                                               </tr>
+                                           </thead>
+
+                                                <td name='dterm_dyn_type'>
+                                                    <label>Dyn 1<br>Type</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
-                                            </tr>
-
-                                            <tr>
                                                 <td name="dterm_lpf_dyn_min_hz">
-                                                    <label>Lowpass Dyn Filter<br>Min Cutoff 1 (Hz)</label>
+                                                    <label>Dyn 1 Min<br>Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="dterm_lpf_dyn_max_hz">
-                                                    <label>Lowpass Dyn Filter<br>Max Cutoff 1 (Hz)</label>
+                                                    <label>Dyn 1 Max<br>Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
 
                                                 <td name='dterm_filter_type'>
-                                                    <label>Lowpass Filter
-                                                        <br>Type 1</label>
+                                                    <label>Static 1
+                                                        <br>Type</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
                                                 <td name="dterm_lpf_hz">
-                                                    <label>Lowpass Filter
-                                                        <br>Cutoff 1 (Hz)</label>
+                                                    <label>Static 1
+                                                        <br>Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name='dterm_filter2_type'>
-                                                    <label>Lowpass Filter
-                                                        <br>Type 2</label>
+                                                    <label>Static 2
+                                                        <br>Type</label>
                                                     <select>
                                                         <!-- list generated here -->
                                                     </select>
                                                 </td>
                                                 <td name="dterm_lpf2_hz">
-                                                    <label>Lowpass Filter
-                                                        <br>Cutoff 2 (Hz)</label>
+                                                    <label>Static 2
+                                                        <br>Cutoff Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="dterm_average_count" class="bf-only">
@@ -1371,33 +1389,41 @@
                                                     <input type="number" step="1" min="0" max="12" />
                                                 </td>
                                             </tr>
+
                                             <tr>
-                                                <td name='dterm_notch_hz' colspan="2">
-                                                    <label>Notch
-                                                        <br>(Hz)</label>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">Static notch filter</th>
+                                               </tr>
+                                           </thead>
+
+                                                <td name="dterm_notch_hz">
+                                                    <label>Center Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
-                                                <td name="dterm_notch_cutoff" colspan="2">
-                                                    <label>Notch Cutoff
-                                                        <br>(Hz)</label>
+                                                <td name="dterm_notch_cutoff">
+                                                    <label>Cutoff Hz</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                             </tr>
 
                                             <tr class='dshot_bidir_required'>
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="2">D_Term RPM filters</th>
+                                               </tr>
+                                           </thead>
+
                                                 <td name='dterm_rpm_notch_harmonics'>
-                                                    <label>RPM Notch
-                                                           <br>Harmonics</label>
+                                                    <label>Harmonics</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                                 <td name="dterm_rpm_notch_q">
-                                                    <label>RPM Notch
-                                                        <br>Q</label>
+                                                    <label>Q</label>
                                                     <input type="number" step="0.1" min="0" max="999.00" />
                                                 </td>
                                                 <td name='dterm_rpm_notch_min'>
-                                                    <label>RPM Notch
-                                                        <br>Min(Hz)</label>
+                                                    <label>Min Hz</label>
                                                     <input type="number" step="0.01" min="0" max="999.00" />
                                                 </td>
                                             </tr>
@@ -1407,7 +1433,7 @@
                                     <table class="parameter cf">
                                         <thead>
                                             <tr>
-                                                <th colspan="4">Other Filters</th>
+                                                <th colspan="1">Other Filters</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -1602,7 +1628,7 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <th colspan="3">ROLL</th>
+                                                    <th colspan="1">Roll rates</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="rcRollRate" class="no-inav">
@@ -1619,7 +1645,7 @@
                                                     </td>
                                                 </tr>
                                                 <tr>
-                                                    <th colspan="3">PITCH</th>
+                                                    <th colspan="1">Pitch rates</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="rcPitchRate" class="no-inav">
@@ -1636,7 +1662,7 @@
                                                     </td>
                                                 </tr>
                                                 <tr>
-                                                    <th colspan="3">YAW</th>
+                                                    <th colspan="1">Yaw rates</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="rcYawRate" class="no-inav">
@@ -1678,7 +1704,7 @@
                                         <table id="rate_limits" class="parameter cf">
                                             <body>
                                                 <tr>
-                                                    <th colspan="5">Rate Limits</th>
+                                                    <th colspan="1">Rate Limits</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="rate_limits_roll">
@@ -1701,7 +1727,7 @@
 
                                             <body>
                                                 <tr>
-                                                    <th colspan="5">Deadband</th>
+                                                    <th colspan="1">Deadband</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="deadband">
@@ -1719,7 +1745,7 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <th colspan="5">RC Smoothing</th>
+                                                    <th colspan="3">RC SMOOTHING</th>
                                                 </tr>
                                                 <tr>
                                                     <td name='rcSmoothingMode'>
@@ -1749,30 +1775,36 @@
                                                         <input type="number" step="1" min="0" max="250" />
                                                     </td>
                                                 </tr>
+                                                    <tr>
+                                                        <th scope="row" colspan="1">Manual Cutoffs</th>
+                                                    </tr>
                                                 <tr>
                                                     <td name="rcSmoothingSetpointHz">
-                                                        <label>Setpoint cutoff Hz</label>
+                                                        <label>Setpoint Hz</label>
                                                         <input type="number" step="1" min="0" max="255" />
                                                     </td>
                                                     <td name="rcSmoothingFeedforwardHz">
-                                                        <label>Feedforward cutoff Hz</label>
+                                                        <label>Feedforward Hz</label>
                                                         <input type="number" step="1" min="0" max="255" />
                                                     </td>
                                                     <td name="rcSmoothingThrottleHz">
-                                                        <label>Throttle cutoff Hz</label>
+                                                        <label>Throttle Hz</label>
                                                         <input type="number" step="1" min="0" max="255" />
                                                 </tr>
+                                                    <tr>
+                                                        <th scope="row" colspan="1">Active Values</th>
+                                                    </tr>
                                                 <tr>
                                                     <td name='rcSmoothingActiveCutoffsSp'>
-                                                        <label>Active Cutoff Setpoint</label>
+                                                        <label>Setpoint</label>
                                                         <input type="number" step="1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingActiveCutoffsFf'>
-                                                        <label>Active Cutoff FF</label>
+                                                        <label>Feedforward</label>
                                                         <input type="number" step="1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingActiveCutoffsThr'>
-                                                        <label>Active Cutoff Throttle</label>
+                                                        <label>Throttle</label>
                                                         <input type="number" step="1" min="0"/>
                                                     </td>
                                                 </tr>
@@ -1801,7 +1833,7 @@
                                         <table class="parameter cf">
                                             <thead>
                                                 <tr>
-                                                    <th colspan="5">Motors</th>
+                                                    <th colspan="3">MOTORS</th>
                                                 </tr>
                                             </thead>
                                             <tbody>

--- a/index.html
+++ b/index.html
@@ -917,7 +917,7 @@
                                                         <label>D gain</label>
                                                         <input type="text" step="1" min="0" max="200" />
                                                     </td>
-                                                    <td name="simplified_dmin_ratio" class="bf-only">
+                                                    <td name="simplified_dmax_gain" class="bf-only">
                                                         <label>Dmax</label>
                                                         <input type="text" step="1" min="0" max="200" />
                                                     </td>
@@ -930,7 +930,7 @@
                                                         <label>FF gain</label>
                                                         <input type="text" step="1" min="0" max="200" />
                                                     </td>
-                                                    <td name="simplified_roll_pitch_ratio" class="bf-only">
+                                                    <td name="simplified_pitch_d_gain" class="bf-only">
                                                         <label>Pitch:Roll</label>
                                                         <input type="text" step="1" min="0" max="200" />
                                                     </td>

--- a/index.html
+++ b/index.html
@@ -706,48 +706,48 @@
                                                 <!-- 0 -->
                                                 <td>Roll</td>
                                                 <td>
-                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                    <input type="text" name="p" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                    <input type="text" name="i" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                    <input type="text" name="f" step="1" min="0" max="255" />
                                                 </td>
                                             </tr>
                                             <tr class="pitchPID">
                                                 <!-- 1 -->
                                                 <td>Pitch</td>
                                                 <td>
-                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                    <input type="text" name="p" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                    <input type="text" name="i" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                    <input type="text" name="f" step="1" min="0" max="255" />
                                                 </td>
                                             </tr>
                                             <tr class="yawPID">
                                                 <!-- 2 -->
                                                 <td>Yaw</td>
                                                 <td>
-                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                    <input type="text" name="p" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                    <input type="text" name="i" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                    <input type="text" name="f" step="1" min="0" max="255" />
                                                 </td>
                                             </tr>
                                         </table>
@@ -764,13 +764,13 @@
                                                 <!-- 3 -->
                                                 <td>ALT</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
+                                                    <input type="text" name="i" step="0.001" min="0" max="0.255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td></td>
                                             </tr>
@@ -778,13 +778,13 @@
                                                 <!-- 9 -->
                                                 <td>VEL</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
+                                                    <input type="text" name="i" step="0.001" min="0" max="0.255" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td></td>
                                             </tr>
@@ -802,7 +802,7 @@
                                                 <!-- 8 -->
                                                 <td>MAG</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
                                                 </td>
                                                 <td></td>
                                                 <td></td>
@@ -822,10 +822,10 @@
                                                 <!-- 4 -->
                                                 <td>POS</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.01" min="0" max="2.55" />
+                                                    <input type="text" name="p" step="0.01" min="0" max="2.55" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                    <input type="text" name="i" step="0.01" min="0" max="2.55" />
                                                 </td>
                                                 <td></td>
                                                 <td></td>
@@ -834,13 +834,13 @@
                                                 <!-- 5 -->
                                                 <td>POSR</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                    <input type="text" name="i" step="0.01" min="0" max="2.55" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="0.001" min="0" max="0.255" />
+                                                    <input type="text" name="d" step="0.001" min="0" max="0.255" />
                                                 </td>
                                                 <td></td>
                                             </tr>
@@ -848,13 +848,13 @@
                                                 <!-- 6 -->
                                                 <td>NAVR</td>
                                                 <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                    <input type="text" name="i" step="0.01" min="0" max="2.55" />
                                                 </td>
                                                 <td>
-                                                    <input type="number" name="d" step="0.001" min="0" max="0.255" />
+                                                    <input type="text" name="d" step="0.001" min="0" max="0.255" />
                                                 </td>
                                                 <td></td>
                                             </tr>
@@ -870,51 +870,105 @@
                                                 <tr>
                                                     <td name="d_min_roll" class="bf-only">
                                                         <label>Roll</label>
-                                                        <input type="number" step="1" min="0" max="100" />
+                                                        <input type="text" step="1" min="0" max="100" />
                                                     </td>
                                                     <td name="d_min_pitch" class="bf-only">
                                                         <label>Pitch</label>
-                                                        <input type="number" step="1" min="0" max="100" />
+                                                        <input type="text" step="1" min="0" max="100" />
                                                     </td>
                                                     <td name="d_min_yaw" class="bf-only">
                                                         <label>Yaw</label>
-                                                        <input type="number" step="1" min="0" max="100" />
+                                                        <input type="text" step="1" min="0" max="100" />
                                                     </td>
                                                     <td name="d_min_gain" class="bf-only">
                                                         <label>Gain</label>
-                                                        <input type="number" step="1" min="0" max="100" />
+                                                        <input type="text" step="1" min="0" max="100" />
                                                     </td>
                                                     <td name="d_min_advance" class="bf-only">
                                                         <label>Advance</label>
-                                                        <input type="number" step="1" min="0" max="200" />
+                                                        <input type="text" step="1" min="0" max="200" />
                                                     </td>
                                                 </tr>
                                             </tbody>
                                         </table>
 
-                                            <table class="parameter cf">
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th colspan="5">PID Sliders</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="simplified_pids_mode" class="bf-only">
+                                                        <label>Status</label>                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="simplified_pi_gain" class="bf-only">
+                                                        <label>PI gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_i_gain" class="bf-only">
+                                                        <label>I gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_d_gain" class="bf-only">
+                                                        <label>D gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_dmin_ratio" class="bf-only">
+                                                        <label>Dmax</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name = blankSimplPIDs>
+                                                        <label>&nbsp&nbsp&nbsp</label>
+                                                    </td>
+                                                    <td name="simplified_feedforward_gain" class="bf-only">
+                                                        <label>FF gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_roll_pitch_ratio" class="bf-only">
+                                                        <label>Pitch:Roll</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_pitch_pi_gain" class="bf-only">
+                                                        <label>Pitch Gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                    <td name="simplified_master_multiplier" class="bf-only">
+                                                        <label>Master Gain</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                </tr>
+                                             </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
                                             <thead>
                                                 <tr>
                                                     <th colspan="5">TPA and Airmode</th>
                                                 </tr>
                                             </thead>
-                                                <tbody>
-                                                    <tr>
-                                                        <td name="dynThrPID">
-                                                            <label>TPA amount</label>
-                                                            <input type="number" step="0.01" min="0" max="1.00" />
-                                                        </td>
-                                                        <td name="tpa-breakpoint">
-                                                            <label>TPA Breakpoint</label>
-                                                            <input type="number" step="10" min="1000" max="2000" />
-                                                        </td>
-                                                        <td name="airmode_activate_throttle" class="bf-only">
-                                                            <label>Airmode Activate</label>
-                                                            <input type="number" step="10" min="1000" max="2000" />
-                                                        </td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="dynThrPID">
+                                                        <label>TPA amount</label>
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="tpa-breakpoint">
+                                                        <label>TPA Breakpoint</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
+                                                    </td>
+                                                    <td name="airmode_activate_throttle" class="bf-only">
+                                                        <label>Airmode Activate</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
 
                                         <table class="parameter cf">
                                             <thead>
@@ -926,7 +980,7 @@
                                                 <tr>
                                                     <td name="feedforwardTransition" class="bf-only">
                                                         <label>Transition</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                        <input type="text" step="0.01" min="0" max="999" />
                                                     </td>
                                                     <td name="feedforwardAveraging" class="bf-only">
                                                         <label>Averaging</label>
@@ -936,19 +990,19 @@
                                                     </td>
                                                     <td name="feedforwardSmoothing" class="bf-only">
                                                         <label>Smoothing</label>
-                                                        <input type="number" step="0" min="0" max="100" />
+                                                        <input type="text" step="0" min="0" max="100" />
                                                     </td>
                                                     <td name="feedforwardJitter" class="bf-only">
                                                         <label>Jitter</label>
-                                                        <input type="number" step="0" min="0" max="100" />
+                                                        <input type="text" step="0" min="0" max="100" />
                                                     </td>
                                                     <td name="feedforwardBoost" class="bf-only">
                                                         <label>Boost</label>
-                                                        <input type="number" step="0" min="0" max="100" />
+                                                        <input type="text" step="0" min="0" max="100" />
                                                     </td>
                                                     <td name="feedforwardMaxRate" class="bf-only">
                                                         <label>MaxRate</label>
-                                                        <input type="number" step="0" min="0" max="100" />
+                                                        <input type="text" step="0" min="0" max="100" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -970,15 +1024,15 @@
                                                     </td>
                                                     <td name="antiGravityGain" class="bf-only">
                                                         <label>Gain</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                        <input type="text" step="0.01" min="0" max="999" />
                                                     </td>
                                                     <td name="antiGravityThreshold" class="bf-only">
                                                         <label>AG Threshold</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                        <input type="text" step="0.01" min="0" max="999" />
                                                     </td>
                                                     <td name="itermWindupPointPercent" class="bf-only">
                                                         <label>Windup Threshold</label>
-                                                        <input type="number" step="1" min="0" max="999" />
+                                                        <input type="text" step="1" min="0" max="999" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -993,7 +1047,7 @@
                                             <tbody>
                                                 <tr>
                                                     <td name="iterm_relax" class="bf-only">
-                                                        <label>On/Off</label>
+                                                        <label>Mode</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
@@ -1006,200 +1060,7 @@
                                                     </td>
                                                     <td name="iterm_relax_cutoff" class="bf-only">
                                                         <label>Cutoff</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table id="pid_accel_header" class="parameter cf">
-                                            <thead>
-                                                <tr>
-                                                    <th>Angle / Horizon settings</th>
-                                                </tr>
-                                            </thead>
-                                        </table>
-                                        <table id="pid_accel" class="pid_tuning">
-                                             <tr class = "pid_labels">
-                                                <th name="Blank">
-                                                    <label>&nbsp</label>
-                                                </th>
-                                                <th name="angle_strength">
-                                                    <label>Angle strength</label>
-                                                </th>
-                                                <th name="horizon_strength">
-                                                    <label>Horizon strength</label>
-                                                </th>
-                                                <th name="horizon_transition">
-                                                    <label>Horizon transition</label>
-                                                </th>
-                                            </tr>
-                                            <tr class="levelPID">
-                                                <!-- 7 -->
-                                                <td>LEVEL</td>
-                                                <td>
-                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                                </td>
-                                                <td>
-                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
-                                                </td>
-                                                <td>
-                                                    <input type="number" name="d" step="1" min="0" max="255" />
-                                                </td>
-                                            </tr>
-                                        </table>
-
-                                        <table class="parameter cf">
-                                            <thead>
-                                                <tr>
-                                                    <th scope="row" colspan="6">Misc</th>
-                                                </tr>
-                                            </thead>
-
-                                            <tbody>
-                                                <tr>
-                                                    <td name="pidSumLimit" class="bf-only">
-                                                        <label>PIDSum Limit</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                    <td name="pidSumLimitYaw" class="bf-only">
-                                                        <label>PIDSum Limit Yaw</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="ptermSRateWeight" class="bf-only">
-                                                        <label>P-Term
-                                                            <br>&nbsp;</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                    <td name="abs_control_gain" class="bf-only">
-                                                        <label>Absolute 
-                                                        <br/>Control</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="setpointRelaxRatio" class="bf-only">
-                                                        <label>Setpoint Relax
-                                                            <br>Ratio</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                    <td name="dtermSetpointWeight" class="bf-only">
-                                                        <label>D Setpoint
-                                                            <br>Weight</label>
-                                                        <input type="number" step="0.01" min="0" max="999" />
-                                                    </td>
-                                                    <td name="rateAccelLimit" class="bf-only">
-                                                        <label>R/P Accel
-                                                            <br>Limit</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="yawRateAccelLimit" class="bf-only">
-                                                        <label>Yaw Accel
-                                                            <br>Limit</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="no-inav parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name='dynamic_pid' class="bf-only">
-                                                        <label>Dynamic PID</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="parameter cf">
-                                            <thead class="BFPIDController">
-                                                <tr>
-                                                    <th colspan="2">P-Term</th>
-                                                    <th class="bf-only" colspan="2">I-Term</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody class="BFPIDController">
-                                                <tr>
-                                                    <td name='dynamic_pterm' class="bf-only">
-                                                        <label>Dynamic P</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                    <td name="yaw_p_limit">
-                                                        <label>Yaw Limit</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="rollPitchItermResetRate" class="bf-only">
-                                                        <label>Roll/Pitch Reset</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="rollPitchItermIgnoreRate" class="bf-only">
-                                                        <label>Roll/Pitch Ignore Rate</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="yawItermResetRate" class="bf-only">
-                                                        <label>Yaw Reset</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                    <td name="yawItermIgnoreRate" class="bf-only">
-                                                        <label>Yaw Ignore Rate</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                            <tbody class="BFPIDController">
-                                                <tr>
-                                                    <td></td>
-                                                    <td name="iterm_reset_offset" class="bf-only">
-                                                        <label>Reset Offset</label>
-                                                        <input type="number" step="1" min="0" max="999" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="bf-only" cellpadding="0" cellspacing="0">
-                                            <tbody class="static-features noline">
-                                                <tr>
-                                                    <td name="pidAtMinThrottle">
-                                                        <label class="option">
-                                                            <input class="ios-switch" type="checkbox" />
-                                                            <div>
-                                                                <div></div>
-                                                            </div>
-                                                        </label>
-                                                    </td>
-                                                    <td>
-                                                        <label>PIDs at min-throttle</label>
-                                                    </td>
-                                                    <td>
-                                                        <span>Zero throttle stability</span>
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td name="use_integrated_yaw">
-                                                        <label class="option">
-                                                            <input class="ios-switch" type="checkbox" />
-                                                            <div>
-                                                                <div></div>
-                                                            </div>
-                                                        </label>
-                                                    </td>
-                                                    <td>
-                                                        <label>Integrated yaw</label>
-                                                    </td>
-                                                    <td>
-                                                        <span>Adds roll to yaw</span>
+                                                        <input type="text" step="0.01" min="0" max="999" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1256,13 +1117,13 @@
                                                         <label>Roll</label>
                                                     </td>
                                                     <td name="rcRollRate" class="no-inav">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="rates[0]">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="rcRollExpo">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                 </tr>
                                                 <tr>
@@ -1270,13 +1131,13 @@
                                                         <label>Pitch</label>
                                                     </td>
                                                     <td name="rcPitchRate" class="no-inav">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="rates[1]">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="rcPitchExpo">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                 </tr>
                                                 <tr>
@@ -1284,13 +1145,13 @@
                                                         <label>Yaw</label>
                                                     </td>
                                                     <td name="rcYawRate" class="no-inav">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="rates[2]">
-                                                        <input type="number" step="0.01" min="0" max="2.55" />
+                                                        <input type="text" step="0.01" min="0" max="2.55" />
                                                     </td>
                                                     <td name="rcYawExpo">
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1301,11 +1162,11 @@
                                                 <tr>
                                                     <td name="superExpoFactor" class="bf-only">
                                                         <label>RP SuperExpo</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="superExpoFactorYaw" class="bf-only">
                                                         <label>YAW SuperExpo</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name='superExpoYawMode' class="bf-only">
                                                         <label>YAW SE Mode</label>
@@ -1325,15 +1186,15 @@
                                                 <tr>
                                                     <td name="rate_limits_roll">
                                                         <label>Roll</label>
-                                                        <input type="number" step="1" min="0" />
+                                                        <input type="text" step="1" min="0" />
                                                     </td>
                                                     <td name="rate_limits_pitch">
                                                         <label>Pitch</label>
-                                                        <input type="number" step="1" min="0" />
+                                                        <input type="text" step="1" min="0" />
                                                     </td>
                                                     <td name="rate_limits_yaw">
                                                         <label>Yaw</label>
-                                                        <input type="number" step="1" min="0" />
+                                                        <input type="text" step="1" min="0" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1347,11 +1208,184 @@
                                                 <tr>
                                                     <td name="deadband">
                                                         <label>Pitch/Roll</label>
-                                                        <input type="number" step="1" min="0" max="32" />
+                                                        <input type="text" step="1" min="0" max="32" />
                                                     </td>
                                                     <td name="yaw_deadband">
                                                         <label>Yaw</label>
-                                                        <input type="number" step="1" min="0" max="100" />
+                                                        <input type="text" step="1" min="0" max="100" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+
+                                <div class="gui_box grey debug">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">MISCELLANEOUS</div>
+                                    </div>
+                                    <div class="spacer_box">
+                                        <table class="parameter cf">
+                                            <tbody">
+                                                <tr>
+                                                    <td name='pidAtMinThrottle'>
+                                                        <label>PID at MinThrottle</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    </td>
+                                                    <td name="abs_control_gain">
+                                                        <label>Absolute Control</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+
+                                                    <td name='use_integrated_yaw'>
+                                                        <label>Integrated Yaw</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table id="pid_accel_header" class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th>Angle / Horizon settings</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                        <table id="pid_accel" class="pid_tuning">
+                                             <tr class = "pid_labels">
+                                                <th name="Blank">
+                                                    <label>&nbsp</label>
+                                                </th>
+                                                <th name="angle_strength">
+                                                    <label>Angle strength</label>
+                                                </th>
+                                                <th name="horizon_strength">
+                                                    <label>Horizon strength</label>
+                                                </th>
+                                                <th name="horizon_transition">
+                                                    <label>Horizon transition</label>
+                                                </th>
+                                            </tr>
+                                            <tr class="levelPID">
+                                                <!-- 7 -->
+                                                <td>LEVEL</td>
+                                                <td>
+                                                    <input type="text" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="text" name="i" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td>
+                                                    <input type="text" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                            </tr>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="4">Limits</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="pidSumLimit" class="bf-only">
+                                                        <label>PIDSum</label>
+                                                        <input type="text" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="pidSumLimitYaw" class="bf-only">
+                                                        <label>PIDSum Yaw</label>
+                                                        <input type="text" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="rateAccelLimit" class="bf-only">
+                                                        <label>R/P Accel</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawRateAccelLimit" class="bf-only">
+                                                        <label>Yaw Accel</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                 </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Deprecated</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="ptermSRateWeight" class="bf-only">
+                                                        <label>P-Term
+                                                            <br>&nbsp;</label>
+                                                        <input type="text" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="setpointRelaxRatio" class="bf-only">
+                                                        <label>Setpoint Relax
+                                                            <br>Ratio</label>
+                                                        <input type="text" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="dtermSetpointWeight" class="bf-only">
+                                                        <label>D Setpoint
+                                                            <br>Weight</label>
+                                                        <input type="text" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name='dynamic_pid' class="bf-only">
+                                                        <label>Dyn PID</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead class="BFPIDController">
+                                                <tr>
+                                                    <th colspan="2">P-Term</th>
+                                                    <th class="bf-only" colspan="2">I-Term</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="BFPIDController">
+                                                <tr>
+                                                    <td name='dynamic_pterm' class="bf-only">
+                                                        <label>Dynamic P</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="rollPitchItermResetRate" class="bf-only">
+                                                        <label>Roll/Pitch Reset</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="rollPitchItermIgnoreRate" class="bf-only">
+                                                        <label>Roll/Pitch Ignore Rate</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawItermResetRate" class="bf-only">
+                                                        <label>Yaw Reset</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawItermIgnoreRate" class="bf-only">
+                                                        <label>Yaw Ignore Rate</label>
+                                                        <input type="text" step="1" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td></td>
+                                                    <td name="iterm_reset_offset" class="bf-only">
+                                                        <label>Reset Offset</label>
+                                                        <input type="text" step="1" min="0" max="999" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1365,6 +1399,18 @@
                                     </div>
                                     <div class="spacer_box">
 
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name='serialrx_provider'>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
                                         <table cellpadding="0" cellspacing="0">
                                             <thead class="rxMode noline">
                                                 <tr>
@@ -1375,18 +1421,6 @@
                                             </thead>
                                             <tbody class="features rxMode noline">
                                                 <!-- table generated here -->
-                                            </tbody>
-                                        </table>
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name='serialrx_provider'>
-                                                        <label>Provider</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                </tr>
                                             </tbody>
                                         </table>
                                     </div>
@@ -1403,15 +1437,15 @@
                                                 <tr>
                                                     <td name="loopTime">
                                                         <label>Looptime</label>
-                                                        <input type="number" step="25" min="0" max="3000" />
+                                                        <input type="text" step="25" min="0" max="3000" />
                                                     </td>
                                                     <td name="gyro_sync_denom">
                                                         <label>Gyro Sync</label>
-                                                        <input type="number" step="1" min="0" max="8" />
+                                                        <input type="text" step="1" min="0" max="8" />
                                                     </td>
                                                     <td name="pid_process_denom">
                                                         <label>PID Process</label>
-                                                        <input type="number" step="1" min="0" max="8" />
+                                                        <input type="text" step="1" min="0" max="8" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1516,11 +1550,11 @@
                                         <div class="spacer_box_title">GYRO SOFTWARE FILTERS</div>
                                     </div>
                                     <div class="spacer_box">
-                                    
+
                                         <table class="parameter cf">
                                             <thead>
-                                               <tr>
-                                                <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -1531,41 +1565,55 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-
                                                     <td name="gyro_soft_dyn_min_hz">
                                                         <label>Dyn Min</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
-
                                                     <td name="gyro_soft_dyn_max_hz">
                                                         <label>Dyn Max</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
-                                                </tr>
-
-                                                <tr>
                                                     <td name='gyro_soft_type'>
                                                         <label>Static 1</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-
                                                     <td name="gyro_lowpass_hz">
                                                         <label>Cutoff</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
-
                                                     <td name='gyro_soft2_type'>
                                                         <label>Static 2</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-
                                                     <td name="gyro_lowpass2_hz">
                                                         <label>Cutoff</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody class="static-features noline">
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Slider settings</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='simplified_gyro_filter'>
+                                                        <label>Status</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="simplified_gyro_filter_multiplier">
+                                                        <label>Slider Position</label>
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1581,19 +1629,19 @@
                                                 <tr>
                                                     <td name='gyro_notch_hz'>
                                                         <label>Notch1 Center</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="gyro_notch_cutoff">
                                                         <label>Notch 1 Cutoff</label>
-                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                        <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                     <td name='gyro_notch_hz_2'>
                                                         <label>Notch2 Center</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="gyro_notch_cutoff_2">
                                                         <label>Notch2 Cutoff</label>
-                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                        <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1609,19 +1657,19 @@
                                                </thead>
                                                     <td name='dynNotchCount'>
                                                         <label>Count/Width</label>
-                                                        <input type="number" step="1" min="0" max="10" />
+                                                        <input type="text" step="1" min="0" max="10" />
                                                     </td>
                                                     <td name="dynNotchQ">
                                                         <label>Q factor</label>
-                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                        <input type="text" step="1" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dynNotchMinHz">
                                                         <label>Min (Hz)</label>
-                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                        <input type="text" step="1" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dynNotchMaxHz">
                                                         <label>>Max (Hz)</label>
-                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                        <input type="text" step="1" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1637,23 +1685,23 @@
                                                </thead>
                                                     <td name='gyro_rpm_notch_harmonics'>
                                                         <label>Harmonics</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="gyro_rpm_notch_q">
                                                         <label>Q</label>
-                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                        <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                     <td name='gyro_rpm_notch_min'>
                                                         <label>Min (Hz)</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name='rpm_filter_fade_range_hz'>
                                                         <label>Fade Range</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name='rpm_notch_lpf'>
                                                         <label>Lpf</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1668,13 +1716,13 @@
                                     <div class="spacer_box">
 
                                         <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
+                                                </tr>
+                                            </thead>
                                             <tbody>
                                                 <tr>
-                                                <thead>
-                                                   <tr>
-                                                    <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
-                                                   </tr>
-                                               </thead>
                                                     <td name='dterm_dyn_type'>
                                                         <label>Dynamic</label>
                                                         <select>
@@ -1683,13 +1731,12 @@
                                                     </td>
                                                     <td name="dterm_lpf_dyn_min_hz">
                                                         <label>Dyn Min</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dterm_lpf_dyn_max_hz">
                                                         <label>Dyn Max</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
-
                                                     <td name='dterm_filter_type'>
                                                         <label>Static 1</label>
                                                         <select>
@@ -1698,7 +1745,7 @@
                                                     </td>
                                                     <td name="dterm_lpf_hz">
                                                         <label>Cutoff</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name='dterm_filter2_type'>
                                                         <label>Static 2</label>
@@ -1708,11 +1755,33 @@
                                                     </td>
                                                     <td name="dterm_lpf2_hz">
                                                         <label>Cutoff</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dterm_average_count" class="bf-only">
                                                         <label>Average Count</label>
-                                                        <input type="number" step="1" min="0" max="12" />
+                                                        <input type="text" step="1" min="0" max="12" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody class="static-features noline">
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Slider settings</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='simplified_dterm_filter'>
+                                                        <label>Status</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="simplified_dterm_filter_multiplier">
+                                                        <label>Position</label>
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1728,11 +1797,11 @@
                                                </thead>
                                                     <td name="dterm_notch_hz">
                                                         <label>Center Hz</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dterm_notch_cutoff">
                                                         <label>Cutoff Hz</label>
-                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                        <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1743,20 +1812,20 @@
                                                 <tr class='dshot_bidir_required'>
                                                 <thead>
                                                     <tr>
-                                                        <th scope="row" colspan="6">D_Term RPM filters</th>
+                                                        <th scope="row" colspan="6">D-Term RPM filters</th>
                                                     </tr>
                                                 </thead>
                                                     <td name='dterm_rpm_notch_harmonics'>
                                                         <label>Harmonics</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="dterm_rpm_notch_q">
                                                         <label>Q</label>
-                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                        <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                     <td name='dterm_rpm_notch_min'>
                                                         <label>Min Hz</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1775,11 +1844,11 @@
                                                 <tr>
                                                     <td name="acc_lpf_hz">
                                                         <label>Acc (Hz)</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="yaw_lpf_hz" class="bf-only">
                                                         <label>Yaw (Hz)</label>
-                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                        <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1805,7 +1874,7 @@
                                                     </td>
                                                     <td name="rcSmoothingRxAverage">
                                                         <label>RX Average (ms)</label>
-                                                        <input type="number" step="0.1" min="0"/>
+                                                        <input type="text" step="0.1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingDebugAxis'>
                                                         <label>Debug Axis</label>
@@ -1817,11 +1886,11 @@
                                                 <tr>
                                                     <td colspan="1" name='rcSmoothingAutoFactorSetpoint'>
                                                         <label>Setpoint auto fact</label>
-                                                        <input type="number" step="1" min="0" max="250" />
+                                                        <input type="text" step="1" min="0" max="250" />
                                                     </td>
                                                     <td name="rcSmoothingAutoFactorThrottle">
                                                         <label>Throttle auto fact</label>
-                                                        <input type="number" step="1" min="0" max="250" />
+                                                        <input type="text" step="1" min="0" max="250" />
                                                     </td>
                                             </tbody>
                                         </table>
@@ -1835,15 +1904,15 @@
                                                 <tr>
                                                     <td name="rcSmoothingSetpointHz">
                                                         <label>Setpoint Hz</label>
-                                                        <input type="number" step="1" min="0" max="255" />
+                                                        <input type="text" step="1" min="0" max="255" />
                                                     </td>
                                                     <td name="rcSmoothingFeedforwardHz">
                                                         <label>Feedforward Hz</label>
-                                                        <input type="number" step="1" min="0" max="255" />
+                                                        <input type="text" step="1" min="0" max="255" />
                                                     </td>
                                                     <td name="rcSmoothingThrottleHz">
                                                         <label>Throttle Hz</label>
-                                                        <input type="number" step="1" min="0" max="255" />
+                                                        <input type="text" step="1" min="0" max="255" />
                                             </tbody>
                                         </table>
 
@@ -1856,15 +1925,15 @@
                                                 <tr>
                                                     <td name='rcSmoothingActiveCutoffsSp'>
                                                         <label>Setpoint</label>
-                                                        <input type="number" step="1" min="0"/>
+                                                        <input type="text" step="1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingActiveCutoffsFf'>
                                                         <label>Feedforward</label>
-                                                        <input type="number" step="1" min="0"/>
+                                                        <input type="text" step="1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingActiveCutoffsThr'>
                                                         <label>Throttle</label>
-                                                        <input type="number" step="1" min="0"/>
+                                                        <input type="text" step="1" min="0"/>
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1908,36 +1977,21 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    <td name='unsynced_fast_pwm'>
-                                                        <label>Motors</label>
-                                                        <select>
-                                                            <!-- list generated here -->
-                                                        </select>
-                                                    </td>
-                                                    <td name="motor_pwm_rate">
-                                                        <label>Motor Rate</label>
-                                                        <input type="number" step="1" min="0" max="32000" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="dynamic_idle_min_rpm">
-                                                        <label>Dynamic Idle Min RPM</label>
-                                                        <input type="number" step="1" min="0" max="100" />
-                                                    </td>
                                                     <td name="dshot_bidir">
                                                         <label>D-Shot Bidir</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                        <td name='motor_poles'>
-                                                        <label>Motor poles</label>
-                                                        <input type="number" step="1" min="0" max="8" />
+                                                    <td name="motor_output_limit">
+                                                        <label>Output Limit</label>
+                                                        <input type="text" step="1" min="0" max="32000" />
+                                                    </td>
+                                                    <td name='unsynced_fast_pwm'>
+                                                        <label>Motors</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1948,15 +2002,51 @@
                                                 <tr>
                                                     <td name="digitalIdleOffset">
                                                         <label>D-Shot Offset %</label>
-                                                        <input type="number" step="0.01" min="0" max="1" />
+                                                        <input type="text" step="0.01" min="0" max="1" />
                                                     </td>
                                                     <td name="motorOutputLow">
                                                         <label>D-Shot Motor Low</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
+                                                        <input type="text" step="10" min="0" max="2047" />
                                                     </td>
                                                     <td name="motorOutputHigh">
                                                         <label>D-Shot Motor High</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
+                                                        <input type="text" step="10" min="0" max="2047" />
+                                                    </td>
+                                                    <td name="motor_pwm_rate">
+                                                        <label>Motor PWM</label>
+                                                        <input type="text" step="1" min="0" max="32000" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Dynamic Idle</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name="dynamic_idle_min_rpm">
+                                                        <label>Min RPM</label>
+                                                        <input type="text" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name='dyn_idle_p_gain'>
+                                                        <label>P gain</label>
+                                                        <input type="text" step="1" min="0" max="8" />
+                                                    </td>
+                                                    <td name='dyn_idle_i_gain'>
+                                                        <label>I gain</label>
+                                                        <input type="text" step="1" min="0" max="8" />
+                                                    </td>
+                                                    <td name="dyn_idle_d_gain">
+                                                        <label>D gain</label>
+                                                        <input type="text" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name='dyn_idle_max_increase'>
+                                                        <label>Max inc</label>
+                                                        <input type="text" step="1" min="0" max="8" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1974,19 +2064,19 @@
                                                 <tr>
                                                     <td name="vbat_sag_compensation">
                                                         <label>Vbat Sag Comp</label>
-                                                        <input type="number" step="1" min="0" max="150" />
+                                                        <input type="text" step="1" min="0" max="150" />
                                                     </td>
                                                     <td name="vbatmaxcellvoltage">
                                                         <label>Max Cell Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="vbatmincellvoltage">
                                                         <label>Min Cell Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="vbatwarningcellvoltage">
                                                         <label>Warning Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="2.55" />
+                                                        <input type="text" step="0.01" min="0" max="2.55" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -1997,19 +2087,19 @@
                                                 <tr>
                                                     <td name="currentMeterScale">
                                                         <label>Current Scale</label>
-                                                        <input type="number" step="1" min="0" max="500" />
+                                                        <input type="text" step="1" min="0" max="500" />
                                                     </td>
                                                     <td name="currentMeterOffset">
                                                         <label>Current Offset</label>
-                                                        <input type="number" step="1" min="0" max="500" />
+                                                        <input type="text" step="1" min="0" max="500" />
                                                     </td>
                                                     <td name="vbatscale">
                                                         <label>VBat Scale</label>
-                                                        <input type="number" step="1" min="0" max="500" />
+                                                        <input type="text" step="1" min="0" max="500" />
                                                     </td>
                                                     <td name="vbatref">
                                                         <label>VBat Ref</label>
-                                                        <input type="number" step="1" min="0" max="500" />
+                                                        <input type="text" step="1" min="0" max="500" />
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -2040,28 +2130,63 @@
 
                                 <div class="gui_box grey throttle">
                                     <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">THROTTLE CURVES</div>
+                                        <div class="spacer_box_title">THROTTLE</div>
                                     </div>
                                     <div class="spacer_box">
 
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Limits and Boost</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='throttle_limit_type'>
+                                                        <label>Limit Type</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="throttle_limit_percent">
+                                                        <label>Percent</label>
+                                                        <input type="text" step="0.01" min="0" max="1" />
+                                                    </td>
+                                                    <td name="throttle_boost">
+                                                        <label>Throttle Boost</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
+                                                    </td>
+                                                    <td name="throttle_boost_cutoff">
+                                                        <label>Cutoff Hz</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+ 
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Curves and range</th>
+                                                   </tr>
+                                               </thead>
                                                     <td name="thrMid">
                                                         <label>Throttle Mid</label>
-                                                        <input type="number" step="0.01" min="0" max="1" />
+                                                        <input type="text" step="0.01" min="0" max="1" />
                                                     </td>
                                                     <td name="thrExpo">
                                                         <label>Throttle Expo</label>
-                                                        <input type="number" step="0.01" min="0" max="1" />
+                                                        <input type="text" step="0.01" min="0" max="1" />
                                                     </td>
                                                     <td name="minthrottle">
                                                         <label>Min Throttle</label>
-                                                        <input type="number" step="10" min="1000" max="2000" />
+                                                        <input type="text" step="10" min="1000" max="2000" />
                                                     </td>
                                                     <td name="maxthrottle">
                                                         <label>Max Throttle</label>
-                                                        <input type="number" step="10" min="1000" max="2000" />
+                                                        <input type="text" step="10" min="1000" max="2000" />
                                                     </td>
                                                 </tr>
                                             </tbody>

--- a/index.html
+++ b/index.html
@@ -667,960 +667,631 @@
                 <div class="modal-body">
                     <form name="header-information" id="pid-tuning">
                         <div class="cf_column half left">
-                            <div class="gui_box grey PID-settings">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">PID Settings</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="no-inav parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='pidController'>
-                                                    <label>Controller</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <table class="pid_titlebar">
-                                        <tr>
-                                            <th class="name">Name</th>
-                                            <th class="proportional">Proportional</th>
-                                            <th class="integral">Integral</th>
-                                            <th class="derivative">Derivative</th>
-                                            <th class="feedforward">Feedforward</th>
-                                        </tr>
-                                    </table>
-                                    <table id="pid_main" class="pid_tuning">
-                                        <tr>
-                                            <th colspan="5">
-                                                <div class="pid_mode">Basic/Acro</div>
-                                            </th>
-                                        </tr>
-                                        <tr class="rollPID">
-                                            <!-- 0 -->
-                                            <td>ROLL</td>
-                                            <td>
-                                                <input type="number" name="p" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="f" step="1" min="0" max="255" />
-                                            </td>
-                                        </tr>
-                                        <tr class="pitchPID">
-                                            <!-- 1 -->
-                                            <td>PITCH</td>
-                                            <td>
-                                                <input type="number" name="p" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="f" step="1" min="0" max="255" />
-                                            </td>
-                                        </tr>
-                                        <tr class="yawPID">
-                                            <!-- 2 -->
-                                            <td>YAW</td>
-                                            <td>
-                                                <input type="number" name="p" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="f" step="1" min="0" max="255" />
-                                            </td>
-                                        </tr>
-                                    </table>
-                                    <table id="pid_baro" class="pid_tuning">
-                                        <tr>
-                                            <th colspan="5">
-                                                <div class="pid_mode">Barometer & Sonar/Altitude</div>
-                                            </th>
-                                        </tr>
-                                        <tr class="altPID">
-                                            <!-- 3 -->
-                                            <td>ALT</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.001" min="0" max="0.255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                            <td></td>
-                                        </tr>
-                                        <tr class="velPID">
-                                            <!-- 9 -->
-                                            <td>VEL</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.001" min="0" max="0.255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                            <td></td>
-                                        </tr>
-                                    </table>
-                                    <table id="pid_mag" class="pid_tuning">
-                                        <tr>
-                                            <th colspan="5">
-                                                <div class="pid_mode">Heading</div>
-                                            </th>
-                                        </tr>
-                                        <tr class="magPID">
-                                            <!-- 8 -->
-                                            <td>MAG</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td></td>
-                                            <td></td>
-                                            <td></td>
-                                        </tr>
-                                    </table>
-                                    <table id="pid_gps" class="pid_tuning">
-                                        <tr>
-                                            <th colspan="5">
-                                                <div class="pid_mode">GPS</div>
-                                            </th>
-                                        </tr>
-                                        <tr class="posPID">
-                                            <!-- 4 -->
-                                            <td>POS</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.01" min="0" max="2.55" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.01" min="0" max="2.55" />
-                                            </td>
-                                            <td></td>
-                                            <td></td>
-                                        </tr>
-                                        <tr class="posrPID">
-                                            <!-- 5 -->
-                                            <td>POSR</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.01" min="0" max="2.55" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="0.001" min="0" max="0.255" />
-                                            </td>
-                                            <td></td>
-                                        </tr>
-                                        <tr class="navrPID">
-                                            <!-- 6 -->
-                                            <td>NAVR</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.01" min="0" max="2.55" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="0.001" min="0" max="0.255" />
-                                            </td>
-                                            <td></td>
-                                        </tr>
-                                    </table>
-                                    <table id="pid_accel" class="pid_tuning">
-                                        <tr>
-                                            <th colspan="4">
-                                                <div class="pid_mode borderleft">
-                                                    <div class="textleft">
-                                                        <div class="pidTuningLevel">Angle/Horizon</div>
-                                                    </div>
-                                                    <div class="pids">Strength (Angle)</div>
-                                                    <div class="pids">Strength (Horizon)</div>
-                                                    <div class="pids">Transition (Horizon)</div>
-                                                </div>
-                                            </th>
-                                        </tr>
-                                        <tr class="levelPID">
-                                            <!-- 7 -->
-                                            <td>LEVEL</td>
-                                            <td>
-                                                <input type="number" name="p" step="0.1" min="0" max="25.5" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="i" step="0.001" min="0" max="0.255" />
-                                            </td>
-                                            <td>
-                                                <input type="number" name="d" step="1" min="0" max="255" />
-                                            </td>
-                                        </tr>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey PID-extra">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">PID Other</div>
-                                </div>
-                                <div class="spacer_box">
-
-                                    <table id="d_min" class="parameter cf">
-                                        <thead>
-                                            <tr>
-                                                <th colspan="2">D Min</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td name="d_min_roll" class="bf-only">
-                                                    <label>Roll</label>
-                                                    <input type="number" step="1" min="0" max="100" />
-                                                </td>
-                                                <td name="d_min_pitch" class="bf-only">
-                                                    <label>Pitch</label>
-                                                    <input type="number" step="1" min="0" max="100" />
-                                                </td>
-                                                <td name="d_min_yaw" class="bf-only">
-                                                    <label>Yaw</label>
-                                                    <input type="number" step="1" min="0" max="100" />
-                                                </td>
-                                                <td name="d_min_gain" class="bf-only">
-                                                    <label>Gain</label>
-                                                    <input type="number" step="1" min="0" max="100" />
-                                                </td>
-                                                <td name="d_min_advance" class="bf-only">
-                                                    <label>Advance</label>
-                                                    <input type="number" step="1" min="0" max="200" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-
-                                    <table class="parameter cf">
-                                        <thead>
-                                            <tr>
-                                                <th scope="row" colspan="2">Feedforward</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td name="feedforwardTransition" class="bf-only">
-                                                    <label>Transition
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="feedforwardAveraging" class="bf-only">
-                                                    <label>Averaging
-                                                        <br/>&nbsp;</label>
-                                                    <select>
-                                                        <!~~ list generated here ~~>
-                                                    </select>
-                                                </td>
-                                                <td name="feedforwardSmoothing" class="bf-only">
-                                                    <label>Smoothing
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0" min="0" max="100" />
-                                                </td>
-                                                <td name="feedforwardJitter" class="bf-only">
-                                                    <label>Jitter
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0" min="0" max="100" />
-                                                </td>
-                                                <td name="feedforwardBoost" class="bf-only">
-                                                    <label>Boost
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0" min="0" max="100" />
-                                                </td>
-                                                <td name="feedforwardMaxRate" class="bf-only">
-                                                    <label>MaxRate
-                                                        <br/>&nbsp;</label>
-                                                    <input type="number" step="0" min="0" max="100" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <caption>Misc</caption>
-                                        <tbody>
-                                            <tr>
-                                                <td name="ptermSRateWeight" class="bf-only">
-                                                    <label>P-Term
-                                                        <br>&nbsp;</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="abs_control_gain" class="bf-only">
-                                                    <label>Absolute Control
-                                                    <br/>&nbsp;</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="setpointRelaxRatio" class="bf-only">
-                                                    <label>Setpoint Relax
-                                                        <br>Ratio</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="dtermSetpointWeight" class="bf-only">
-                                                    <label>D Setpoint
-                                                        <br>Weight</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="rateAccelLimit" class="bf-only">
-                                                    <label>R/P Accel
-                                                        <br>Limit</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="yawRateAccelLimit" class="bf-only">
-                                                    <label>Yaw Accel
-                                                        <br>Limit</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name="antiGravityMode" class="bf-only">
-                                                    <label>AG Mode</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="antiGravityGain" class="bf-only">
-                                                    <label>AG Gain</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="antiGravityThreshold" class="bf-only">
-                                                    <label>AG Threshold</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="itermWindupPointPercent" class="bf-only">
-                                                    <label>Windup Threshold</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name="iterm_relax" class="bf-only">
-                                                    <label>ITerm Relax</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="iterm_relax_type" class="bf-only">
-                                                    <label>ITerm Relax Type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="iterm_relax_cutoff" class="bf-only">
-                                                    <label>ITerm Relax Cutoff</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name="pidSumLimit" class="bf-only">
-                                                    <label>PIDSum Limit</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                                <td name="pidSumLimitYaw" class="bf-only">
-                                                    <label>PIDSum Limit Yaw</label>
-                                                    <input type="number" step="0.01" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="no-inav parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='dynamic_pid' class="bf-only">
-                                                    <label>Dynamic PID</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <thead class="BFPIDController">
-                                            <tr>
-                                                <th colspan="2">P-Term</th>
-                                                <th class="bf-only" colspan="2">I-Term</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody class="BFPIDController">
-                                            <tr>
-                                                <td name='dynamic_pterm' class="bf-only">
-                                                    <label>Dynamic P</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="yaw_p_limit">
-                                                    <label>Yaw Limit</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="rollPitchItermResetRate" class="bf-only">
-                                                    <label>Roll/Pitch Reset</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="rollPitchItermIgnoreRate" class="bf-only">
-                                                    <label>Roll/Pitch Ignore Rate</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="yawItermResetRate" class="bf-only">
-                                                    <label>Yaw Reset</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                                <td name="yawItermIgnoreRate" class="bf-only">
-                                                    <label>Yaw Ignore Rate</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                        <tbody class="BFPIDController">
-                                            <tr>
-                                                <td></td>
-                                                <td name="iterm_reset_offset" class="bf-only">
-                                                    <label>Reset Offset</label>
-                                                    <input type="number" step="1" min="0" max="999" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="bf-only" cellpadding="0" cellspacing="0">
-                                        <tbody class="static-features noline">
-                                            <tr>
-                                                <td name="pidAtMinThrottle">
-                                                    <label class="option">
-                                                        <input class="ios-switch" type="checkbox" />
-                                                        <div>
-                                                            <div></div>
-                                                        </div>
-                                                    </label>
-                                                </td>
-                                                <td>
-                                                    <label>PIDs active at min-throttle</label>
-                                                </td>
-                                                <td>
-                                                    <span>Zero throttle stability</span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td name="use_integrated_yaw">
-                                                    <label class="option">
-                                                        <input class="ios-switch" type="checkbox" />
-                                                        <div>
-                                                            <div></div>
-                                                        </div>
-                                                    </label>
-                                                </td>
-                                                <td>
-                                                    <label>Integrated yaw</label>
-                                                </td>
-                                                <td>
-                                                    <span>Adds roll to yaw</span>
-                                                </td>
-                                            </tr>
-
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey filters">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Filters</div>
-                                </div>
-                                <div class="spacer_box">
-
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='gyro_hardware_lpf' colspan="2">
-                                                    <label>Gyro Hardware LPF</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name='gyro_32khz_hardware_lpf' colspan="2">
-                                                    <label>Gyro 32KHz Hardware LPF</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-
-                                    <table class="parameter cf">
-                                        <thead>
-                                            <tr>
-                                                <th colspan="5">Gyro Software Filters</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">Lowpass filters</th>
-                                               </tr>
-                                           </thead>
-
-                                            <tr>
-                                                <td name='gyro_soft_dyn_type'>
-                                                    <label>Dyn 1<br>Type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-
-                                                <td name="gyro_soft_dyn_min_hz">
-                                                    <label>Dyn 1 Min<br>
-                                                        Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-
-                                                <td name="gyro_soft_dyn_max_hz">
-                                                    <label>Dyn 1 Max
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                            <tr>
-                                                <td name='gyro_soft_type'>
-                                                    <label>Static 1
-                                                        <br>Filter type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-
-                                                <td name="gyro_lowpass_hz">
-                                                    <label>Static 1
-                                                        <br>Cutoff 1 Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-
-                                                <td name='gyro_soft2_type'>
-                                                    <label>Static 2
-                                                        <br> Filter type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-
-                                                <td name="gyro_lowpass2_hz">
-                                                    <label>Static 2
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                            <tr>
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">Static notch filters</th>
-                                               </tr>
-                                           </thead>
-                                                <td name='gyro_notch_hz'>
-                                                    <label>Notch 1
-                                                        <br>Center Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="gyro_notch_cutoff">
-                                                    <label>Notch 1 
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                                <td name='gyro_notch_hz_2'>
-                                                    <label>Notch 2
-                                                        <br>Center Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="gyro_notch_cutoff_2">
-                                                    <label>Notch 2
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                            <tr class="dyn_filter_required">
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">Dynamic notch filters</th>
-                                               </tr>
-                                           </thead>
-                                                <td name='dynNotchCount'>
-                                                    <label>Count/Width</label>
-                                                    <input type="number" step="1" min="0" max="10" />
-                                                </td>
-                                                <td name="dynNotchQ">
-                                                    <label>Q factor</label>
-                                                    <input type="number" step="1" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dynNotchMinHz">
-                                                    <label>Min (Hz)</label>
-                                                    <input type="number" step="1" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dynNotchMaxHz">
-                                                    <label>>Max (Hz)</label>
-                                                    <input type="number" step="1" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                            <tr class='dshot_bidir_required'>
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">RPM filters</th>
-                                               </tr>
-                                           </thead>
-                                                <td name='gyro_rpm_notch_harmonics'>
-                                                    <label>Harmonics</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="gyro_rpm_notch_q">
-                                                    <label>Q</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                                <td name='gyro_rpm_notch_min'>
-                                                    <label>Min(Hz)</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name='rpm_filter_fade_range_hz'>
-                                                    <label>FadeRng</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name='rpm_notch_lpf'>
-                                                    <label>Lpf</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <thead>
-                                            <tr>
-                                                <th colspan="5">D-Term Filters</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-
-                                            <tr>
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">Lowpass filters</th>
-                                               </tr>
-                                           </thead>
-
-                                                <td name='dterm_dyn_type'>
-                                                    <label>Dyn 1<br>Type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="dterm_lpf_dyn_min_hz">
-                                                    <label>Dyn 1 Min<br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dterm_lpf_dyn_max_hz">
-                                                    <label>Dyn 1 Max<br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-
-                                                <td name='dterm_filter_type'>
-                                                    <label>Static 1
-                                                        <br>Type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="dterm_lpf_hz">
-                                                    <label>Static 1
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name='dterm_filter2_type'>
-                                                    <label>Static 2
-                                                        <br>Type</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name="dterm_lpf2_hz">
-                                                    <label>Static 2
-                                                        <br>Cutoff Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dterm_average_count" class="bf-only">
-                                                    <label>Average Count</label>
-                                                    <input type="number" step="1" min="0" max="12" />
-                                                </td>
-                                            </tr>
-
-                                            <tr>
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">Static notch filter</th>
-                                               </tr>
-                                           </thead>
-
-                                                <td name="dterm_notch_hz">
-                                                    <label>Center Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dterm_notch_cutoff">
-                                                    <label>Cutoff Hz</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                            <tr class='dshot_bidir_required'>
-                                            <thead>
-                                               <tr>
-                                                <th scope="row" colspan="2">D_Term RPM filters</th>
-                                               </tr>
-                                           </thead>
-
-                                                <td name='dterm_rpm_notch_harmonics'>
-                                                    <label>Harmonics</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="dterm_rpm_notch_q">
-                                                    <label>Q</label>
-                                                    <input type="number" step="0.1" min="0" max="999.00" />
-                                                </td>
-                                                <td name='dterm_rpm_notch_min'>
-                                                    <label>Min Hz</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <thead>
-                                            <tr>
-                                                <th colspan="1">Other Filters</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td name="acc_lpf_hz">
-                                                    <label>Acc (Hz)</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                                <td name="yaw_lpf_hz" class="bf-only">
-                                                    <label>Yaw (Hz)</label>
-                                                    <input type="number" step="0.01" min="0" max="999.00" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey rxMode">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Receiver Mode</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table cellpadding="0" cellspacing="0">
-                                        <thead class="rxMode noline">
-                                            <tr>
-                                                <th class="cbox"></th>
-                                                <th class="item"></th>
-                                                <th class="description"></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody class="features rxMode noline">
-                                            <!-- table generated here -->
-                                        </tbody>
-                                    </table>
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='serialrx_provider'>
-                                                    <label>Provider</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-
-                                </div>
-                            </div>
-                            <div class="gui_box grey hardware">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Hardware Options</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name="loopTime">
-                                                    <label>Looptime</label>
-                                                    <input type="number" step="25" min="0" max="3000" />
-                                                </td>
-                                                <td name="gyro_sync_denom">
-                                                    <label>Gyro Sync</label>
-                                                    <input type="number" step="1" min="0" max="8" />
-                                                </td>
-                                                <td name="pid_process_denom">
-                                                    <label>PID Process</label>
-                                                    <input type="number" step="1" min="0" max="8" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                        <tbody>
-                                            <tr>
-                                                <td name='acc_hardware'>
-                                                    <label>Accelerometer</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name='mag_hardware'>
-                                                    <label>Magnetometer</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name='baro_hardware'>
-                                                    <label>Barometer</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                        <tbody>
-                                            <tr>
-                                                <td name='gyro_to_use'>
-                                                    <label>Selected gyro</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                                <td name='motor_poles'>
-                                                    <label>Motor poles</label>
-                                                    <input type="number" step="1" min="0" max="8" />
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                    <table class="bf-only" cellpadding="0" cellspacing="0">
-                                        <tbody class="static-features noline">
-                                            <tr>
-                                                <td name="gyro_cal_on_first_arm">
-                                                    <label class="option">
-                                                        <input class="ios-switch" type="checkbox" />
-                                                        <div>
-                                                            <div></div>
-                                                        </div>
-                                                    </label>
-                                                </td>
-                                                <td>
-                                                    <label>GYRO_CAL_ON_FIRST_ARM</label>
-                                                </td>
-                                                <td>
-                                                    <span>Calibrate Gyro on first arm</span>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey debug">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Debug Settings</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table class="parameter cf">
-                                        <tbody>
-                                            <tr>
-                                                <td name='debug_mode'>
-                                                    <label>Debug Mode</label>
-                                                    <select>
-                                                        <!-- list generated here -->
-                                                    </select>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                            <div class="gui_box grey disabled_fields">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Disabled Fields</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <table cellpadding="0" cellspacing="0">
-                                        <thead class="fields_list disabled_fields noline">
-                                            <tr>
-                                                <th class="checkbox"></th>
-                                                <th class="item"></th>
-                                                <th class="description"></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody class="fields_list disabled_fields noline">
-                                            <!-- table generated here -->
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="cf_column half right">
                             <div class="spacer_left">
-                                <div class="gui_box grey rates">
+
+                                <div class="gui_box grey PID-settings">
                                     <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">RC Command and Motor Protocols</div>
+                                        <div class="spacer_box_title">PID SETTINGS</div>
                                     </div>
+
                                     <div class="spacer_box">
+
+                                        <table id="pid_main_header" class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th>PID Values</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+
+                                        <table id="pid_main" class="pid_tuning">
+                                             <tr class = "pid_labels">
+                                                <th name="Blank">
+                                                    <label>&nbsp</label>
+                                                </th>
+                                                <th name="Proportional">
+                                                    <label>Proportional</label>
+                                                </th>
+                                                <th name="Integral">
+                                                    <label>Integral</label>
+                                                </th>
+                                                <th name="Derivative">
+                                                    <label>Derivative</label>
+                                                </th>
+                                                <th name="Feedforward">
+                                                    <label>Feedforward</label>
+                                                </th>
+                                            </tr>
+                                            <tr class="rollPID">
+                                                <!-- 0 -->
+                                                <td>Roll</td>
+                                                <td>
+                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                </td>
+                                            </tr>
+                                            <tr class="pitchPID">
+                                                <!-- 1 -->
+                                                <td>Pitch</td>
+                                                <td>
+                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                </td>
+                                            </tr>
+                                            <tr class="yawPID">
+                                                <!-- 2 -->
+                                                <td>Yaw</td>
+                                                <td>
+                                                    <input type="number" name="p" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="f" step="1" min="0" max="255" />
+                                                </td>
+                                            </tr>
+                                        </table>
+
+                                        <table id="pid_baro_header" class="parameter cf">
+                                        <thead>
+                                                <tr>
+                                                    <th>Baro</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                        <table id="pid_baro" class="pid_tuning">
+                                            <tr class="altPID">
+                                                <!-- 3 -->
+                                                <td>ALT</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                            <tr class="velPID">
+                                                <!-- 9 -->
+                                                <td>VEL</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                        </table>
+
+                                        <table id="pid_mag_header" class="parameter cf">
+                                        <thead>
+                                                <tr>
+                                                    <th>Mag</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                        <table id="pid_mag" class="pid_tuning">
+                                            <tr class="magPID">
+                                                <!-- 8 -->
+                                                <td>MAG</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td></td>
+                                                <td></td>
+                                                <td></td>
+                                            </tr>
+                                        </table>
+
+                                        <table id="pid_gps_header" class="parameter cf">
+                                        <thead>
+                                                <tr>
+                                                    <th>GPS</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                        <table id="pid_gps" class="pid_tuning">
+                                             <tr class="posPID">
+                                                <!-- 4 -->
+                                                <td>POS</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.01" min="0" max="2.55" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                </td>
+                                                <td></td>
+                                                <td></td>
+                                            </tr>
+                                            <tr class="posrPID">
+                                                <!-- 5 -->
+                                                <td>POSR</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                            <tr class="navrPID">
+                                                <!-- 6 -->
+                                                <td>NAVR</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.01" min="0" max="2.55" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td></td>
+                                            </tr>
+                                        </table>
+
+                                        <table id="d_min" class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th colspan="5">D Min</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="d_min_roll" class="bf-only">
+                                                        <label>Roll</label>
+                                                        <input type="number" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="d_min_pitch" class="bf-only">
+                                                        <label>Pitch</label>
+                                                        <input type="number" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="d_min_yaw" class="bf-only">
+                                                        <label>Yaw</label>
+                                                        <input type="number" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="d_min_gain" class="bf-only">
+                                                        <label>Gain</label>
+                                                        <input type="number" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="d_min_advance" class="bf-only">
+                                                        <label>Advance</label>
+                                                        <input type="number" step="1" min="0" max="200" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                            <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th colspan="5">TPA and Airmode</th>
+                                                </tr>
+                                            </thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td name="dynThrPID">
+                                                            <label>TPA amount</label>
+                                                            <input type="number" step="0.01" min="0" max="1.00" />
+                                                        </td>
+                                                        <td name="tpa-breakpoint">
+                                                            <label>TPA Breakpoint</label>
+                                                            <input type="number" step="10" min="1000" max="2000" />
+                                                        </td>
+                                                        <td name="airmode_activate_throttle" class="bf-only">
+                                                            <label>Airmode Activate</label>
+                                                            <input type="number" step="10" min="1000" max="2000" />
+                                                        </td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Feedforward</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="feedforwardTransition" class="bf-only">
+                                                        <label>Transition</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="feedforwardAveraging" class="bf-only">
+                                                        <label>Averaging</label>
+                                                        <select>
+                                                            <!~~ list generated here ~~>
+                                                        </select>
+                                                    </td>
+                                                    <td name="feedforwardSmoothing" class="bf-only">
+                                                        <label>Smoothing</label>
+                                                        <input type="number" step="0" min="0" max="100" />
+                                                    </td>
+                                                    <td name="feedforwardJitter" class="bf-only">
+                                                        <label>Jitter</label>
+                                                        <input type="number" step="0" min="0" max="100" />
+                                                    </td>
+                                                    <td name="feedforwardBoost" class="bf-only">
+                                                        <label>Boost</label>
+                                                        <input type="number" step="0" min="0" max="100" />
+                                                    </td>
+                                                    <td name="feedforwardMaxRate" class="bf-only">
+                                                        <label>MaxRate</label>
+                                                        <input type="number" step="0" min="0" max="100" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">AntiGravity</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="antiGravityMode" class="bf-only">
+                                                        <label>Mode</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="antiGravityGain" class="bf-only">
+                                                        <label>Gain</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="antiGravityThreshold" class="bf-only">
+                                                        <label>AG Threshold</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="itermWindupPointPercent" class="bf-only">
+                                                        <label>Windup Threshold</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Iterm Relax</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="iterm_relax" class="bf-only">
+                                                        <label>On/Off</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="iterm_relax_type" class="bf-only">
+                                                        <label>Type</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="iterm_relax_cutoff" class="bf-only">
+                                                        <label>Cutoff</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table id="pid_accel_header" class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th>Angle / Horizon settings</th>
+                                                </tr>
+                                            </thead>
+                                        </table>
+                                        <table id="pid_accel" class="pid_tuning">
+                                             <tr class = "pid_labels">
+                                                <th name="Blank">
+                                                    <label>&nbsp</label>
+                                                </th>
+                                                <th name="angle_strength">
+                                                    <label>Angle strength</label>
+                                                </th>
+                                                <th name="horizon_strength">
+                                                    <label>Horizon strength</label>
+                                                </th>
+                                                <th name="horizon_transition">
+                                                    <label>Horizon transition</label>
+                                                </th>
+                                            </tr>
+                                            <tr class="levelPID">
+                                                <!-- 7 -->
+                                                <td>LEVEL</td>
+                                                <td>
+                                                    <input type="number" name="p" step="0.1" min="0" max="25.5" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="i" step="0.001" min="0" max="0.255" />
+                                                </td>
+                                                <td>
+                                                    <input type="number" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                            </tr>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Misc</th>
+                                                </tr>
+                                            </thead>
+
+                                            <tbody>
+                                                <tr>
+                                                    <td name="pidSumLimit" class="bf-only">
+                                                        <label>PIDSum Limit</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="pidSumLimitYaw" class="bf-only">
+                                                        <label>PIDSum Limit Yaw</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <th colspan="3">Rates Type</th>
+                                                    <td name="ptermSRateWeight" class="bf-only">
+                                                        <label>P-Term
+                                                            <br>&nbsp;</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="abs_control_gain" class="bf-only">
+                                                        <label>Absolute 
+                                                        <br/>Control</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="setpointRelaxRatio" class="bf-only">
+                                                        <label>Setpoint Relax
+                                                            <br>Ratio</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="dtermSetpointWeight" class="bf-only">
+                                                        <label>D Setpoint
+                                                            <br>Weight</label>
+                                                        <input type="number" step="0.01" min="0" max="999" />
+                                                    </td>
+                                                    <td name="rateAccelLimit" class="bf-only">
+                                                        <label>R/P Accel
+                                                            <br>Limit</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawRateAccelLimit" class="bf-only">
+                                                        <label>Yaw Accel
+                                                            <br>Limit</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
                                                 </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="no-inav parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name='dynamic_pid' class="bf-only">
+                                                        <label>Dynamic PID</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead class="BFPIDController">
+                                                <tr>
+                                                    <th colspan="2">P-Term</th>
+                                                    <th class="bf-only" colspan="2">I-Term</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="BFPIDController">
+                                                <tr>
+                                                    <td name='dynamic_pterm' class="bf-only">
+                                                        <label>Dynamic P</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="yaw_p_limit">
+                                                        <label>Yaw Limit</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="rollPitchItermResetRate" class="bf-only">
+                                                        <label>Roll/Pitch Reset</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="rollPitchItermIgnoreRate" class="bf-only">
+                                                        <label>Roll/Pitch Ignore Rate</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawItermResetRate" class="bf-only">
+                                                        <label>Yaw Reset</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                    <td name="yawItermIgnoreRate" class="bf-only">
+                                                        <label>Yaw Ignore Rate</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                            <tbody class="BFPIDController">
+                                                <tr>
+                                                    <td></td>
+                                                    <td name="iterm_reset_offset" class="bf-only">
+                                                        <label>Reset Offset</label>
+                                                        <input type="number" step="1" min="0" max="999" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="bf-only" cellpadding="0" cellspacing="0">
+                                            <tbody class="static-features noline">
+                                                <tr>
+                                                    <td name="pidAtMinThrottle">
+                                                        <label class="option">
+                                                            <input class="ios-switch" type="checkbox" />
+                                                            <div>
+                                                                <div></div>
+                                                            </div>
+                                                        </label>
+                                                    </td>
+                                                    <td>
+                                                        <label>PIDs at min-throttle</label>
+                                                    </td>
+                                                    <td>
+                                                        <span>Zero throttle stability</span>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="use_integrated_yaw">
+                                                        <label class="option">
+                                                            <input class="ios-switch" type="checkbox" />
+                                                            <div>
+                                                                <div></div>
+                                                            </div>
+                                                        </label>
+                                                    </td>
+                                                    <td>
+                                                        <label>Integrated yaw</label>
+                                                    </td>
+                                                    <td>
+                                                        <span>Adds roll to yaw</span>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey debug">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">DEBUG MODE</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name='debug_mode'>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">RATES</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
                                                 <tr>
                                                     <td name="rates_type" class="bf-only">
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
+                                                    <td name="rcRate">
+                                                        <label>Rate</label>
+                                                    </td>
+                                                    <td name="rcSuperRate">
+                                                        <label>Super Rate</label>
+                                                    </td>
+                                                    <td name="rcExpo">
+                                                        <label>Expo</label>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="rcRollRowName" class="no-inav">
+                                                        <label>Roll</label>
+                                                    </td>
+                                                    <td name="rcRollRate" class="no-inav">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="rates[0]">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="rcRollExpo">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="rcPitchRowName" class="no-inav">
+                                                        <label>Pitch</label>
+                                                    </td>
+                                                    <td name="rcPitchRate" class="no-inav">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="rates[1]">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="rcPitchExpo">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td name="rcYawRowName" class="no-inav">
+                                                        <label>Yaw</label>
+                                                    </td>
+                                                    <td name="rcYawRate" class="no-inav">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="rates[2]">
+                                                        <input type="number" step="0.01" min="0" max="2.55" />
+                                                    </td>
+                                                    <td name="rcYawExpo">
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
                                                 </tr>
                                             </tbody>
                                         </table>
@@ -1628,83 +1299,28 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <th colspan="1">Roll rates</th>
-                                                </tr>
-                                                <tr>
-                                                    <td name="rcRollRate" class="no-inav">
-                                                        <label>Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="rates[0]">
-                                                        <label>Super Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="rcRollExpo">
-                                                        <label>Expo</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <th colspan="1">Pitch rates</th>
-                                                </tr>
-                                                <tr>
-                                                    <td name="rcPitchRate" class="no-inav">
-                                                        <label>Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="rates[1]">
-                                                        <label>Super Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="rcPitchExpo">
-                                                        <label>Expo</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <th colspan="1">Yaw rates</th>
-                                                </tr>
-                                                <tr>
-                                                    <td name="rcYawRate" class="no-inav">
-                                                        <label>Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="rates[2]">
-                                                        <label>Super Rate</label>
-                                                        <input type="number" step="0.01" min="0" max="2.55" />
-                                                    </td>
-                                                    <td name="rcYawExpo">
-                                                        <label>Expo</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                </tr>
-                                                <tr>
                                                     <td name="superExpoFactor" class="bf-only">
-                                                        <label>ROLL/PITCH SuperExpo</label>
+                                                        <label>RP SuperExpo</label>
                                                         <input type="number" step="0.01" min="0" max="1.00" />
                                                     </td>
                                                     <td name="superExpoFactorYaw" class="bf-only">
                                                         <label>YAW SuperExpo</label>
                                                         <input type="number" step="0.01" min="0" max="1.00" />
                                                     </td>
-                                                    <td></td>
-                                                </tr>
-                                                <tr>
-                                                    <td></td>
                                                     <td name='superExpoYawMode' class="bf-only">
+                                                        <label>YAW SE Mode</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    <td></td>
                                                 </tr>
                                             </tbody>
                                         </table>
 
-                                        <table id="rate_limits" class="parameter cf">
+                                        <table class="parameter cf">
                                             <body>
                                                 <tr>
-                                                    <th colspan="1">Rate Limits</th>
+                                                    <th colspan="3">Rate Limits</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="rate_limits_roll">
@@ -1724,10 +1340,9 @@
                                         </table>
 
                                         <table class="parameter cf">
-
                                             <body>
                                                 <tr>
-                                                    <th colspan="1">Deadband</th>
+                                                    <th colspan="2">Deadband</th>
                                                 </tr>
                                                 <tr>
                                                     <td name="deadband">
@@ -1738,15 +1353,449 @@
                                                         <label>Yaw</label>
                                                         <input type="number" step="1" min="0" max="100" />
                                                     </td>
-                                                    <td></td>
                                                 </tr>
-                                                </tbody>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey rxMode">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">RECEIVER MODE</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table cellpadding="0" cellspacing="0">
+                                            <thead class="rxMode noline">
+                                                <tr>
+                                                    <th class="cbox"></th>
+                                                    <th class="item"></th>
+                                                    <th class="description"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="features rxMode noline">
+                                                <!-- table generated here -->
+                                            </tbody>
                                         </table>
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <th colspan="3">RC SMOOTHING</th>
+                                                    <td name='serialrx_provider'>
+                                                        <label>Provider</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
                                                 </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey hardware">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">HARDWARE OPTIONS</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="loopTime">
+                                                        <label>Looptime</label>
+                                                        <input type="number" step="25" min="0" max="3000" />
+                                                    </td>
+                                                    <td name="gyro_sync_denom">
+                                                        <label>Gyro Sync</label>
+                                                        <input type="number" step="1" min="0" max="8" />
+                                                    </td>
+                                                    <td name="pid_process_denom">
+                                                        <label>PID Process</label>
+                                                        <input type="number" step="1" min="0" max="8" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                            <tbody>
+                                                <tr>
+                                                    <td name='acc_hardware'>
+                                                        <label>Accelerometer</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name='mag_hardware'>
+                                                        <label>Magnetometer</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name='baro_hardware'>
+                                                        <label>Barometer</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                            <tbody>
+                                                <tr>
+                                                    <td name='gyro_to_use'>
+                                                        <label>Selected gyro</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                   <td name='gyro_hardware_lpf'>
+                                                        <label>Hardware gyro LPF</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name='gyro_32khz_hardware_lpf'>
+                                                        <label>Gyro 32KHz Hardware LPF</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                               </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="bf-only" cellpadding="0" cellspacing="0">
+                                            <tbody class="static-features noline">
+                                                <tr>
+                                                    <td name="gyro_cal_on_first_arm">
+                                                        <label class="option">
+                                                            <input class="ios-switch" type="checkbox" />
+                                                            <div>
+                                                                <div></div>
+                                                            </div>
+                                                        </label>
+                                                    </td>
+                                                    <td>
+                                                        <label>GYRO_CAL_ON_FIRST_ARM</label>
+                                                    </td>
+                                                    <td>
+                                                        <span>Calibrate Gyro on first arm</span>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey disabled_fields">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">DISABLED FIELDS</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table cellpadding="0" cellspacing="0">
+                                            <thead class="fields_list disabled_fields noline">
+                                                <tr>
+                                                    <th class="checkbox"></th>
+                                                    <th class="item"></th>
+                                                    <th class="description"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody class="fields_list disabled_fields noline">
+                                                <!-- table generated here -->
+                                            </tbody>
+                                        </table>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="cf_column half right">
+                            <div class="spacer_left">
+
+                                <div class="gui_box grey filters">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">GYRO SOFTWARE FILTERS</div>
+                                    </div>
+                                    <div class="spacer_box">
+                                    
+                                        <table class="parameter cf">
+                                            <thead>
+                                               <tr>
+                                                <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name='gyro_soft_dyn_type'>
+                                                        <label>Dynamic</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+
+                                                    <td name="gyro_soft_dyn_min_hz">
+                                                        <label>Dyn Min</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+
+                                                    <td name="gyro_soft_dyn_max_hz">
+                                                        <label>Dyn Max</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+
+                                                <tr>
+                                                    <td name='gyro_soft_type'>
+                                                        <label>Static 1</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+
+                                                    <td name="gyro_lowpass_hz">
+                                                        <label>Cutoff</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+
+                                                    <td name='gyro_soft2_type'>
+                                                        <label>Static 2</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+
+                                                    <td name="gyro_lowpass2_hz">
+                                                        <label>Cutoff</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="row" colspan="6">Fixed notch filters - cutoff in hz</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name='gyro_notch_hz'>
+                                                        <label>Notch1 Center</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="gyro_notch_cutoff">
+                                                        <label>Notch 1 Cutoff</label>
+                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='gyro_notch_hz_2'>
+                                                        <label>Notch2 Center</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="gyro_notch_cutoff_2">
+                                                        <label>Notch2 Cutoff</label>
+                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr class="dyn_filter_required">
+                                                <thead>
+                                                   <tr>
+                                                        <th scope="row" colspan="6">Dynamic notch filters</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='dynNotchCount'>
+                                                        <label>Count/Width</label>
+                                                        <input type="number" step="1" min="0" max="10" />
+                                                    </td>
+                                                    <td name="dynNotchQ">
+                                                        <label>Q factor</label>
+                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dynNotchMinHz">
+                                                        <label>Min (Hz)</label>
+                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dynNotchMaxHz">
+                                                        <label>>Max (Hz)</label>
+                                                        <input type="number" step="1" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr class='dshot_bidir_required'>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">RPM filters - frequency in Hz</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='gyro_rpm_notch_harmonics'>
+                                                        <label>Harmonics</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="gyro_rpm_notch_q">
+                                                        <label>Q</label>
+                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='gyro_rpm_notch_min'>
+                                                        <label>Min (Hz)</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='rpm_filter_fade_range_hz'>
+                                                        <label>Fade Range</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='rpm_notch_lpf'>
+                                                        <label>Lpf</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey filters">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">D-TERM SOFTWARE FILTERS</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Lowpass filters - cutoffs in hz</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name='dterm_dyn_type'>
+                                                        <label>Dynamic</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="dterm_lpf_dyn_min_hz">
+                                                        <label>Dyn Min</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dterm_lpf_dyn_max_hz">
+                                                        <label>Dyn Max</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+
+                                                    <td name='dterm_filter_type'>
+                                                        <label>Static 1</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="dterm_lpf_hz">
+                                                        <label>Cutoff</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='dterm_filter2_type'>
+                                                        <label>Static 2</label>
+                                                        <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
+                                                    <td name="dterm_lpf2_hz">
+                                                        <label>Cutoff</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dterm_average_count" class="bf-only">
+                                                        <label>Average Count</label>
+                                                        <input type="number" step="1" min="0" max="12" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                <thead>
+                                                   <tr>
+                                                    <th scope="row" colspan="6">Static notch filter</th>
+                                                   </tr>
+                                               </thead>
+                                                    <td name="dterm_notch_hz">
+                                                        <label>Center Hz</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dterm_notch_cutoff">
+                                                        <label>Cutoff Hz</label>
+                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr class='dshot_bidir_required'>
+                                                <thead>
+                                                    <tr>
+                                                        <th scope="row" colspan="6">D_Term RPM filters</th>
+                                                    </tr>
+                                                </thead>
+                                                    <td name='dterm_rpm_notch_harmonics'>
+                                                        <label>Harmonics</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="dterm_rpm_notch_q">
+                                                        <label>Q</label>
+                                                        <input type="number" step="0.1" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name='dterm_rpm_notch_min'>
+                                                        <label>Min Hz</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey debug">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">OTHER FILTERS</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="acc_lpf_hz">
+                                                        <label>Acc (Hz)</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                    <td name="yaw_lpf_hz" class="bf-only">
+                                                        <label>Yaw (Hz)</label>
+                                                        <input type="number" step="0.01" min="0" max="999.00" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+
+                                <div class="gui_box grey rc_smoothing">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">RC SMOOTHING</div>
+                                    </div>
+                                    <div class="spacer_box">
+
+                                        <table class="parameter cf">
+                                            <tbody>
                                                 <tr>
                                                     <td name='rcSmoothingMode'>
                                                         <label>On/Off</label>
@@ -1766,7 +1815,7 @@
                                                     </td>
                                                 </tr>
                                                 <tr>
-                                                    <td colspan="2" name='rcSmoothingAutoFactorSetpoint'>
+                                                    <td colspan="1" name='rcSmoothingAutoFactorSetpoint'>
                                                         <label>Setpoint auto fact</label>
                                                         <input type="number" step="1" min="0" max="250" />
                                                     </td>
@@ -1774,9 +1823,14 @@
                                                         <label>Throttle auto fact</label>
                                                         <input type="number" step="1" min="0" max="250" />
                                                     </td>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
                                                 </tr>
                                                     <tr>
-                                                        <th scope="row" colspan="1">Manual Cutoffs</th>
+                                                        <th scope="row" colspan="3">Manual Cutoffs</th>
                                                     </tr>
                                                 <tr>
                                                     <td name="rcSmoothingSetpointHz">
@@ -1790,9 +1844,14 @@
                                                     <td name="rcSmoothingThrottleHz">
                                                         <label>Throttle Hz</label>
                                                         <input type="number" step="1" min="0" max="255" />
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
                                                 </tr>
                                                     <tr>
-                                                        <th scope="row" colspan="1">Active Values</th>
+                                                        <th scope="row" colspan="3">Active Values</th>
                                                     </tr>
                                                 <tr>
                                                     <td name='rcSmoothingActiveCutoffsSp'>
@@ -1810,6 +1869,7 @@
                                                 </tr>
                                             </tbody>
                                         </table>
+
                                         <table class="noline" cellpadding="0" cellspacing="0">
                                             <tbody class="static-features misc noline">
                                                 <tr>
@@ -1830,12 +1890,16 @@
                                                 </tr>
                                             </tbody>
                                         </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey motors">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">MOTORS</div>
+                                    </div>
+                                    <div class="spacer_box">
+
                                         <table class="parameter cf">
-                                            <thead>
-                                                <tr>
-                                                    <th colspan="3">MOTORS</th>
-                                                </tr>
-                                            </thead>
                                             <tbody>
                                                 <tr>
                                                     <td name='fast_pwm_protocol'>
@@ -1854,23 +1918,132 @@
                                                         <label>Motor Rate</label>
                                                         <input type="number" step="1" min="0" max="32000" />
                                                     </td>
-                                                        <td name="dshot_bidir">
-                                                        <label>DSHOT Bidir</label>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="dynamic_idle_min_rpm">
+                                                        <label>Dynamic Idle Min RPM</label>
+                                                        <input type="number" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="dshot_bidir">
+                                                        <label>D-Shot Bidir</label>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
+                                                        <td name='motor_poles'>
+                                                        <label>Motor poles</label>
+                                                        <input type="number" step="1" min="0" max="8" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
 
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="digitalIdleOffset">
+                                                        <label>D-Shot Offset %</label>
+                                                        <input type="number" step="0.01" min="0" max="1" />
+                                                    </td>
+                                                    <td name="motorOutputLow">
+                                                        <label>D-Shot Motor Low</label>
+                                                        <input type="number" step="10" min="0" max="2047" />
+                                                    </td>
+                                                    <td name="motorOutputHigh">
+                                                        <label>D-Shot Motor High</label>
+                                                        <input type="number" step="10" min="0" max="2047" />
+                                                    </td>
                                                 </tr>
                                             </tbody>
                                         </table>
                                     </div>
                                 </div>
-                                <div class="gui_box grey throttle">
+
+                                <div class="gui_box grey voltagecurrent">
                                     <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">Throttle</div>
+                                        <div class="spacer_box_title">VOLTAGE & CURRENT</div>
                                     </div>
                                     <div class="spacer_box">
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="vbat_sag_compensation">
+                                                        <label>Vbat Sag Comp</label>
+                                                        <input type="number" step="1" min="0" max="150" />
+                                                    </td>
+                                                    <td name="vbatmaxcellvoltage">
+                                                        <label>Max Cell Voltage</label>
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="vbatmincellvoltage">
+                                                        <label>Min Cell Voltage</label>
+                                                        <input type="number" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="vbatwarningcellvoltage">
+                                                        <label>Warning Voltage</label>
+                                                        <input type="number" step="0.01" min="0" max="2.55" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <tbody>
+                                                <tr>
+                                                    <td name="currentMeterScale">
+                                                        <label>Current Scale</label>
+                                                        <input type="number" step="1" min="0" max="500" />
+                                                    </td>
+                                                    <td name="currentMeterOffset">
+                                                        <label>Current Offset</label>
+                                                        <input type="number" step="1" min="0" max="500" />
+                                                    </td>
+                                                    <td name="vbatscale">
+                                                        <label>VBat Scale</label>
+                                                        <input type="number" step="1" min="0" max="500" />
+                                                    </td>
+                                                    <td name="vbatref">
+                                                        <label>VBat Ref</label>
+                                                        <input type="number" step="1" min="0" max="500" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="noline bf-only" cellpadding="0" cellspacing="0">
+                                            <tbody class="static-features misc noline">
+                                                <tr>
+                                                    <td name="vbat_pid_compensation">
+                                                        <label class="option">
+                                                            <input class="ios-switch orange" type="checkbox" />
+                                                            <div>
+                                                                <div></div>
+                                                            </div>
+                                                        </label>
+                                                    </td>
+                                                    <td>
+                                                        <label>Vat PID compensation</label>
+                                                    </td>
+                                                    <td>
+                                                        <span>Scale PIDs with voltage</span>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                <div class="gui_box grey throttle">
+                                    <div class="gui_box_titlebar">
+                                        <div class="spacer_box_title">THROTTLE CURVES</div>
+                                    </div>
+                                    <div class="spacer_box">
+
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
@@ -1893,138 +2066,15 @@
                                                 </tr>
                                             </tbody>
                                         </table>
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="dynThrPID">
-                                                        <label>TPA</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="tpa-breakpoint">
-                                                        <label>TPA&nbsp;Breakpoint</label>
-                                                        <input type="number" step="10" min="1000" max="2000" />
-                                                    </td>
-                                                    <td name="airmode_activate_throttle" class="bf-only">
-                                                        <label>Airmode Activate</label>
-                                                        <input type="number" step="10" min="1000" max="2000" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="motorOutputLow">
-                                                        <label>D-Shot Motor Low</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
-                                                    </td>
-                                                    <td name="motorOutputHigh">
-                                                        <label>D-Shot Motor High</label>
-                                                        <input type="number" step="10" min="0" max="2047" />
-                                                    </td>
-                                                </tr>
-                                                <tr>
-                                                    <td name="digitalIdleOffset">
-                                                        <label>D-Shot Offset (%)</label>
-                                                        <input type="number" step="0.01" min="0" max="1" />
-                                                    </td>
-                                                    <td name="dynamic_idle_min_rpm">
-                                                        <label>Dynamic Idle Min RPM (* 100)</label>
-                                                        <input type="number" step="1" min="0" max="100" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
                                     </div>
                                 </div>
-                                <div class="gui_box grey voltagecurrent">
-                                    <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">Voltage and Current</div>
-                                    </div>
-                                    <div class="spacer_box">
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="currentMeterScale">
-                                                        <label>Current Scale</label>
-                                                        <input type="number" step="1" min="0" max="500" />
-                                                    </td>
-                                                    <td name="currentMeterOffset">
-                                                        <label>Current Offset</label>
-                                                        <input type="number" step="1" min="0" max="500" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                            <tbody>
-                                                <tr>
-                                                    <td name="vbatscale">
-                                                        <label>VBat Scale</label>
-                                                        <input type="number" step="1" min="0" max="500" />
-                                                    </td>
-                                                    <td name="vbatref">
-                                                        <label>VBat Ref</label>
-                                                        <input type="number" step="1" min="0" max="500" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                            <tbody>
-                                                <tr>
-                                                    <td name="vbatmincellvoltage">
-                                                        <label>Min Cell Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="vbatwarningcellvoltage">
-                                                        <label>Warning Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="2.55" />
-                                                    </td>
-                                                    <td name="vbatmaxcellvoltage">
-                                                        <label>Max Cell Voltage</label>
-                                                        <input type="number" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        <table class="noline bf-only" cellpadding="0" cellspacing="0">
-                                            <tbody class="static-features misc noline">
-                                                <tr>
-                                                    <td name="vbat_pid_compensation">
-                                                        <label class="option">
-                                                            <input class="ios-switch orange" type="checkbox" />
-                                                            <div>
-                                                                <div></div>
-                                                            </div>
-                                                        </label>
-                                                        <td>
-                                                            <label>VBAT_PID_COMPENSATION</label>
-                                                        </td>
-                                                        <td>
-                                                            <span>Scale PID parameters based upon current battery voltage</span>
-                                                        </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        <table class="parameter cf">
-                                            <tbody>
-                                                <tr>
-                                                    <td name="vbat_sag_compensation">
-                                                        <label>Vbat Sag Compensation</label>
-                                                        <input type="number" step="1" min="0" max="150" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-                                        <table cellpadding="0" cellspacing="0">
-                                            <tbody class="features battery noline">
-                                                <!-- table generated here -->
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
+
                                 <div class="gui_box grey other">
                                     <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">Other Features</div>
+                                        <div class="spacer_box_title">OTHER FEATURES</div>
                                     </div>
                                     <div class="spacer_box">
+
                                         <table cellpadding="0" cellspacing="0">
                                             <thead class="features other noline">
                                                 <tr>

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -469,6 +469,18 @@ var
         "2_POINT",
         "3_POINT",
         "4_POINT",
+    ]),
+
+    SIMPLIFIED_PIDS_MODE = makeReadOnly([
+        "OFF",
+        "ON - RP",
+        "ON - RPY",
+    ]),
+
+    THROTTLE_LIMIT_TYPE = makeReadOnly([
+        "OFF",
+        "SCALE",
+        "CLIP",
     ]);
 
 function adjustFieldDefsList(firmwareType, firmwareVersion) {

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -492,6 +492,10 @@ function adjustFieldDefsList(firmwareType, firmwareVersion) {
             DEBUG_MODE.splice(DEBUG_MODE.indexOf('DUAL_GYRO'),          1);
             DEBUG_MODE.splice(DEBUG_MODE.indexOf('DUAL_GYRO_COMBINED'), 1);
         }
+        if(semver.gte(firmwareVersion, '4.3.0')) {
+            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_INTERPOLATED'), 1, 'FEEDFORWARD');
+            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_LIMIT'),        1, 'FEEDFORWARD_LIMIT');
+        }
         DEBUG_MODE = makeReadOnly(DEBUG_MODE);
 
         // Flight mode names

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -298,18 +298,18 @@ function FlightLogFieldPresenter() {
             'debug[3]':'ESC RPM [4]',
         },
         'DSHOT_RPM_TELEMETRY' : {
-            'debug[all]':'DSHOT RPM', 
-            'debug[0]':'DSHOT RPM [1]',
-            'debug[1]':'DSHOT RPM [2]',
-            'debug[2]':'DSHOT RPM [3]',
-            'debug[3]':'DSHOT RPM [4]',
+            'debug[all]':'DShot Telemetry RPM', 
+            'debug[0]':'Motor 1 - DShot',
+            'debug[1]':'Motor 2 - DShot',
+            'debug[2]':'Motor 3 - DShot',
+            'debug[3]':'Motor 4 - DShot',
         },
         'RPM_FILTER' : {
             'debug[all]':'RPM Filter', 
-            'debug[0]':'RPM Filter [1]',
-            'debug[1]':'RPM Filter [2]',
-            'debug[2]':'RPM Filter [3]',
-            'debug[3]':'RPM Filter [4]',
+            'debug[0]':'Motor 1 - rpmFilter',
+            'debug[1]':'Motor 2 - rpmFilter',
+            'debug[2]':'Motor 3 - rpmFilter',
+            'debug[3]':'Motor 4 - rpmFilter',
         },
         'D_MIN' : {
             'debug[all]':'D_MIN',
@@ -788,7 +788,7 @@ function FlightLogFieldPresenter() {
                         return value.toFixed(0) + "Hz";
                     }
                 case 'DSHOT_RPM_TELEMETRY':
-                    return (value * 50 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + "RPM";
+                    return (value * 200 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + " rpm";
                 case 'RPM_FILTER':
                     return value.toFixed(0) + "Hz";
                 case 'D_MIN':

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -195,8 +195,9 @@ var FlightLogParser = function(logData) {
             deviceUID: null
         },
 
-        // These are now part of the blackbox log header, but they are in addition to the standard logger.
-        // each name should match a field in blackbox.c of the current firmware
+        // Blackbox log header parameter names.
+        // each name should exist in the blackbox log of the current firmware, or
+        // be an older name which is translated into a current name in the table below
 
         defaultSysConfigExtension = {
             abs_control_gain:null,                  // Aboslute control gain
@@ -322,12 +323,13 @@ var FlightLogParser = function(logData) {
             rc_smoothing_auto_factor_throttle:null, // RC Smoothing cutoff for throttle
             rc_smoothing_active_cutoffs_ff_sp_thr:[null,null,null],// RC Smoothing active cutoffs feedforward, setpoint, throttle
             dyn_notch_count: null,                  // Number of dynamic notches 4.3
+            rpm_filter_fade_range_hz: null,         // Fade range for RPM notch filters in Hz
             unknownHeaders : []                     // Unknown Extra Headers
         },
 
         // Translation of the field values name to the sysConfig var where it must be stored
-        // on the left are field names from older versions of blackbox.c
-        // on the right are names from the list above
+        // on the left are field names from the latest versions of blackbox.c
+        // on the right are older field names that must exist in the list above
 
         translationValues = {
             acc_limit_yaw             : "yawRateAccelLimit",
@@ -340,6 +342,11 @@ var FlightLogParser = function(logData) {
             dterm_lowpass_hz          : "dterm_lpf_hz",
             dterm_lowpass_dyn_hz      : "dterm_lpf_dyn_hz",
             dterm_lowpass2_hz         : "dterm_lpf2_hz",
+            dterm_lpf1_type           : "dterm_filter_type",
+            dterm_lpf1_static_hz      : "dterm_lpf_hz",
+            dterm_lpf1_dyn_hz         : "dterm_lpf_dyn_hz",
+            dterm_lpf2_type           : "dterm_filter2_type",
+            dterm_lpf2_static_hz      : "dterm_lpf2_hz",
             dterm_setpoint_weight     : "dtermSetpointWeight",
             digital_idle_value        : "digitalIdleOffset",
             dshot_idle_value          : "digitalIdleOffset",
@@ -347,6 +354,11 @@ var FlightLogParser = function(logData) {
             gyro_lowpass              : "gyro_lowpass_hz",
             gyro_lowpass_type         : "gyro_soft_type",
             gyro_lowpass2_type        : "gyro_soft2_type",
+            gyro_lpf1_type            : "gyro_soft_type",
+            gyro_lpf1_static_hz       : "gyro_lowpass_hz",
+            gyro_lpf1_dyn_hz          : "gyro_lowpass_dyn_hz",
+            gyro_lpf2_type            : "gyro_soft2_type",
+            gyro_lpf2_static_hz       : "gyro_lowpass2_hz",
             "gyro.scale"              : "gyro_scale",
             iterm_windup              : "itermWindupPointPercent",
             motor_pwm_protocol        : "fast_pwm_protocol",
@@ -373,7 +385,11 @@ var FlightLogParser = function(logData) {
             feedforward_transition    : "ff_transition",
             feedforward_weight        : "ff_weight",
             rc_smoothing_auto_factor  : "rc_smoothing_auto_factor_setpoint",
-            rc_smoothing_type         : "rc_smoothing_mode"
+            rc_smoothing_type         : "rc_smoothing_mode",
+            rpm_filter_harmonics      : "gyro_rpm_notch_harmonics",
+            rpm_filter_q              : "gyro_rpm_notch_q",
+            rpm_filter_min_hz         : "gyro_rpm_notch_min",
+            rpm_filter_lpf_hz         : "rpm_notch_lpf"
         },
 
         frameTypes,
@@ -640,6 +656,7 @@ var FlightLogParser = function(logData) {
             case "gyro_rpm_notch_harmonics":
             case "gyro_rpm_notch_q":
             case "gyro_rpm_notch_min":
+            case "rpm_filter_fade_range_hz":
             case "rpm_notch_lpf":
             case "dterm_rpm_notch_harmonics":
             case "dterm_rpm_notch_q":

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -332,9 +332,9 @@ var FlightLogParser = function(logData) {
             simplified_pi_gain: null,
             simplified_i_gain: null,
             simplified_d_gain: null,
-            simplified_dmin_ratio: null,
+            simplified_dmax_gain: null,
             simplified_feedforward_gain: null,
-            simplified_roll_pitch_ratio: null,
+            simplified_pitch_d_gain: null,
             simplified_pitch_pi_gain: null,
             simplified_master_multiplier: null,
             simplified_dterm_filter: null,
@@ -412,38 +412,8 @@ var FlightLogParser = function(logData) {
             rpm_filter_q              : "gyro_rpm_notch_q",
             rpm_filter_min_hz         : "gyro_rpm_notch_min",
             rpm_filter_lpf_hz         : "rpm_notch_lpf",
-            rc_sm_md                  : "rc_smoothing_mode",
-            rc_sm_ff_hz               : "rc_smoothing_feedforward_hz",
-            rc_sm_sp_hz               : "rc_smoothing_setpoint_hz",
-            rc_sm_af_sp               : "rc_smoothing_auto_factor_setpoint",
-            rc_sm_thr_hz              : "rc_smoothing_throttle_hz",
-            rc_sm_af_thr              : "rc_smoothing_auto_factor_throttle",
-            rc_sm_dbg_ax              : "rc_smoothing_debug_axis",
-            rc_sm_act_cuts            : "rc_smoothing_active_cutoffs_ff_sp_thr",
-            rc_sm_rx_av               : "rc_smoothing_rx_average",
-            vbat_s_comp               : "vbat_sag_compensation",
-            d_idl_m_r                 : "dynamic_idle_min_rpm",
-            d_idl_p                   : "dyn_idle_p_gain",
-            d_idl_i                   : "dyn_idle_i_gain",
-            d_idl_d                   : "dyn_idle_d_gain",
-            d_idl_max                 : "dyn_idle_max_increase",
-            simpl_mode                : "simplified_pids_mode",
-            simpl_mast                : "simplified_master_multiplier",
-            simpl_pi                  : "simplified_pi_gain",
-            simpl_i                   : "simplified_i_gain",
-            simpl_d                   : "simplified_d_gain",
-            simpl_dmr                 : "simplified_dmin_ratio",
-            simpl_ff                  : "simplified_feedforward_gain",
-            simpl_rpr                 : "simplified_roll_pitch_ratio",
-            simpl_d_f                 : "simplified_dterm_filter",
-            simpl_d_f_m               : "simplified_dterm_filter_multiplier",
-            simpl_g_f                 : "simplified_gyro_filter",
-            simpl_g_f_m               : "simplified_gyro_filter_multiplier",
-            m_out_lim                 : "motor_output_limit",
-            thr_lim_t                 : "throttle_limit_type",
-            thr_lim_p                 : "throttle_limit_percent",
-            thr_bst                   : "throttle_boost",
-            thr_bst_cut               : "throttle_boost_cutoff"
+            rc_smoothing              : "rc_smoothing_mode",
+            dyn_idle_min_rpm          : "dynamic_idle_min_rpm",
         },
 
         frameTypes,
@@ -738,9 +708,9 @@ var FlightLogParser = function(logData) {
             case "simplified_pi_gain":
             case "simplified_i_gain":
             case "simplified_d_gain":
-            case "simplified_dmin_ratio":
+            case "simplified_dmax_gain":
             case "simplified_feedforward_gain":
-            case "simplified_roll_pitch_ratio":
+            case "simplified_pitch_d_gain":
             case "simplified_pitch_pi_gain":
             case "simplified_master_multiplier":
 

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -324,6 +324,28 @@ var FlightLogParser = function(logData) {
             rc_smoothing_active_cutoffs_ff_sp_thr:[null,null,null],// RC Smoothing active cutoffs feedforward, setpoint, throttle
             dyn_notch_count: null,                  // Number of dynamic notches 4.3
             rpm_filter_fade_range_hz: null,         // Fade range for RPM notch filters in Hz
+            dyn_idle_p_gain: null,
+            dyn_idle_i_gain: null,
+            dyn_idle_d_gain: null,
+            dyn_idle_max_increase: null,
+            simplified_pids_mode: null,             // Simplified / slider PIDS
+            simplified_pi_gain: null,
+            simplified_i_gain: null,
+            simplified_d_gain: null,
+            simplified_dmin_ratio: null,
+            simplified_feedforward_gain: null,
+            simplified_roll_pitch_ratio: null,
+            simplified_pitch_pi_gain: null,
+            simplified_master_multiplier: null,
+            simplified_dterm_filter: null,
+            simplified_dterm_filter_multiplier: null,
+            simplified_gyro_filter: null,
+            simplified_gyro_filter_multiplier: null,
+            motor_output_limit: null,                // motor output limit
+            throttle_limit_type: null,               // throttle limit
+            throttle_limit_percent: null,
+            throttle_boost: null,                    // throttle boost
+            throttle_boost_cutoff: null,
             unknownHeaders : []                     // Unknown Extra Headers
         },
 
@@ -389,7 +411,39 @@ var FlightLogParser = function(logData) {
             rpm_filter_harmonics      : "gyro_rpm_notch_harmonics",
             rpm_filter_q              : "gyro_rpm_notch_q",
             rpm_filter_min_hz         : "gyro_rpm_notch_min",
-            rpm_filter_lpf_hz         : "rpm_notch_lpf"
+            rpm_filter_lpf_hz         : "rpm_notch_lpf",
+            rc_sm_md                  : "rc_smoothing_mode",
+            rc_sm_ff_hz               : "rc_smoothing_feedforward_hz",
+            rc_sm_sp_hz               : "rc_smoothing_setpoint_hz",
+            rc_sm_af_sp               : "rc_smoothing_auto_factor_setpoint",
+            rc_sm_thr_hz              : "rc_smoothing_throttle_hz",
+            rc_sm_af_thr              : "rc_smoothing_auto_factor_throttle",
+            rc_sm_dbg_ax              : "rc_smoothing_debug_axis",
+            rc_sm_act_cuts            : "rc_smoothing_active_cutoffs_ff_sp_thr",
+            rc_sm_rx_av               : "rc_smoothing_rx_average",
+            vbat_s_comp               : "vbat_sag_compensation",
+            d_idl_m_r                 : "dynamic_idle_min_rpm",
+            d_idl_p                   : "dyn_idle_p_gain",
+            d_idl_i                   : "dyn_idle_i_gain",
+            d_idl_d                   : "dyn_idle_d_gain",
+            d_idl_max                 : "dyn_idle_max_increase",
+            simpl_mode                : "simplified_pids_mode",
+            simpl_mast                : "simplified_master_multiplier",
+            simpl_pi                  : "simplified_pi_gain",
+            simpl_i                   : "simplified_i_gain",
+            simpl_d                   : "simplified_d_gain",
+            simpl_dmr                 : "simplified_dmin_ratio",
+            simpl_ff                  : "simplified_feedforward_gain",
+            simpl_rpr                 : "simplified_roll_pitch_ratio",
+            simpl_d_f                 : "simplified_dterm_filter",
+            simpl_d_f_m               : "simplified_dterm_filter_multiplier",
+            simpl_g_f                 : "simplified_gyro_filter",
+            simpl_g_f_m               : "simplified_gyro_filter_multiplier",
+            m_out_lim                 : "motor_output_limit",
+            thr_lim_t                 : "throttle_limit_type",
+            thr_lim_p                 : "throttle_limit_percent",
+            thr_bst                   : "throttle_boost",
+            thr_bst_cut               : "throttle_boost_cutoff"
         },
 
         frameTypes,
@@ -676,6 +730,31 @@ var FlightLogParser = function(logData) {
             case "motor_pwm_protocol":
             case "gyro_to_use":
             case "dynamic_idle_min_rpm":
+            case "dyn_idle_p_gain":
+            case "dyn_idle_i_gain":
+            case "dyn_idle_d_gain":
+            case "dyn_idle_max_increase":
+            case "simplified_pids_mode":
+            case "simplified_pi_gain":
+            case "simplified_i_gain":
+            case "simplified_d_gain":
+            case "simplified_dmin_ratio":
+            case "simplified_feedforward_gain":
+            case "simplified_roll_pitch_ratio":
+            case "simplified_pitch_pi_gain":
+            case "simplified_master_multiplier":
+
+            case "simplified_dterm_filter":
+            case "simplified_dterm_filter_multiplier":
+            case "simplified_gyro_filter":
+            case "simplified_gyro_filter_multiplier":
+
+            case "motor_output_limit":
+            case "throttle_limit_type":
+            case "throttle_limit_percent":
+            case "throttle_boost":
+            case "throttle_boost_cutoff":
+
             case "motor_poles":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -48,14 +48,14 @@ function GraphConfig(graphConfig) {
                 newGraph = $.extend(
                     // Default values for missing properties:
                     {
-                        height: 1
+                        height: 1,
                     }, 
                     // The old graph
                     graph, 
                     // New fields to replace the old ones:
                     {
-                        fields:[]
-                    }
+                        fields:[],
+                    },
                 ),
                 colorIndex = 0;
             
@@ -536,7 +536,81 @@ GraphConfig.load = function(config) {
                                 return getCurveForMinMaxFieldsZeroOffset(fieldName);
                         }
                         break;
-                }
+                    case 'FF_INTERPOLATED':
+                        switch (fieldName) {
+                            case 'debug[0]': // setpoint Delta
+                            case 'debug[1]': // AccelerationModified
+                            case 'debug[2]': // Acceleration
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 1000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // Clip or Count
+                                return {
+                                    offset: -10,
+                                    power: 1.0,
+                                    inputRange: 10,
+                                    outputRange: 1.0,
+                                };
+                        }
+                        break;
+                    case 'FEEDFORWARD': // replaces FF_INTERPOLATED in 4.3
+                        switch (fieldName) {
+                            case 'debug[0]': // in 4.3 is interpolated setpoint
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: maxDegreesSecond(gyroScaleMargin),
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[1]': // feedforward delta element
+                            case 'debug[2]': // feedforward boost element
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 1000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // rcCommand delta
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 10000,
+                                    outputRange: 1.0,
+                                };
+                        }
+                        break;
+                    case 'FF_LIMIT':
+                    case 'FEEDFORWARD_LIMIT':
+                        return {
+                            offset: 0,
+                            power: 1.0,
+                            inputRange: 300,
+                            outputRange: 1.0,
+                        };
+                    case 'DYN_IDLE':
+                        switch (fieldName) {
+                            case 'debug[0]': // in 4.3 is dyn idle P
+                            case 'debug[1]': // in 4.3 is dyn idle I
+                            case 'debug[2]': // in 4.3 is dyn idle D
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 1000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // in 4.3 and 4.2 is minRPS
+                                return {
+                                    offset: -1000,
+                                    power: 1.0,
+                                    inputRange: 1000,
+                                    outputRange: 1.0,
+                                };
+                        }
+                        break;
+                 }
             }
             // if not found above then
             // Scale and center the field based on the whole-log observed ranges for that field

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -112,17 +112,17 @@ function HeaderDialog(dialog, onSave) {
         {name:'rc_smoothing_active_cutoffs_thr',   type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dyn_notch_count'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'rpm_filter_fade_range_hz'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'dyn_idle_p_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'dyn_idle_i_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'dyn_idle_d_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'dyn_idle_max_increase'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_p_gain'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_i_gain'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_d_gain'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_max_increase'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_pids_mode'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_pi_gain'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_i_gain'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_d_gain'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'simplified_dmin_ratio'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_dmax_gain'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_feedforward_gain'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'simplified_roll_pitch_ratio'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_pitch_d_gain'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_pitch_pi_gain'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_master_multiplier'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'simplified_dterm_filter'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
@@ -799,9 +799,9 @@ function HeaderDialog(dialog, onSave) {
         setParameter('simplified_pi_gain'           , sysConfig.simplified_pi_gain, 0);
         setParameter('simplified_i_gain'            , sysConfig.simplified_i_gain, 0);
         setParameter('simplified_d_gain'            , sysConfig.simplified_d_gain, 0);
-        setParameter('simplified_dmin_ratio'        , sysConfig.simplified_dmin_ratio, 0);
+        setParameter('simplified_dmax_gain'         , sysConfig.simplified_dmax_gain, 0);
         setParameter('simplified_feedforward_gain'  , sysConfig.simplified_feedforward_gain, 0);
-        setParameter('simplified_roll_pitch_ratio'  , sysConfig.simplified_roll_pitch_ratio, 0);
+        setParameter('simplified_pitch_d_gain'      , sysConfig.simplified_pitch_d_gain, 0);
         setParameter('simplified_pitch_pi_gain'     , sysConfig.simplified_pitch_pi_gain, 0);
         setParameter('simplified_master_multiplier' , sysConfig.simplified_master_multiplier, 0);
 

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -521,6 +521,11 @@ function HeaderDialog(dialog, onSave) {
 		}
 
     	renderSelect("pidController", sysConfig.pidController, PID_CONTROLLER_TYPE);
+    	
+        if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0')) {
+            $('.parameter td[name="pidController"]').css('display', 'none');
+        }
+
 
         // Populate the ROLL Pid Faceplate
         populatePID('rollPID'					, sysConfig.rollPID);
@@ -537,8 +542,11 @@ function HeaderDialog(dialog, onSave) {
             populatePID('navrPID'               , sysConfig.navrPID);
         } else {
             $('#pid_baro').hide();
+            $('#pid_baro_header').hide();
             $('#pid_mag').hide();
+            $('#pid_mag_header').hide();
             $('#pid_gps').hide();
+            $('#pid_gps_header').hide();
         }
 
         populatePID('levelPID'					, sysConfig.levelPID);

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -43,6 +43,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'motor_pwm_rate'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'serialrx_provider'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'dterm_filter_type'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+        {name:'dterm_filter2_type'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'pidAtMinThrottle'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'itermThrottleGain'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'3.0.1'},
         {name:'ptermSRateWeight'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'3.0.0'},
@@ -111,6 +112,28 @@ function HeaderDialog(dialog, onSave) {
         {name:'rc_smoothing_active_cutoffs_thr',   type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dyn_notch_count'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'rpm_filter_fade_range_hz'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_p_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_i_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_d_gain'              , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'dyn_idle_max_increase'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_pids_mode'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_pi_gain'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_i_gain'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_d_gain'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_dmin_ratio'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_feedforward_gain'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_roll_pitch_ratio'   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_pitch_pi_gain'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_master_multiplier'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_dterm_filter'       , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_dterm_filter_multiplier' , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_gyro_filter'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'simplified_gyro_filter_multiplier'  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'motor_output_limit'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'throttle_limit_type'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'throttle_limit_percent'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'throttle_boost'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'throttle_boost_cutoff'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -718,6 +741,7 @@ function HeaderDialog(dialog, onSave) {
         renderSelect('dshot_bidir'              ,sysConfig.dshot_bidir, OFF_ON);
 
         renderSelect('dterm_filter_type'		,sysConfig.dterm_filter_type, FILTER_TYPE);
+        renderSelect('dterm_filter2_type'		,sysConfig.dterm_filter2_type, FILTER_TYPE);
         setParameter('ptermSRateWeight'			,sysConfig.ptermSRateWeight,2);
         setParameter('dtermSetpointWeight'		,sysConfig.dtermSetpointWeight,2);
 
@@ -767,6 +791,34 @@ function HeaderDialog(dialog, onSave) {
         setParameter('vbat_sag_compensation'    ,sysConfig.vbat_sag_compensation,0);
 
         setParameter('dynamic_idle_min_rpm'     , sysConfig.dynamic_idle_min_rpm, 0);
+        setParameter('dyn_idle_p_gain'          , sysConfig.dyn_idle_p_gain, 0);
+        setParameter('dyn_idle_i_gain'          , sysConfig.dyn_idle_i_gain, 0);
+        setParameter('dyn_idle_d_gain'          , sysConfig.dyn_idle_d_gain, 0);
+        setParameter('dyn_idle_max_increase'    , sysConfig.dyn_idle_max_increase, 0);
+        renderSelect('simplified_pids_mode'         , sysConfig.simplified_pids_mode, SIMPLIFIED_PIDS_MODE);
+        setParameter('simplified_pi_gain'           , sysConfig.simplified_pi_gain, 0);
+        setParameter('simplified_i_gain'            , sysConfig.simplified_i_gain, 0);
+        setParameter('simplified_d_gain'            , sysConfig.simplified_d_gain, 0);
+        setParameter('simplified_dmin_ratio'        , sysConfig.simplified_dmin_ratio, 0);
+        setParameter('simplified_feedforward_gain'  , sysConfig.simplified_feedforward_gain, 0);
+        setParameter('simplified_roll_pitch_ratio'  , sysConfig.simplified_roll_pitch_ratio, 0);
+        setParameter('simplified_pitch_pi_gain'     , sysConfig.simplified_pitch_pi_gain, 0);
+        setParameter('simplified_master_multiplier' , sysConfig.simplified_master_multiplier, 0);
+
+        renderSelect('simplified_dterm_filter'            , sysConfig.simplified_dterm_filter, OFF_ON);
+        setParameter('simplified_dterm_filter_multiplier' , sysConfig.simplified_dterm_filter_multiplier, 0);
+        renderSelect('simplified_gyro_filter'             , sysConfig.simplified_gyro_filter, OFF_ON);
+        setParameter('simplified_gyro_filter_multiplier'  , sysConfig.simplified_gyro_filter_multiplier, 0);
+
+        setParameter('motor_output_limit'        , sysConfig.motor_output_limit, 0);
+        renderSelect('throttle_limit_type'       , sysConfig.throttle_limit_type, THROTTLE_LIMIT_TYPE);
+        setParameter('throttle_limit_percent'    , sysConfig.throttle_limit_percent, 0);
+        setParameter('throttle_boost'            , sysConfig.throttle_boost, 0);
+        setParameter('throttle_boost_cutoff'     , sysConfig.throttle_boost_cutoff, 0);
+
+        renderSelect('pidAtMinThrottle'         ,sysConfig.pidAtMinThrottle, OFF_ON);
+        renderSelect('use_integrated_yaw'       ,sysConfig.use_integrated_yaw, OFF_ON);
+
 
         // Dynamic filters of Betaflight 4.0
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0') &&
@@ -775,11 +827,10 @@ function HeaderDialog(dialog, onSave) {
             renderSelect('gyro_soft_dyn_type', sysConfig.gyro_soft_type, FILTER_TYPE);
             setParameter('gyro_soft_dyn_min_hz', sysConfig.gyro_lowpass_dyn_hz[0], 0);
             setParameter('gyro_soft_dyn_max_hz', sysConfig.gyro_lowpass_dyn_hz[1], 0);
-            $('.parameter td[name="gyro_soft_dyn_type"]').parent().css('display', '');
             $('.parameter td[name="gyro_soft_type"]').css('display', 'none');
             $('.parameter td[name="gyro_lowpass_hz"]').css('display', 'none');
         } else {
-            $('.parameter td[name="gyro_soft_dyn_type"]').parent().css('display', 'none');
+            $('.parameter td[name="gyro_soft_dyn_type"]').css('display', 'none');
             $('.parameter td[name="gyro_soft_dyn_min_hz"]').css('display', 'none');
             $('.parameter td[name="gyro_soft_dyn_max_hz"]').css('display', 'none');
         }
@@ -787,16 +838,14 @@ function HeaderDialog(dialog, onSave) {
         if(activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.0.0') &&
                 (sysConfig.dterm_lpf_dyn_hz[0] != null) && (sysConfig.dterm_lpf_dyn_hz[0] > 0) &&
                 (sysConfig.dterm_lpf_dyn_hz[1] > sysConfig.dterm_lpf_dyn_hz[0])) {
-            renderSelect('dterm_filter2_type', sysConfig.dterm_filter2_type, FILTER_TYPE);
             renderSelect('dterm_dyn_type', sysConfig.dterm_filter_type, FILTER_TYPE);
             setParameter('dterm_lpf_dyn_min_hz', sysConfig.dterm_lpf_dyn_hz[0], 0);
             setParameter('dterm_lpf_dyn_max_hz', sysConfig.dterm_lpf_dyn_hz[1], 0);
-            $('.parameter td[name="dterm_dyn_type"]').parent().css('display', '');
             $('.parameter td[name="dterm_filter_type"]').css('display', 'none');
             $('.parameter td[name="dterm_lpf_hz"]').css('display', 'none');
         } else {
-            $('.parameter td[name="dterm_filter2_type"]').css('display', 'none');
-            $('.parameter td[name="dterm_dyn_type"]').parent().css('display', 'none');
+//            $('.parameter td[name="dterm_dyn_type"]').parent().css('display', 'none');
+            $('.parameter td[name="dterm_dyn_type"]').css('display', 'none');
             $('.parameter td[name="dterm_lpf_dyn_min_hz"]').css('display', 'none');
             $('.parameter td[name="dterm_lpf_dyn_max_hz"]').css('display', 'none');
         }
@@ -819,8 +868,6 @@ function HeaderDialog(dialog, onSave) {
         setCheckbox('gyro_cal_on_first_arm'		,sysConfig.gyro_cal_on_first_arm);
         setCheckbox('vbat_pid_compensation'		,sysConfig.vbat_pid_compensation);
         setCheckbox('rc_smoothing'				,sysConfig.rc_smoothing);
-        setCheckbox('pidAtMinThrottle'			,sysConfig.pidAtMinThrottle);
-        setCheckbox('use_integrated_yaw'        ,sysConfig.use_integrated_yaw);
 
         /* Selected Fields */
         if(activeSysConfig.firmwareType === FIRMWARE_TYPE_BETAFLIGHT && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -110,6 +110,7 @@ function HeaderDialog(dialog, onSave) {
         {name:'rc_smoothing_active_cutoffs_sp',    type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'rc_smoothing_active_cutoffs_thr',   type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dyn_notch_count'               , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
+        {name:'rpm_filter_fade_range_hz'      , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
     ];
 
 	function isParameterValid(name) {
@@ -637,6 +638,7 @@ function HeaderDialog(dialog, onSave) {
         setParameter('gyro_rpm_notch_harmonics', sysConfig.gyro_rpm_notch_harmonics  , 0);
         setParameter('gyro_rpm_notch_q'        , sysConfig.gyro_rpm_notch_q          , 0);
         setParameter('gyro_rpm_notch_min'      , sysConfig.gyro_rpm_notch_min        , 0);
+        setParameter('rpm_filter_fade_range_hz', sysConfig.rpm_filter_fade_range_hz  , 0); 
         setParameter('rpm_notch_lpf'           , sysConfig.rpm_notch_lpf             , 0);
 
         setParameter('dterm_rpm_notch_harmonics', sysConfig.dterm_rpm_notch_harmonics, 0);


### PR DESCRIPTION
Provides full support for all the new field names in 4.3 in the Log Header information screen.

Includes the changes from #535 and #521, which I will close now, as well as supporting the changes made in betaflight PR's [10978 lowpass field names](https://github.com/betaflight/betaflight/pull/10978) and [10856 rpm filter names](https://github.com/betaflight/betaflight/pull/10856) and others.

Fixes an issue with incorrect RPM readings in the Dynamic Idle debug, which were 4 times lower than they should have been.

Tested and ready to merge.

Very useful for anyone working with 4.3 logs after all the changes we've made.

Extensive re-arrangement of fields and CSS changes as well.  The most useful tuning fields are at the top. Fields are entered, and the scrolling widgets are removed.

Screenshot:

![Screen Shot 2021-10-31 at 18 12 57](https://user-images.githubusercontent.com/11737748/139573183-3a6c93e7-a008-41b3-9950-327d849127e2.jpg)


