### PR TITLE
Extended dshot telemetry data parsing and presentation

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -296,6 +296,39 @@ function FlightLog(logData) {
         return numMotors;
     };
 
+    /*
+     * Propagates array data fiels over empty fields
+     * Debug fields can be arrays with data, so it fills data gaps when no arrays are stored
+     */
+    function propagateArrayFields(chunks)
+    {
+        var currentFrame;
+        
+        for (let k = 0; k < chunks.length; k++)
+        {
+            let previousFrame = 0;
+            
+            for (let j = 0; j < chunks[k].frames.length; j++)
+            {
+                currentFrame = chunks[k].frames[j]; 
+                if (previousFrame == 0)
+                {
+                    previousFrame = currentFrame;
+                }
+                    
+                for (let i = 0; i < currentFrame.length; i++)
+                {
+                    if (!Array.isArray(currentFrame[i]) && Array.isArray(previousFrame[i]))
+                    {
+                        currentFrame[i] = previousFrame[i];
+                    }
+                }
+                
+                previousFrame = chunks[k].frames[j];
+            }
+        }
+    }
+
     /**
      * Get the raw chunks in the range [startIndex...endIndex] (inclusive)
      *
@@ -504,6 +537,7 @@ function FlightLog(logData) {
         }
 
         injectComputedFields(resultChunks, resultChunks);
+        propagateArrayFields(resultChunks);
 
         return resultChunks;
     }

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -361,6 +361,13 @@ let
         "MAG_CALIB",
         "MAG_TASK_RATE",
         "EZLANDING",
+        "DSHOT_STATUS_N_TEMPERATURE",
+        "DSHOT_STATUS_N_VOLTAGE",
+        "DSHOT_STATUS_N_CURRENT",
+        "DSHOT_STATUS_N_DEBUG1",
+        "DSHOT_STATUS_N_DEBUG2",
+        "DSHOT_STATUS_N_STRESS_LVL",
+        "DSHOT_STATUS_N_ERPM_FRACTION_18",
     ]),
 
     SUPER_EXPO_YAW = makeReadOnly([

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -1114,6 +1114,55 @@ function FlightLogFieldPresenter() {
             'debug[2]': 'Upper Limit',
             'debug[3]': 'EZ Land Limit',
         },
+        'DSHOT_STATUS_N_TEMPERATURE' : {
+            'debug[all]': 'ESC Status & Temperature',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_VOLTAGE' : {
+            'debug[all]': 'ESC Status & Voltage',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_CURRENT' : {
+            'debug[all]': 'ESC Status & Current',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_DEBUG1' : {
+            'debug[all]': 'ESC Status & Debug1',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_DEBUG2' : {
+            'debug[all]': 'ESC Status & Debug2',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_STRESS_LVL' : {
+            'debug[all]': 'ESC Status & Stress Level',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
+        'DSHOT_STATUS_N_ERPM_FRACTION_18' : {
+            'debug[all]': 'ESC Status & RPM',
+            'debug[0]': 'ESC1',
+            'debug[1]': 'ESC2',
+            'debug[2]': 'ESC3',
+            'debug[3]': 'ESC4',
+        },
     };
 
     let DEBUG_FRIENDLY_FIELD_NAMES = null;
@@ -1879,7 +1928,24 @@ function FlightLogFieldPresenter() {
                     return value.toFixed(0);
                 case 'DSHOT_TELEMETRY_COUNTS':
                     return value.toFixed(0);
+                case 'DSHOT_STATUS_N_TEMPERATURE':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}ºC` : '---';
+                case 'DSHOT_STATUS_N_VOLTAGE':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}V` : '---';
+                case 'DSHOT_STATUS_N_CURRENT':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}A` : '---';
+                case 'DSHOT_STATUS_N_DEBUG1':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}` : '---';
+                case 'DSHOT_STATUS_N_DEBUG2':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}` : '---';
+                case 'DSHOT_STATUS_N_STRESS_LVL':
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${value[4]}sTrs` : '---';
+                case 'DSHOT_STATUS_N_ERPM_FRACTION_18':
+					var rpm = (value[4] * 200 / flightLog.getSysConfig().motor_poles).toFixed();
+                    return (value[0] != null) ? `A${value[0]} W${value[1]} E${value[2]} STRESS:${value[3]} ${rpm}Rpm` : '---';
+
             }
+
             return value.toFixed(0);
         }
         return "";

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -996,6 +996,7 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                         }
+                        
                     case 'GPS_DOP':
                         switch (fieldName) {
                             case 'debug[0]': // Number of Satellites (now this is in normal GPS data, maybe gpsTrust?)
@@ -1135,7 +1136,33 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                         }
-                }
+                    case 'DSHOT_STATUS_N_TEMPERATURE':
+                    case 'DSHOT_STATUS_N_CURRENT':
+                    case 'DSHOT_STATUS_N_DEBUG1':
+                    case 'DSHOT_STATUS_N_DEBUG2':
+                    case 'DSHOT_STATUS_N_STRESS_LVL':
+                        return {
+                            offset: 0,
+                            power: 1.0,
+                            inputRange: 400,
+                            outputRange: 1.0,
+                        };
+                    case 'DSHOT_STATUS_N_VOLTAGE':
+                        return {
+                            offset: 0,
+                            power: 1.0,
+                            inputRange: 255,
+                            outputRange: 1.0,
+                        };
+                    case 'DSHOT_STATUS_N_ERPM_FRACTION_18':
+                        return {
+                            offset: 0,
+                            power: 1.0,
+                            inputRange: 4000,
+                            outputRange: 1.0,
+                        };
+
+                    }
             }
             // if not found above then
             // Scale and center the field based on the whole-log observed ranges for that field

--- a/js/main.js
+++ b/js/main.js
@@ -50,7 +50,7 @@ function BlackboxLogViewer() {
         
         prefs = new PrefStorage(),
         
-        configuration = null,           					       // is their an associated dump file ?
+        configuration = null,                                      // is their an associated dump file ?
         configurationDefaults = new ConfigurationDefaults(prefs),  // configuration defaults
 
         // User's video render config:
@@ -66,7 +66,7 @@ function BlackboxLogViewer() {
         lastGraphConfig = null,     // Undo feature - go back to last configuration.
         workspaceGraphConfigs = [], // Workspaces
         activeWorkspace = 1,        // Active Workspace
-        bookmarkTimes	= [],		// Empty array for bookmarks (times)
+        bookmarkTimes   = [],       // Empty array for bookmarks (times)
         
         // Graph configuration which is currently in use, customised based on the current flight log from graphConfig
         activeGraphConfig = new GraphConfig(),
@@ -168,6 +168,9 @@ function BlackboxLogViewer() {
         if (value === null)
             return "(absent)";
 
+        if (Array.isArray(value))
+            return value.toString();
+            
         return value.toFixed(2);
     }
     
@@ -239,8 +242,8 @@ function BlackboxLogViewer() {
 
             // Update flight mode flags on status bar
             $(".flight-mode", statusBar).text(
-            		fieldPresenter.decodeFieldToFriendly(null, 'flightModeFlags', currentFlightMode, null)	
-            	);
+                fieldPresenter.decodeFieldToFriendly(null, 'flightModeFlags', currentFlightMode, null)
+            );
 
             // update time field on status bar
             $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));
@@ -857,22 +860,22 @@ function BlackboxLogViewer() {
     }
     
     this.getBookmarks = function() { // get bookmark events
-    	var bookmarks = [];
-    	try {
-    		if(bookmarkTimes!=null) {
-		    	for(var i=0; i<=9; i++) {
-		    		if(bookmarkTimes[i]!=null) {
-			    		bookmarks[i] = {
-			    			state: (bookmarkTimes[i]!=0),
-			    			time:  bookmarkTimes[i]
-			    			};
-			    		} else bookmarks[i] = null;
-		    	}
-    		}
-	    	return bookmarks;	    		
-    	} catch(e) {
-    		return null;
-    	}
+        var bookmarks = [];
+        try {
+            if (bookmarkTimes != null) {
+                for (var i = 0; i <= 9; i++) {
+                    if (bookmarkTimes[i] != null) {
+                        bookmarks[i] = {
+                                  state: (bookmarkTimes[i] != 0),
+                            time: bookmarkTimes[i]
+                        };
+                    } else bookmarks[i] = null;
+                }
+            }
+            return bookmarks;
+        } catch (e) {
+            return null;
+        }
     }
 
     this.getBookmarkTimes = function() {
@@ -1444,28 +1447,28 @@ function BlackboxLogViewer() {
             },
 
             function(newSettings) { // onSave
-	            userSettings = newSettings;
+                userSettings = newSettings;
 
-	            prefs.set('userSettings', newSettings);
+                prefs.set('userSettings', newSettings);
 
-	            // refresh the craft model
-	            if(graph!=null) {
-	                graph.refreshOptions(newSettings);
-	                graph.refreshLogo();
-	                graph.initializeCraftModel();
+                // refresh the craft model
+                if(graph!=null) {
+                    graph.refreshOptions(newSettings);
+                    graph.refreshLogo();
+                    graph.initializeCraftModel();
                     if(flightLog.hasGpsData()) {
                         mapGrapher.setUserSettings(newSettings);
                     }
-	                updateCanvasSize();
-	            }
+                    updateCanvasSize();
+                }
 
-	        }),
+            }),
 
-	        exportDialog = new VideoExportDialog($("#dlgVideoExport"), function(newConfig) {
-	            videoConfig = newConfig;
-	            
-	            prefs.set('videoConfig', newConfig);
-	        });
+            exportDialog = new VideoExportDialog($("#dlgVideoExport"), function(newConfig) {
+                videoConfig = newConfig;
+                
+                prefs.set('videoConfig', newConfig);
+            });
         
         $(".open-graph-configuration-dialog").click(function(e) {
             e.preventDefault();
@@ -1491,14 +1494,14 @@ function BlackboxLogViewer() {
         });
 
         $(".marker-offset", statusBar).click(function(e) {
-	        setCurrentBlackboxTime(markerTime);
-	        invalidateGraph(); 
+            setCurrentBlackboxTime(markerTime);
+            invalidateGraph(); 
         });
         
         for(var i=1; i< 9; i++) { // Loop through all the bookmarks.
             $('.bookmark-'+i, statusBar).click(function() {
-    	        setCurrentBlackboxTime(bookmarkTimes[parseInt(this.className.slice(-1))]);
-    	        invalidateGraph(); 
+                setCurrentBlackboxTime(bookmarkTimes[parseInt(this.className.slice(-1))]);
+                invalidateGraph(); 
             });
         }
 
@@ -1508,7 +1511,7 @@ function BlackboxLogViewer() {
                 $('.bookmark-'+ i, statusBar).css('visibility', 'hidden' );
             }
             $('.bookmark-clear', statusBar).css('visibility', 'hidden' );
-	        invalidateGraph(); 
+            invalidateGraph(); 
         });
 
         $('.configuration-file-name', statusBar).click(function(e) {
@@ -1935,38 +1938,38 @@ function BlackboxLogViewer() {
                                     }
                                 }
                             } else { // Bookmark Feature
-                        		if (!e.shiftKey) { // retrieve time from bookmark
-		                            if (bookmarkTimes[e.which-48] != null) {
-		                                setCurrentBlackboxTime(bookmarkTimes[e.which-48]);
-		                                invalidateGraph(); 
-		                            }
+                                if (!e.shiftKey) { // retrieve time from bookmark
+                                    if (bookmarkTimes[e.which - 48] != null) {
+                                        setCurrentBlackboxTime(bookmarkTimes[e.which - 48]);
+                                        invalidateGraph();
+                                    }
 
-		                        } else {// store time to bookmark
-		                            // Special Case : Shift Alt 0 clears all bookmarks
-		                            if(e.which==48) {
-		                                bookmarkTimes = null;
-		                                for(var i=1; i<=9; i++) {
-	                                        $('.bookmark-'+ i, statusBar).css('visibility', 'hidden' );
-		                                }
-                                        $('.bookmark-clear', statusBar).css('visibility', 'hidden' );
-		                            } else {
-		                                if(bookmarkTimes==null) bookmarkTimes = new Array();
-                                        if (bookmarkTimes[e.which-48] == null) {
-                                             bookmarkTimes[e.which-48] = currentBlackboxTime; 		// Save current time to bookmark
+                                } else {// store time to bookmark
+                                    // Special Case : Shift Alt 0 clears all bookmarks
+                                    if (e.which == 48) {
+                                        bookmarkTimes = null;
+                                        for (var i = 1; i <= 9; i++) {
+                                            $('.bookmark-' + i, statusBar).css('visibility', 'hidden');
+                                        }
+                                        $('.bookmark-clear', statusBar).css('visibility', 'hidden');
+                                    } else {
+                                        if (bookmarkTimes == null) bookmarkTimes = new Array();
+                                        if (bookmarkTimes[e.which - 48] == null) {
+                                            bookmarkTimes[e.which - 48] = currentBlackboxTime;         // Save current time to bookmark
                                         } else {
-                                             bookmarkTimes[e.which-48] = null; 			            // clear the bookmark
+                                            bookmarkTimes[e.which - 48] = null;                         // clear the bookmark
                                         }
-                                        $('.bookmark-'+(e.which-48), statusBar).css('visibility', ((bookmarkTimes[e.which-48]!=null)?('visible'):('hidden')) );
+                                        $('.bookmark-' + (e.which - 48), statusBar).css('visibility', ((bookmarkTimes[e.which - 48] != null) ? ('visible') : ('hidden')));
                                         var countBookmarks = 0;
-                                        for(var i=0; i<=9; i++) {
-                                        	countBookmarks += (bookmarkTimes[i]!=null)?1:0;
+                                        for (var i = 0; i <= 9; i++) {
+                                            countBookmarks += (bookmarkTimes[i] != null) ? 1 : 0;
                                         }
-                                        $('.bookmark-clear', statusBar).css('visibility', ((countBookmarks>0)?('visible'):('hidden')) );
+                                        $('.bookmark-clear', statusBar).css('visibility', ((countBookmarks > 0) ? ('visible') : ('hidden')));
 
-		                            }
-		                            invalidateGraph();
-		                        }
-                        	}
+                                    }
+                                    invalidateGraph();
+                                }
+                            }
                         } catch(e) {
                             console.log('Workspace feature not functioning');
                         }


### PR DESCRIPTION
This pr adds EDT parsing and presentation functionality to blackbox explorer.
EDT data is packed in debug fields in the following way:
- bit 15 - alert event
- bit 14 - warning event
- bit 13 - error event
- bits 11-8 - Max stress level during the whole flight
- bits 7-0 - ESC data depending on the chosen debug mode

This pr is related to:
https://github.com/bird-sanctuary/bluejay/pull/64
https://github.com/betaflight/betaflight/pull/12170
https://github.com/betaflight/betaflight-configurator/pull/3262

ESC temperature log files for testing:
[BTFL_BLACKBOX_LOG_Meteor65_20230201_183226.zip](https://github.com/betaflight/blackbox-log-viewer/files/10572044/BTFL_BLACKBOX_LOG_Meteor65_20230201_183226.zip)
[BTFL_BLACKBOX_LOG_Meteor65_20230202_183845.zip](https://github.com/betaflight/blackbox-log-viewer/files/10572056/BTFL_BLACKBOX_LOG_Meteor65_20230202_183845.zip)

ESC demag metric files for testing:
[BTFL_BLACKBOX_LOG_Meteor65_20230203_224822.zip](https://github.com/betaflight/blackbox-log-viewer/files/10583249/BTFL_BLACKBOX_LOG_Meteor65_20230203_224822.zip)

ESC rpm log files for testing:
[BTFL_BLACKBOX_LOG_Meteor65_20230203_232019.zip](https://github.com/betaflight/blackbox-log-viewer/files/10583252/BTFL_BLACKBOX_LOG_Meteor65_20230203_232019.zip)


