### PR TITLE
restore lost debug names, update DOP graphics scaling

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -348,6 +348,7 @@ let
         "GPS_RESCUE_TRACKING",
         "ATTITUDE",
         "VTX_MSP",
+        "GPS_DOP",
     ]),
 
     SUPER_EXPO_YAW = makeReadOnly([
@@ -545,20 +546,7 @@ function adjustFieldDefsList(firmwareType, firmwareVersion) {
             DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_INTERPOLATED'), 1);
         }
         if (semver.gte(firmwareVersion, '4.3.0')) {
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_INTERPOLATED'), 1, 'FEEDFORWARD');
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_LIMIT'),        1, 'FEEDFORWARD_LIMIT');
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('DYN_IDLE'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FFT'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FFT_TIME'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FFT_FREQ'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_RESCUE_THROTTLE_PID'), 1);
-        }
-        if (semver.gte(firmwareVersion, '4.4.0')) {
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('BARO'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('RTH'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_RESCUE_THROTTLE_PID'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('VTX_MSP'), 1);
-            DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_DOP'), 1);
+            DEBUG_MODE.splice(DEBUG_MODE.indexOf('FF_LIMIT'),        1, 'FEEDFORWARD_LIMIT', 'FEEDFORWARD');
         }
 
         DEBUG_MODE = makeReadOnly(DEBUG_MODE);

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -669,6 +669,20 @@ function FlightLogFieldPresenter() {
             'debug[2]':'Setpoint Roll',
             'debug[3]':'Setpoint Pitch',
         },
+        'VTX_MSP' : {
+            'debug[all]': 'VTX MSP',
+            'debug[0]': 'packetCounter',
+            'debug[1]': 'isCrsfPortConfig',
+            'debug[2]': 'isLowPowerDisarmed',
+            'debug[3]': 'mspTelemetryDescriptor',
+        },
+        'GPS_DOP' : {
+            'debug[all]': 'GPS Dilution of Precision',
+            'debug[0]': 'Number of Satellites',
+            'debug[1]': 'pDOP (positional - 3D)',
+            'debug[2]': 'hDOP (horizontal - 2D)',
+            'debug[3]': 'vDOP (vertical - 1D)',
+        },
     };
 
     let DEBUG_FRIENDLY_FIELD_NAMES = null;
@@ -699,20 +713,6 @@ function FlightLogFieldPresenter() {
                     'debug[1]':'Throttle D',
                     'debug[2]':'Altitude',
                     'debug[3]':'Target altitude',
-                };
-                DEBUG_FRIENDLY_FIELD_NAMES.VTX_MSP = {
-                    'debug[all]': 'VTX MSP',
-                    'debug[0]': 'packetCounter',
-                    'debug[1]': 'isCrsfPortConfig',
-                    'debug[2]': 'isLowPowerDisarmed',
-                    'debug[3]': 'mspTelemetryDescriptor',
-                };
-                DEBUG_FRIENDLY_FIELD_NAMES.GPS_DOP = {
-                    'debug[all]': 'GPS Dilution of Precision',
-                    'debug[0]': 'Number of Satellites',
-                    'debug[1]': 'pDOP (positional - 3D)',
-                    'debug[2]': 'hDOP (horizontal - 2D)',
-                    'debug[3]': 'vDOP (vertical - 1D)',
                 };
             } else if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
@@ -1307,7 +1307,7 @@ function FlightLogFieldPresenter() {
                         case 'debug[2]': // hDOP (horizontal - 2D)
                         case 'debug[3]': // vDOP (vertical - 1D)
                         default:
-                            return (value / 100).toFixed(1);
+                            return (value / 100).toFixed(2);
                     }
             }
             return value.toFixed(0);

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -894,6 +894,21 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                             }
+                    case 'GPS_DOP':
+                        switch (fieldName) {
+                            case 'debug[0]': // Number of Satellites (now this is in normal GPS data, maybe gpsTrust?)
+                            case 'debug[1]': // pDOP
+                            case 'debug[2]': // hDOP
+                            case 'debug[3]': // vDOP
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 200 ,
+                                    outputRange: 1.0,
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
                     }
             }
             // if not found above then

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -232,7 +232,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                         idents.vbatField = fieldIndex;
                         idents.numCells = flightLog.getNumCellsEstimate();
                     break;
-                    case "BaroAlt":
+                    case "baroAlt":
                         idents.baroField = fieldIndex;
                     break;
                     case "roll":


### PR DESCRIPTION
I found that debugs after `ATTITUDE` would not display properly.  I don't know the exact cause, but adding one extra line to the debug name list solves the problem.  

If there is a better fix, please let me know.

Also modified the new GPS_DOP debug graphics to have a fixed amplitude scale, to make comparisons between DOP values easier.

I think the new GPS_DOP and MSP_VTX can appear in the 'normal' place and don't need a 'splice' until modified.

Found and fixed a BaroAlt that should have been baroAlt.
