### PR TITLE
Bugfix: chrome.fileSystem.chooseEntry now requires "description"

### DIFF
--- a/js/flightlog_video_renderer.js
+++ b/js/flightlog_video_renderer.js
@@ -99,7 +99,7 @@ function FlightLogVideoRenderer(flightLog, logParameters, videoOptions, events) 
     function openFileForWrite(suggestedName, onComplete) {
         return new Promise(function(resolve, reject) {
             chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: suggestedName, 
-                    accepts: [{extensions: ['webm']}]}, function(fileEntry) {
+                    accepts: [{extensions: ['webm'], description: "WebM video"}]}, function(fileEntry) {
                 var 
                     error = chrome.runtime.lastError;
                 


### PR DESCRIPTION
Fix inspired by this pull request from another project that had the same issue:
https://github.com/excalidraw/excalidraw/pull/4280