### PR TITLE
Remove old motor legacy graph

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -11,7 +11,7 @@
  */
 function FlightLog(logData) {
     var
-        ADDITIONAL_COMPUTED_FIELD_COUNT = 23, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + MOTOR_LEGACY **/
+        ADDITIONAL_COMPUTED_FIELD_COUNT = 15, /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED **/
 
         that = this,
         logIndex = false,
@@ -239,15 +239,6 @@ function FlightLog(logData) {
         }
         if (!(that.isFieldDisabled().GYRO || that.isFieldDisabled().PID)) {
             fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
-        }
-        if (!that.isFieldDisabled().MOTORS) {
-            for (let i = 0; i < MAX_MOTOR_NUMBER; i++) {
-                if (fieldNames.find(element => element === `motor[${i}]`)) {
-                    fieldNames.push(`motorLegacy[${i}]`);
-                } else {
-                    break;
-                }
-            }
         }
 
         fieldNameToIndex = {};
@@ -564,9 +555,6 @@ function FlightLog(logData) {
                          [fieldNameToIndex["axisP[1]"], fieldNameToIndex["axisI[1]"], fieldNameToIndex["axisD[1]"], fieldNameToIndex["axisF[1]"]],
                          [fieldNameToIndex["axisP[2]"], fieldNameToIndex["axisI[2]"], fieldNameToIndex["axisD[2]"], fieldNameToIndex["axisF[2]"]]];
 
-        let motor = [fieldNameToIndex["motor[0]"], fieldNameToIndex["motor[1]"], fieldNameToIndex["motor[2]"], fieldNameToIndex["motor[3]"],
-                       fieldNameToIndex["motor[4]"], fieldNameToIndex["motor[5]"], fieldNameToIndex["motor[6]"], fieldNameToIndex["motor[7]"]];
-
         let sourceChunkIndex;
         let destChunkIndex;
         let attitude;
@@ -600,10 +588,6 @@ function FlightLog(logData) {
 
         if (!axisPID[0]) {
             axisPID = false;
-        }
-
-        if (!motor[0]) {
-            motor = false;
         }
 
         sourceChunkIndex = 0;
@@ -697,13 +681,6 @@ function FlightLog(logData) {
                         for (var axis = 0; axis < 3; axis++) {
                             let gyroADCdegrees = (gyroADC[axis] !== undefined ? that.gyroRawToDegreesPerSecond(srcFrame[gyroADC[axis]]) : 0);
                             destFrame[fieldIndex++] = destFrame[fieldIndexRcCommands + axis] - gyroADCdegrees;
-                        }
-                    }
-
-                    // Duplicate the motor field to show the motor legacy values
-                    if (motor) {
-                        for (let motorNumber = 0; motorNumber < numMotors; motorNumber++) {
-                            destFrame[fieldIndex++] = srcFrame[motor[motorNumber]];
                         }
                     }
 
@@ -1199,13 +1176,6 @@ FlightLog.prototype.rcCommandRawToDegreesPerSecond = function(value, axis, curre
 FlightLog.prototype.rcCommandRawToThrottle = function(value) {
     // Throttle displayed as percentage
     return Math.min(Math.max(((value - this.getSysConfig().minthrottle) / (this.getSysConfig().maxthrottle - this.getSysConfig().minthrottle)) * 100.0, 0.0),100.0);
-};
-
-FlightLog.prototype.rcMotorRawToPctEffective = function(value) {
-    // Motor displayed as percentage
-    const minValue = (this.isDigitalProtocol() && this.getSysConfig().dynamic_idle_min_rpm > 0) ? this.getSysConfig().digitalIdleOffset : this.getSysConfig().motorOutput[0];
-    return Math.min((value - minValue) / (this.getSysConfig().motorOutput[1] - minValue) * 100.0, 100.0);
-
 };
 
 FlightLog.prototype.rcMotorRawToPctPhysical = function(value) {

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -68,16 +68,6 @@ function FlightLogFieldPresenter() {
         'motor[6]': 'Motor [7]',
         'motor[7]': 'Motor [8]',
 
-        'motorLegacy[all]': 'Motors (Legacy)',
-        'motorLegacy[0]': 'Motor (Legacy) [1]',
-        'motorLegacy[1]': 'Motor (Legacy) [2]',
-        'motorLegacy[2]': 'Motor (Legacy) [3]',
-        'motorLegacy[3]': 'Motor (Legacy) [4]',
-        'motorLegacy[4]': 'Motor (Legacy) [5]',
-        'motorLegacy[5]': 'Motor (Legacy) [6]',
-        'motorLegacy[6]': 'Motor (Legacy) [7]',
-        'motorLegacy[7]': 'Motor (Legacy) [8]',
-
         'servo[all]': 'Servos',
         'servo[5]': 'Servo Tail',
 
@@ -1299,16 +1289,6 @@ function FlightLogFieldPresenter() {
             case 'motor[6]':
             case 'motor[7]':
                 return `${flightLog.rcMotorRawToPctPhysical(value).toFixed(2)} %`;
-
-            case 'motorLegacy[0]':
-            case 'motorLegacy[1]':
-            case 'motorLegacy[2]':
-            case 'motorLegacy[3]':
-            case 'motorLegacy[4]':
-            case 'motorLegacy[5]':
-            case 'motorLegacy[6]':
-            case 'motorLegacy[7]':
-                return `${flightLog.rcMotorRawToPctEffective(value).toFixed(2)} % (${value})`;
 
             case 'rcCommands[0]':
             case 'rcCommands[1]':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -267,13 +267,6 @@ GraphConfig.load = function(config) {
                         DSHOT_RANGE / 2 : (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
                     outputRange: 1.0,
                 };
-            } else if (fieldName.match(/^motorLegacy\[/)) {
-                return {
-                    offset: -(sysConfig.motorOutput[1] + sysConfig.motorOutput[0]) / 2,
-                    power: 1.0,
-                    inputRange: (sysConfig.motorOutput[1] - sysConfig.motorOutput[0]) / 2,
-                    outputRange: 1.0,
-                };
             } else if (fieldName.match(/^servo\[/)) {
                 return {
                     offset: -1500,


### PR DESCRIPTION
When @ctzsnooze and me moved the motors to show the real command sent to motors, we left the legacy way to see if users prefer the old method. It seems nobody has complained, and I've seen some users confused about the legacy option. I think better to remove it. This reduces the amount of data the blackbox has to manage.