### PR TITLE
Make measurement system units changeable.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2830,6 +2830,57 @@
                                     </div>
                                 </div>
                             </div>
+                            <!--
+                            <div class="gui_box grey unit-settings">
+                                <div class="gui_box_titlebar">
+                                    <div class="spacer_box_title">Measurement System</div>
+                                </div>
+                                <div class="spacer_box">
+                                    <div>
+                                        <label class="option">Units
+                                            <input class="measurement-units ios-switch" type="checkbox" />
+                                            <div>
+                                                <div></div>
+                                            </div>
+                                            <span>Change to Imperial units. (Default: Metric)</span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            -->
+                            <div class="gui_box grey unit-settings">
+                                <div class="gui_box_titlebar">
+                                    <div class="spacer_box_title">Measurement System</div>
+                                </div>
+                                <div>
+                                    <div class="speed-mode-group">
+                                        <table>
+                                            <tr>
+                                                <td>
+                                                    <label>Speed Units</label>
+                                                    <input type="radio" name="speed-mode" value="1">m/s</input>
+                                                    <br>
+                                                    <input type="radio" name="speed-mode" value="2">kph</input>
+                                                    <br>
+                                                    <input type="radio" name="speed-mode" value="3">mph</input>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </div>
+                                    <div class="altitude-mode-group">
+                                        <table>
+                                            <tr>
+                                                <td>
+                                                    <label>Altitude Units</label>
+                                                    <input type="radio" name="altitude-mode" value="1">meters</input>
+                                                    <br>
+                                                    <input type="radio" name="altitude-mode" value="2">feet</input>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="cf_column half right">

--- a/index.html
+++ b/index.html
@@ -2830,24 +2830,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <!--
-                            <div class="gui_box grey unit-settings">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">Measurement System</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <div>
-                                        <label class="option">Units
-                                            <input class="measurement-units ios-switch" type="checkbox" />
-                                            <div>
-                                                <div></div>
-                                            </div>
-                                            <span>Change to Imperial units. (Default: Metric)</span>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                            -->
                             <div class="gui_box grey unit-settings">
                                 <div class="gui_box_titlebar">
                                     <div class="spacer_box_title">Measurement System</div>

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -857,7 +857,7 @@ function FlightLogFieldPresenter() {
      * @param altitude String: Altitude in meters.
      * @param altitudeUnits Integer: 1 for meters, 2 for feet.
      * 
-     * @returns meters in selected unit.
+     * @returns String: readable meters in selected unit.
      */
 
     FlightLogFieldPresenter.decodeCorrectAltitude = function(altitude, altitudeUnits) {
@@ -985,7 +985,6 @@ function FlightLogFieldPresenter() {
                 return (value / Math.PI * 180).toFixed(1) + "°";
 
             case 'baroAlt':
-                //return (value / 100).toFixed(1) + " m";
                 return FlightLogFieldPresenter.decodeCorrectAltitude((value/100), userSettings.altitudeUnits);
 
             case 'flightModeFlags':
@@ -994,7 +993,7 @@ function FlightLogFieldPresenter() {
             case 'stateFlags':
                 return FlightLogFieldPresenter.presentFlags(value, FLIGHT_LOG_FLIGHT_STATE_NAME);
 
-            case 'failsafePhase':
+            case 'failsafePhase':fork
                 return FlightLogFieldPresenter.presentEnum(value, FLIGHT_LOG_FAILSAFE_PHASE_NAME);
 
             case 'features':
@@ -1010,7 +1009,6 @@ function FlightLogFieldPresenter() {
             case 'GPS_coord[1]':
                 return `${(value/10000000).toFixed(5)}`;
             case 'GPS_altitude':
-                //return `${(value/10).toFixed(2)} m`;
                 return FlightLogFieldPresenter.decodeCorrectAltitude((value/10), userSettings.altitudeUnits);
             case 'GPS_speed':
                 switch (userSettings.speedUnits) {

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -993,7 +993,7 @@ function FlightLogFieldPresenter() {
             case 'stateFlags':
                 return FlightLogFieldPresenter.presentFlags(value, FLIGHT_LOG_FLIGHT_STATE_NAME);
 
-            case 'failsafePhase':fork
+            case 'failsafePhase':
                 return FlightLogFieldPresenter.presentEnum(value, FLIGHT_LOG_FAILSAFE_PHASE_NAME);
 
             case 'features':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -867,7 +867,7 @@ function FlightLogFieldPresenter() {
             case 2: // Translate it into feet.
                 return (altitude * 3.28).toFixed(2) + " ft";
         }
-    }
+    };
 
     /**
      * Attempt to decode the given raw logged value into something more human readable, or return an empty string if

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -852,6 +852,24 @@ function FlightLogFieldPresenter() {
     };
 
     /**
+     * Function to translate altitudes from the default meters
+     * to the user selected measurement unit.
+     * @param altitude String: Altitude in meters.
+     * @param altitudeUnits Integer: 1 for meters, 2 for feet.
+     * 
+     * @returns meters in selected unit.
+     */
+
+    FlightLogFieldPresenter.decodeCorrectAltitude = function(altitude, altitudeUnits) {
+        switch (altitudeUnits) {
+            case 1: // Keep it in meters.
+                return (altitude).toFixed(2) + " m";
+            case 2: // Translate it into feet.
+                return (altitude * 3.28).toFixed(2) + " ft";
+        }
+    }
+
+    /**
      * Attempt to decode the given raw logged value into something more human readable, or return an empty string if
      * no better representation is available.
      *
@@ -967,7 +985,8 @@ function FlightLogFieldPresenter() {
                 return (value / Math.PI * 180).toFixed(1) + "°";
 
             case 'baroAlt':
-                return (value / 100).toFixed(1) + " m";
+                //return (value / 100).toFixed(1) + " m";
+                return FlightLogFieldPresenter.decodeCorrectAltitude((value/100), userSettings.altitudeUnits);
 
             case 'flightModeFlags':
                 return FlightLogFieldPresenter.presentFlags(value, FLIGHT_LOG_FLIGHT_MODE_NAME);
@@ -991,9 +1010,17 @@ function FlightLogFieldPresenter() {
             case 'GPS_coord[1]':
                 return `${(value/10000000).toFixed(5)}`;
             case 'GPS_altitude':
-                return `${(value/10).toFixed(2)} m`;
+                //return `${(value/10).toFixed(2)} m`;
+                return FlightLogFieldPresenter.decodeCorrectAltitude((value/10), userSettings.altitudeUnits);
             case 'GPS_speed':
-                return `${(value/100).toFixed(2)} m/s`;
+                switch (userSettings.speedUnits) {
+                    case 1:
+                        return `${(value/100).toFixed(2)} m/s`;
+                    case 2:
+                        return `${((value/100) * 3.6).toFixed(2)} kph`;
+                    case 3:
+                        return `${((value/100) * 2.2369).toFixed(2)} mph`;
+                }
             case 'GPS_ground_course':
                 return `${(value/10).toFixed(1)} °`;
 

--- a/js/user_settings_dialog.js
+++ b/js/user_settings_dialog.js
@@ -44,6 +44,8 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 		stickTrails			: false,			// Show stick trails?
 		stickInvertYaw		: false,			// Invert yaw in stick display?
         legendUnits			: true,	            // Show units on legend?
+        speedUnits          : 1,                // Default speed mode = m/s
+        altitudeUnits       : 1,                // Default altitude mode = meters
 		gapless				: false,
         drawCraft           : "3D", 
         hasCraft            : true,
@@ -314,6 +316,14 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
         currentSettings.legendUnits = $(this).is(":checked");
     });
 
+    $('input[type=radio][name=speed-mode]').change(function() {
+        currentSettings.speedUnits = parseInt($(this).val());
+    });
+
+    $('input[type=radio][name=altitude-mode]').change(function() {
+        currentSettings.altitudeUnits = parseInt($(this).val());
+    });
+
     // Load Custom Logo
     function readURL(input) {
         if (input.files && input.files[0]) {
@@ -390,13 +400,15 @@ function UserSettingsDialog(dialog, onLoad, onSave) {
 				$(".legend-units").prop('checked', currentSettings.legendUnits);
 			}
 
-
         mixerListSelection(currentSettings.mixerConfiguration); // select current mixer configuration
     		stickModeSelection(currentSettings.stickMode);
 
     		// setup the stick mode and dropdowns;
     		$('select.mixerList').val(currentSettings.mixerConfiguration);
     		$('input:radio[name="stick-mode"]').filter('[value="' + currentSettings.stickMode + '"]').attr('checked', true);
+
+    		$('input:radio[name="speed-mode"]').filter('[value="' + currentSettings.speedUnits + '"]').attr('checked', true);
+    		$('input:radio[name="altitude-mode"]').filter('[value="' + currentSettings.altitudeUnits + '"]').attr('checked', true);
 
     		$('.stick-mode-group input[name="stick-top"]').val(parseInt(currentSettings.sticks.top));
     		$('.stick-mode-group input[name="stick-left"]').val(parseInt(currentSettings.sticks.left));


### PR DESCRIPTION
This PR contains the following additions to the Advanced User Settings menu:
![bild](https://user-images.githubusercontent.com/45761642/205130888-e50deda6-f9e2-43dc-8cef-0122e2114ee0.png)

This allows the user to switch between different measurement systems/units for GPS speed and GPS/Baro Altitude in the Legend Screen.

Default:
![bild](https://user-images.githubusercontent.com/45761642/205131408-c98997ef-6278-478d-9c59-ec9234188281.png)

Imperical Example:
![bild](https://user-images.githubusercontent.com/45761642/205131557-c3d5def4-ac05-4e99-8c99-265de50b810b.png)