### PR TITLE
Show Dmax in log header properly for 4.3

### DIFF
--- a/css/header_dialog.css
+++ b/css/header_dialog.css
@@ -290,7 +290,7 @@ select {
 .header-dialog table td,
 .header-dialog .pid_titlebar th {
     padding: 1px;
-    width: 20%;
+    width: 15%;
     border-right: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
 }

--- a/index.html
+++ b/index.html
@@ -695,6 +695,9 @@
                                                 <th name="Integral">
                                                     <label>Integral</label>
                                                 </th>
+                                                <th name="D_Max">
+                                                    <label>D_Max</label>
+                                                </th>
                                                 <th name="Derivative">
                                                     <label>Derivative</label>
                                                 </th>
@@ -715,6 +718,9 @@
                                                     <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
+                                                    <input type="text" name="d_min_roll" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
                                                     <input type="text" name="f" step="1" min="0" max="255" />
                                                 </td>
                                             </tr>
@@ -729,6 +735,9 @@
                                                 </td>
                                                 <td>
                                                     <input type="text" name="d" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
+                                                    <input type="text" name="d_min_pitch" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
                                                     <input type="text" name="f" step="1" min="0" max="255" />
@@ -747,6 +756,9 @@
                                                     <input type="text" name="d" step="1" min="0" max="255" />
                                                 </td>
                                                 <td>
+                                                    <input type="text" name="d_min_yaw" step="1" min="0" max="255" />
+                                                </td>
+                                                <td>
                                                     <input type="text" name="f" step="1" min="0" max="255" />
                                                 </td>
                                             </tr>
@@ -759,6 +771,7 @@
                                                 </tr>
                                             </thead>
                                         </table>
+
                                         <table id="pid_baro" class="pid_tuning">
                                             <tr class="altPID">
                                                 <!-- 3 -->
@@ -774,6 +787,7 @@
                                                 </td>
                                                 <td></td>
                                             </tr>
+
                                             <tr class="velPID">
                                                 <!-- 9 -->
                                                 <td>VEL</td>
@@ -860,38 +874,6 @@
                                             </tr>
                                         </table>
 
-                                        <table id="d_min" class="parameter cf">
-                                            <thead>
-                                                <tr>
-                                                    <th colspan="5">D Min</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <tr>
-                                                    <td name="d_min_roll" class="bf-only">
-                                                        <label>Roll</label>
-                                                        <input type="text" step="1" min="0" max="100" />
-                                                    </td>
-                                                    <td name="d_min_pitch" class="bf-only">
-                                                        <label>Pitch</label>
-                                                        <input type="text" step="1" min="0" max="100" />
-                                                    </td>
-                                                    <td name="d_min_yaw" class="bf-only">
-                                                        <label>Yaw</label>
-                                                        <input type="text" step="1" min="0" max="100" />
-                                                    </td>
-                                                    <td name="d_min_gain" class="bf-only">
-                                                        <label>Gain</label>
-                                                        <input type="text" step="1" min="0" max="100" />
-                                                    </td>
-                                                    <td name="d_min_advance" class="bf-only">
-                                                        <label>Advance</label>
-                                                        <input type="text" step="1" min="0" max="200" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
                                         <table class="parameter cf">
                                             <thead>
                                                 <tr>
@@ -949,30 +931,6 @@
                                         <table class="parameter cf">
                                             <thead>
                                                 <tr>
-                                                    <th colspan="5">TPA and Airmode</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <tr>
-                                                    <td name="dynThrPID">
-                                                        <label>TPA amount</label>
-                                                        <input type="text" step="0.01" min="0" max="1.00" />
-                                                    </td>
-                                                    <td name="tpa-breakpoint">
-                                                        <label>TPA Breakpoint</label>
-                                                        <input type="text" step="10" min="1000" max="2000" />
-                                                    </td>
-                                                    <td name="airmode_activate_throttle" class="bf-only">
-                                                        <label>Airmode Activate</label>
-                                                        <input type="text" step="10" min="1000" max="2000" />
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
-
-                                        <table class="parameter cf">
-                                            <thead>
-                                                <tr>
                                                     <th scope="row" colspan="6">Feedforward</th>
                                                 </tr>
                                             </thead>
@@ -1003,6 +961,50 @@
                                                     <td name="feedforwardMaxRate" class="bf-only">
                                                         <label>MaxRate</label>
                                                         <input type="text" step="0" min="0" max="100" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table id="d_min" class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th colspan="5">D Min</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="d_min_gain" class="bf-only">
+                                                        <label>Gain</label>
+                                                        <input type="text" step="1" min="0" max="100" />
+                                                    </td>
+                                                    <td name="d_min_advance" class="bf-only">
+                                                        <label>Advance</label>
+                                                        <input type="text" step="1" min="0" max="200" />
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+
+                                        <table class="parameter cf">
+                                            <thead>
+                                                <tr>
+                                                    <th colspan="5">TPA and Airmode</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td name="dynThrPID">
+                                                        <label>TPA amount</label>
+                                                        <input type="text" step="0.01" min="0" max="1.00" />
+                                                    </td>
+                                                    <td name="tpa-breakpoint">
+                                                        <label>TPA Breakpoint</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
+                                                    </td>
+                                                    <td name="airmode_activate_throttle" class="bf-only">
+                                                        <label>Airmode Activate</label>
+                                                        <input type="text" step="10" min="1000" max="2000" />
                                                     </td>
                                                 </tr>
                                             </tbody>

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -806,13 +806,13 @@ var FlightLogParser = function(logData) {
                     var expoParams = parseCommaSeparatedString(fieldValue);
                     that.sysConfig.superExpoFactor    = expoParams[0];
                     that.sysConfig.superExpoFactorYaw = expoParams[1];
-
                 } else {
                     that.sysConfig.superExpoFactor = parseInt(fieldValue, 10);
                 }
             break;
 
             /* CSV packed values */
+
             case "rates":
             case "rate_limits":
             case "rollPID":
@@ -831,24 +831,30 @@ var FlightLogParser = function(logData) {
             case "rc_smoothing_active_cutoffs_ff_sp_thr":
             case "gyro_lowpass_dyn_hz":
             case "dterm_lpf_dyn_hz":
-            case "d_min":
                 that.sysConfig[fieldName] = parseCommaSeparatedString(fieldValue);
             break;
             case "magPID":
                 that.sysConfig.magPID = parseCommaSeparatedString(fieldValue,3); //[parseInt(fieldValue, 10), null, null];
             break;
+            case "d_min":
+                // Add Dmin values as Derivative numbers to PID array
+                 var dMinValues = parseCommaSeparatedString(fieldValue);
+                 that.sysConfig["rollPID"].push(dMinValues[0]);
+                 that.sysConfig["pitchPID"].push(dMinValues[1]);
+                 that.sysConfig["yawPID"].push(dMinValues[2]);
+            break;
             case "ff_weight":
-                // Add it to the end of the rollPID, pitchPID and yawPID
+                // Add feedforward values to the PID array
                 var ffValues = parseCommaSeparatedString(fieldValue);
                 that.sysConfig["rollPID"].push(ffValues[0]);
                 that.sysConfig["pitchPID"].push(ffValues[1]);
                 that.sysConfig["yawPID"].push(ffValues[2]);
             break;
+
             /* End of CSV packed values */
 
             case "vbatcellvoltage":
                 var vbatcellvoltageParams = parseCommaSeparatedString(fieldValue);
-
                 that.sysConfig.vbatmincellvoltage = vbatcellvoltageParams[0];
                 that.sysConfig.vbatwarningcellvoltage = vbatcellvoltageParams[1];
                 that.sysConfig.vbatmaxcellvoltage = vbatcellvoltageParams[2];
@@ -856,14 +862,12 @@ var FlightLogParser = function(logData) {
             case "currentMeter":
             case "currentSensor":
                 var currentMeterParams = parseCommaSeparatedString(fieldValue);
-
                 that.sysConfig.currentMeterOffset = currentMeterParams[0];
                 that.sysConfig.currentMeterScale = currentMeterParams[1];
             break;
             case "gyro.scale":
             case "gyro_scale":
                     that.sysConfig.gyroScale = hexToFloat(fieldValue);
-
                     /* Baseflight uses a gyroScale that'll give radians per microsecond as output, whereas Cleanflight produces degrees
                      * per second and leaves the conversion to radians per us to the IMU. Let's just convert Cleanflight's scale to
                      * match Baseflight so we can use Baseflight's IMU for both: */

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -235,7 +235,7 @@ function HeaderDialog(dialog, onSave) {
 					case 0:
 						if(data[i]!=null) {
 								$(this).val((data[i]).toFixed(0));
-								$(this).attr('decPl', 1);
+								$(this).attr('decPl', 0);
 								$(this).removeClass('missing');
 							} else {
 								$(this).addClass('missing');
@@ -245,7 +245,7 @@ function HeaderDialog(dialog, onSave) {
 					case 1:
 						if(data[i]!=null) {
 								$(this).val((data[i]).toFixed(0));
-								$(this).attr('decPl', 3);
+								$(this).attr('decPl', 0);
 								$(this).removeClass('missing');
 							} else {
 								$(this).addClass('missing');
@@ -265,7 +265,18 @@ function HeaderDialog(dialog, onSave) {
                     case 3:
                         if(data[i]!=null) {
                             $(this).val(data[i].toFixed(0));
-                            $(this).attr('decPl', 2);
+                            $(this).attr('decPl', 0);
+                            $(this).removeClass('missing');
+                        } else {
+                            $(this).val('');
+                            $(this).addClass('missing');
+                        }
+                        i++;
+                        break;
+                    case 4:
+                        if(data[i]!=null) {
+                            $(this).val(data[i].toFixed(0));
+                            $(this).attr('decPl', 0);
                             $(this).removeClass('missing');
                         } else {
                             $(this).val('');


### PR DESCRIPTION
Puts a Dmax column in the PID display section of the log header to show values like in Configurator.  Thanks to @Asizon for assistance and advice.

Added case/break to fix and issue CSV values were not being parsed properly.  If there is a neater way to do it, please let me know.

Now we don't need separate Dmin rows, we can rearrange the D parameters.  This is how the PID box now looks:

![Screen Shot 2021-12-27 at 16 00 52](https://user-images.githubusercontent.com/11737748/147436203-84364f2a-7760-49ae-82dc-765762f0eed8.jpg)

