### PR TITLE
zoom control 200px wide to increase accuracy

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -978,7 +978,7 @@ html.has-log .video-top-controls {
 
 .playback-rate-control,
 .graph-zoom-control  {
-    width: 130px;
+    width: 200px;
     margin-right: 13px;
     margin-top: 6px;
 }


### PR DESCRIPTION
While working with GPS Rescue graphs, it's great to zoom in a lot, eg 1%, 2%, 3%.

With the zoom element width of 130px, it was not possible (on my mac, anyway) to get 2% zoom.

By increasing the element width in CSS to 200px, it's a lot easier.