### PR TITLE
fir header dialog information into min width

### DIFF
--- a/css/header_dialog.css
+++ b/css/header_dialog.css
@@ -100,6 +100,11 @@ select {
     font-family: 'open_sanssemibold', Arial, serif;
 }
 
+.h5 {
+    color: red;
+    margin: 0;
+}
+
 /* Spacers */
 .spacer {
     padding-left: 7px;
@@ -125,14 +130,14 @@ select {
 
 /* space around each div*/
 .spacer_left {
-    padding-left: 15px;
+    padding-left: 0px;
     float: left;
-    width: calc(100% - 15px);
+    width: calc(100%);
 }
 
 .spacer_right {
-    padding-right: 15px;
-    width: calc(100% - 15px);
+    padding-right: 5px;
+    width: calc(100% - 5px);
     float: left;
 }
 
@@ -176,7 +181,7 @@ select {
 
 .header-dialog .modal-dialog {
     width:75%;
-    min-width:954px;
+    min-width:850px;
 }
 
 .header-dialog .cf th {

--- a/index.html
+++ b/index.html
@@ -627,7 +627,7 @@
                     </button>
                     <h4 class="modal-title">Configure graphs</h4>
                 </div>
-                <div class="modal-body">
+                <div class="modal-body" padding-left:5px;>
                     <div class="btn-group">
                         <button type="button" class="btn btn-primary dropdown-toggle config-graphs-add" data-toggle="dropdown" aria-expanded="false">
                             <span class="glyphicon glyphicon-plus"></span> Add graph
@@ -655,14 +655,11 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close" data-toggle="tooltip" title="Close without saving changes">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close" data-toggle="tooltip" title="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
-                    <h4 class="modal-title">Log Header Information</h4>
-                    <h5 class="modal-title-revision"></h5>
-                    <h5 class="modal-title-board-info"></h5>
-                    <h5 class="modal-title-date"></h5>
                     <h5 class="modal-title-craft"></h5>
+                    <h5 class="modal-title-revision"></h5>
                 </div>
                 <div class="modal-body">
                     <form name="header-information" id="pid-tuning">
@@ -690,19 +687,19 @@
                                                     <label>&nbsp</label>
                                                 </th>
                                                 <th name="Proportional">
-                                                    <label>Proportional</label>
+                                                    <label>P</label>
                                                 </th>
                                                 <th name="Integral">
-                                                    <label>Integral</label>
+                                                    <label>I</label>
                                                 </th>
                                                 <th name="D_Max">
                                                     <label>D_Max</label>
                                                 </th>
                                                 <th name="Derivative">
-                                                    <label>Derivative</label>
+                                                    <label>D</label>
                                                 </th>
                                                 <th name="Feedforward">
-                                                    <label>Feedforward</label>
+                                                    <label>FF</label>
                                                 </th>
                                             </tr>
                                             <tr class="rollPID">
@@ -941,7 +938,7 @@
                                                         <input type="text" step="0.01" min="0" max="999" />
                                                     </td>
                                                     <td name="feedforwardAveraging" class="bf-only">
-                                                        <label>Averaging</label>
+                                                        <label>Avgerage</label>
                                                         <select>
                                                             <!~~ list generated here ~~>
                                                         </select>
@@ -1634,7 +1631,7 @@
                                                         <input type="text" step="0.01" min="0" max="999.00" />
                                                     </td>
                                                     <td name="gyro_notch_cutoff">
-                                                        <label>Notch 1 Cutoff</label>
+                                                        <label>Notch1 Cutoff</label>
                                                         <input type="text" step="0.1" min="0" max="999.00" />
                                                     </td>
                                                     <td name='gyro_notch_hz_2'>

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -511,10 +511,10 @@ function HeaderDialog(dialog, onSave) {
 
       // Update the log header
 
-      $('h5.modal-title-revision').text((sysConfig['Firmware revision'] != null) ? ` Rev : ${sysConfig['Firmware revision']}` : '');
+      $('h5.modal-title-craft').text((sysConfig['Craft name'] != null) ? ` ${sysConfig['Craft name']}` : '');
+//      $('h5.modal-title-date').text((sysConfig['Firmware date'] != null) ? ` ${sysConfig['Firmware date']}` : '');
+      $('h5.modal-title-revision').text(((sysConfig['Firmware revision'] != null) ? ` ${sysConfig['Firmware revision']}` : '')  + ' - ' + ((sysConfig['Firmware date'] != null) ? ` ${sysConfig['Firmware date']}` : ''));
       $('h5.modal-title-board-info').text((sysConfig['Board information'] != null) ? ` Board : ${sysConfig['Board information']}` : '');
-      $('h5.modal-title-date').text((sysConfig['Firmware date'] != null) ? ` Date : ${sysConfig['Firmware date']}` : '');
-      $('h5.modal-title-craft').text((sysConfig['Craft name'] != null) ? ` Name : ${sysConfig['Craft name']}` : '');
 
 		switch(sysConfig.firmwareType) {
 			case FIRMWARE_TYPE_BETAFLIGHT:

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,7 @@ const NEW_WINDOW_HEIGHT  = 760;
 
 // these values set the minimum resize dimensions of a secondary window
 // minimum resize dimensions of the initial window are set in package.json
-const INNER_BOUNDS_WIDTH  = 740;
+const INNER_BOUNDS_WIDTH  = 930;
 const INNER_BOUNDS_HEIGHT = 480;
 
 const INITIAL_APP_PAGE = "index.html";

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "id": "main",
     "show": true,
     "icon": "images/bf_icon_128.png",
-    "min_width": 740,
+    "min_width": 930,
     "min_height": 480
   },
   "repository": {


### PR DESCRIPTION
fixes #568

@McGiverGim expressed concern that at minimum window width, not all the information in the header dialog was visible.

I rearranged things a bit - margins, rearranging the header, that sort of thing, and it all now fits quite neatly.

The minimum window width is now 930px, a meaningful increase over the previous minimum of 740px.  The minimum width could be as small as 900px and still look OK (see below), but at 930px the header dialog sits symmetrically above the main graphical area and looks good.  It should still fit into most computer screens at 930px.

Here is an image showing how it looks at 930px width.

![redraft min window](https://user-images.githubusercontent.com/11737748/155995163-ed43e81d-5add-4666-a3d3-c80addb0c386.jpg)

This is the previous appearance at about the same width.

![same size previously](https://user-images.githubusercontent.com/11737748/155995756-2b787af1-a997-4da3-893d-bec6173616ff.jpg)

This is the new appearance but with a min-width of 900px (this is not the value in the PR, but I included it here in case you think it might be better like that).  

We don't really need all the white space at the top but I couldn't figure out how to get rid of it.  

![moin width 900](https://user-images.githubusercontent.com/11737748/155996362-7b77be5d-ddc1-4e54-b256-de0846a826f2.jpg)
