### PR TITLE
Update  GPS Rescue Altitude, Heading and Tracking, and Altitude, Baro and RTH debugs

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -626,6 +626,27 @@ function FlightLogFieldPresenter() {
             'debug[2]':'Frequency Offset',
             'debug[3]':'Phase Shift',
         },
+        'GPS_RESCUE_VELOCITY' : {
+            'debug[all]':'GPS Rescue Velocity',
+            'debug[0]':'Velocity P',
+            'debug[1]':'Velocity D',
+            'debug[2]':'Velocity to Home',
+            'debug[3]':'Target Velocity',
+        },
+        'GPS_RESCUE_HEADING' : {
+            'debug[all]':'GPS Rescue Heading',
+            'debug[0]':'Rescue Yaw',
+            'debug[1]':'Rescue Roll',
+            'debug[2]':'Attitude',
+            'debug[3]':'Angle to home',
+        },
+        'GPS_RESCUE_TRACKING' : {
+            'debug[all]':'GPS Rescue Tracking',
+            'debug[0]':'Velocity to home',
+            'debug[1]':'Target velocity',
+            'debug[2]':'Altitude',
+            'debug[3]':'Target altitude',
+        },
     };
 
     let DEBUG_FRIENDLY_FIELD_NAMES = null;
@@ -635,7 +656,15 @@ function FlightLogFieldPresenter() {
         DEBUG_FRIENDLY_FIELD_NAMES = {...DEBUG_FRIENDLY_FIELD_NAMES_INITIAL};
 
         if (firmwareType === FIRMWARE_TYPE_BETAFLIGHT) {
-            if (semver.gte(firmwareVersion, '4.3.0')) {
+            if (semver.gte(firmwareVersion, '4.4.0')) {
+                DEBUG_FRIENDLY_FIELD_NAMES.RTH = {
+                    'debug[all]':'RTH Rescue codes',
+                    'debug[0]':'Pitch angle, deg',
+                    'debug[1]':'Rescue Phase',
+                    'debug[2]':'Failure code',
+                    'debug[3]':'Failure timers',
+                };
+            } else if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
                     'debug[all]':'Feedforward [roll]',
                     'debug[0]':'Setpoint, un-smoothed [roll]',
@@ -677,6 +706,13 @@ function FlightLogFieldPresenter() {
                     'debug[1]':'Notch 2 Center Freq [dbg-axis]',
                     'debug[2]':'Notch 3 Center Freq [dbg-axis]',
                     'debug[3]':'Gyro Pre Dyn Notch [dbg-axis]',
+                };
+                DEBUG_FRIENDLY_FIELD_NAMES.GPS_RESCUE_THROTTLE_PID = {
+                    'debug[all]':'GPS Rescue Altitude',
+                    'debug[0]':'Throttle P',
+                    'debug[1]':'Throttle D',
+                    'debug[2]':'Altitude',
+                    'debug[3]':'Target Altitude',
                 };
             } else if (semver.gte(firmwareVersion, '4.2.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FF_INTERPOLATED = {
@@ -1002,7 +1038,7 @@ function FlightLogFieldPresenter() {
                     }
                 case 'RTH':
                     switch(fieldName) {
-                        case 'debug[1]':
+                        case 'debug[0]': // pitch angle +/-4000 means +/- 40 deg
                             return (value / 100).toFixed(1) + 'deg';
                         default:
                             return value.toFixed(0);
@@ -1058,8 +1094,6 @@ function FlightLogFieldPresenter() {
                         default:
                             return value.toFixed(0) + "Hz";
                     }
-                case 'GPS_RESCUE_THROTTLE_PID':
-                        return value.toFixed(0);
                 case 'DYN_IDLE':
                     switch (fieldName) {
                         case 'debug[3]': // minRPS
@@ -1127,6 +1161,47 @@ function FlightLogFieldPresenter() {
                         // debug 3 = Pphase shift in us
                         default:
                             return value.toFixed(0) + 'us';
+                    }
+                case 'GPS_RESCUE_THROTTLE_PID':
+                    switch (fieldName) {
+                        case 'debug[0]': // Throttle P added uS
+                        case 'debug[1]': // Throttle D added * uS
+                            return value.toFixed(0) + 'uS';
+                        case 'debug[2]': // current altitude in m
+                        case 'debug[3]': // TARGET altitude in m
+                            return (value / 100).toFixed(1) + 'm';
+                        default:
+                            return value.toFixed(0);
+                    }
+                case 'GPS_RESCUE_VELOCITY':
+                    switch (fieldName) {
+                        case 'debug[0]': // Pitch P degrees * 100
+                        case 'debug[1]': // Pitch D degrees * 100
+                            return (value / 100).toFixed(1) + 'deg';
+                        case 'debug[2]': // velocity to home cm/s
+                        case 'debug[3]': // velocity target cm/s
+                            return (value / 100).toFixed(1) + 'm/s';
+                    }
+                case 'GPS_RESCUE_HEADING':
+                    switch (fieldName) {
+                        case 'debug[0]': // Rescue yaw rate deg/s * 10 up to +/- 90 
+                            return (value / 10).toFixed(1) + 'deg/s';
+                        case 'debug[1]': // Rescue roll deg * 100 up to +/- 20 deg
+                            return (value / 100).toFixed(1) + 'deg';
+                        case 'debug[2]': // Attitude in degrees * 10
+                        case 'debug[3]': // Angle to home in degrees * 10
+                            return (value / 10).toFixed(1) + 'deg';
+                    }
+                case 'GPS_RESCUE_TRACKING':
+                    switch (fieldName) {
+                        case 'debug[0]': // velocity to home cm/s
+                        case 'debug[1]': // velocity target cm/s
+                            return (value / 100).toFixed(1) + 'm/s';
+                        case 'debug[2]': // altitude cm
+                        case 'debug[3]': // altitude target cm
+                            return (value / 100).toFixed(1) + 'm';
+                        default:
+                            return value.toFixed(0);
                     }
             }
             return value.toFixed(0);

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -664,6 +664,13 @@ function FlightLogFieldPresenter() {
                     'debug[2]':'Failure code',
                     'debug[3]':'Failure timers',
                 };
+                DEBUG_FRIENDLY_FIELD_NAMES.GPS_RESCUE_THROTTLE_PID = {
+                    'debug[all]':'GPS Rescue throttle PIDs',
+                    'debug[0]':'Throttle P',
+                    'debug[1]':'Throttle D',
+                    'debug[2]':'Altitude',
+                    'debug[3]':'Target altitude',
+                };
             } else if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
                     'debug[all]':'Feedforward [roll]',
@@ -1181,6 +1188,8 @@ function FlightLogFieldPresenter() {
                         case 'debug[2]': // velocity to home cm/s
                         case 'debug[3]': // velocity target cm/s
                             return (value / 100).toFixed(1) + 'm/s';
+                        default:
+                            return value.toFixed(0);
                     }
                 case 'GPS_RESCUE_HEADING':
                     switch (fieldName) {
@@ -1191,6 +1200,8 @@ function FlightLogFieldPresenter() {
                         case 'debug[2]': // Attitude in degrees * 10
                         case 'debug[3]': // Angle to home in degrees * 10
                             return (value / 10).toFixed(1) + 'deg';
+                        default:
+                            return value.toFixed(0);
                     }
                 case 'GPS_RESCUE_TRACKING':
                     switch (fieldName) {

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -737,6 +737,171 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                             }
+                    case 'GPS_RESCUE_THROTTLE_PID':
+                        switch (fieldName) {
+                            case 'debug[0]': // Throttle P uS added
+                            case 'debug[1]': // Throttle D uS added
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 200,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[2]': // Altitude
+                            case 'debug[3]': // Target Altitude
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 5000,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'GPS_RESCUE_VELOCITY':
+                        switch (fieldName) {
+                            case 'debug[0]': // Pitch P deg * 100
+                            case 'debug[1]': // Pitch D deg * 100
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 2000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[2]': // Velocity in cm/s
+                            case 'debug[3]': // Velocity to home in cm/s
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 500,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'GPS_RESCUE_HEADING':
+                        switch (fieldName) {
+                            case 'debug[0]': // Rescue yaw rate deg/s * 10 up to +/- 90 
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 1000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[1]': // Rescue roll deg * 100 up to +/- 20 deg
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 10000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[2]': // Yaw attitude * 10
+                            case 'debug[3]': // Angle to home * 10
+                                return {
+                                    offset: -1800,
+                                    power: 1.0,
+                                    inputRange: 1800,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'RTH':
+                        switch (fieldName) {
+                            case 'debug[0]': // Pitch angle, deg * 100
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 4000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[1]': // Rescue Phase
+                            case 'debug[2]': // Failure code
+                                return {
+                                    offset: -10,
+                                    power: 1.0,
+                                    inputRange: 10,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // Failure counters coded
+                                return {
+                                    offset: -2000,
+                                    power: 1.0,
+                                    inputRange: 2000,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'GPS_RESCUE_TRACKING':
+                        switch (fieldName) {
+                            case 'debug[0]': // velocity to home cm/s
+                            case 'debug[1]': // target velocity cm/s
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 500,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[2]': // altitude m
+                            case 'debug[3]': // Target altitude m
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 5000,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'ALTITUDE':
+                        switch (fieldName) {
+                            case 'debug[0]': // GPS Trust
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 200,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[1]': // Baro Alt
+                            case 'debug[2]': // GPS Alt
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 5000,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // Vario
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 500,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
+                    case 'BARO':
+                        switch (fieldName) {
+                            case 'debug[0]': // Baro state 0-10
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 20,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[1]': // Baro Temp
+                            case 'debug[2]': // Baro Raw
+                            case 'debug[3]': // Baro smoothed
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 2000,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
                     }
             }
             // if not found above then
@@ -788,6 +953,12 @@ GraphConfig.load = function(config) {
         }
         if (!flightLog.isFieldDisabled().ACC) {
             EXAMPLE_GRAPHS.push({label: "Accelerometers",fields: ["accSmooth[all]"]});
+        }
+        if (!flightLog.isFieldDisabled().HEADING) {
+            EXAMPLE_GRAPHS.push({label: "Heading",fields: ["heading[all]"]});
+        }
+        if (!flightLog.isFieldDisabled().MAGNETOMETER) {
+            EXAMPLE_GRAPHS.push({label: "Compass",fields: ["magADC[all]"]});
         }
         if (!flightLog.isFieldDisabled().DEBUG) {
             EXAMPLE_GRAPHS.push({label: "Debug",fields: ["debug[all]"]});


### PR DESCRIPTION
Updates or adds the following debug headers and graph configs tp display the relevant fields properly in 4.4

Closed #592 and #572 which were never merged but did the same things.

- GPS Rescue Altitude
- GPS Rescue Heading
- GPS Rescue Tracking
- GPS Rescue Throttle PID
- RTH
- Altitude
- Barometer

Also dds Heading and Magnetometer options to `Add Graph` in the `Graph Setup` dialog so that people checking out their GPS or Mag can more readily load these options.

Would be grateful if this could be merged asap so that people can readily view the GPS Rescue debugs