### PR TITLE
zoom resolution of 1, not 10

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,10 +35,10 @@ function BlackboxLogViewer() {
         PLAYBACK_MAX_RATE = 300,
         PLAYBACK_DEFAULT_RATE = 100,
         PLAYBACK_RATE_STEP = 5,
-        GRAPH_MIN_ZOOM = 10,
+        GRAPH_MIN_ZOOM = 1,
         GRAPH_MAX_ZOOM = 1000,
         GRAPH_DEFAULT_ZOOM = 100,
-        GRAPH_ZOOM_STEP = 10;
+        GRAPH_ZOOM_STEP = 1;
     
     var
         graphState = GRAPH_STATE_PAUSED,


### PR DESCRIPTION
Quick little PR that changes the zoom (time scaling) steps to be units of 1, rather than 10, with a minimum of 10.

Currently a minimum of 10 allows a maximum of 10s of data in a screen.  Minimum of 1 allows up to 100s of data, which is a bit long to be useful, but does give a broad overview of a flight.  

Steps of 1 allow zooming to whatever amount you like.  With a fast computer this can be done very smoothly, although with a lot of data scrolling is a bit slow.

The downside is that the zoom isn't in neat steps of 10 any more.

It might be nice to have a 'preference' for the size of step, and minimum value, but I don't know how to code that.

I personally find this very useful.