### PR TITLE
Fix open new empty window and duplicate windows

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -129,9 +129,7 @@ function BlackboxLogViewer() {
                 'min_height' : INNER_BOUNDS_HEIGHT,
             },
             function (createdWindow) {
-                if (fileToOpen !== undefined) {
-                    createdWindow.window.argv = fileToOpen;
-                }
+                createdWindow.window.argv = fileToOpen;
             });
 
         }
@@ -2111,10 +2109,10 @@ function BlackboxLogViewer() {
                 // so we limit it to one of them, the first in the list for example
                 const windows = chrome.app.window.getAll();
 
-                const firstWindowId = windows[0].id;
-                const currentWindowId = chrome.app.window.current().id;
+                const firstWindow = windows[0];
+                const currentWindow = chrome.app.window.current();
 
-                if (currentWindowId === firstWindowId) {
+                if (currentWindow === firstWindow) {
 
                     const filePathToOpenExpression = /.*"([^"]*)"$/;
                     const fileToOpen = path.match(filePathToOpenExpression);


### PR DESCRIPTION
This PR fixes two problems that appeared at some node/nw update:
- When you click the "new window" button, it opens a new window with the first blackbox log. This is not what this button must do, it must open a new "empty" window to let the user select the file that wants to open.
- When you have several blackbox windows opened, and you close the first one, and after that you double click in a blackbox file, this new blackbox file generates several new blackbox windows, one for each old blackbox window that exist.

This has been tested under Windows only, I hope it works the same for Linux/Mac.