### PR TITLE
fix name of setpoint trace in feedforward debug

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -638,7 +638,7 @@ function FlightLogFieldPresenter() {
             if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
                     'debug[all]':'Feedforward [roll]',
-                    'debug[0]':'Setpoint, interpolated [roll]',
+                    'debug[0]':'Setpoint, un-smoothed [roll]',
                     'debug[1]':'Delta, smoothed [roll]',
                     'debug[2]':'Boost, smoothed [roll]',
                     'debug[3]':'rcCommand Delta [roll]',


### PR DESCRIPTION
Simple name change.

The setpoint trace in the feedforward debug currently shows the un-smoothed setpoint, for use when evaluating RC smoothing delays, and feedforward delays.

It isn't an interpolated setpoint trace, it is now an un-smoothed setpoint trace.

This only applies to firmware 4.3 (since a PR about 4 months ago), so no version control is needed.