### PR TITLE
Add (e)RPM black box field

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -1336,5 +1336,6 @@ FlightLog.prototype.isFieldDisabled = function() {
             DEBUG         : (disabledFields & (1 << 9))!==0,
             MOTORS        : (disabledFields & (1 << 10))!==0,
             GPS           : (disabledFields & (1 << 11))!==0,
+            RPM           : (disabledFields & (1 << 12))!==0,
         };
 };

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -68,6 +68,16 @@ function FlightLogFieldPresenter() {
         'motor[6]': 'Motor [7]',
         'motor[7]': 'Motor [8]',
 
+        'RPM[all]': 'RPM',
+        'RPM[0]': 'RPM [1]',
+        'RPM[1]': 'RPM [2]',
+        'RPM[2]': 'RPM [3]',
+        'RPM[3]': 'RPM [4]',
+        'RPM[4]': 'RPM [5]',
+        'RPM[5]': 'RPM [6]',
+        'RPM[6]': 'RPM [7]',
+        'RPM[7]': 'RPM [8]',
+
         'servo[all]': 'Servos',
         'servo[5]': 'Servo Tail',
 
@@ -1289,6 +1299,16 @@ function FlightLogFieldPresenter() {
             case 'motor[6]':
             case 'motor[7]':
                 return `${flightLog.rcMotorRawToPctPhysical(value).toFixed(2)} %`;
+
+            case 'RPM[0]':
+            case 'RPM[1]':
+            case 'RPM[2]':
+            case 'RPM[3]':
+            case 'RPM[4]':
+            case 'RPM[5]':
+            case 'RPM[6]':
+            case 'RPM[7]':
+                return (value * 200 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + " rpm / " + (value * 3.333 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + ' hz';
 
             case 'rcCommands[0]':
             case 'rcCommands[1]':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -68,15 +68,15 @@ function FlightLogFieldPresenter() {
         'motor[6]': 'Motor [7]',
         'motor[7]': 'Motor [8]',
 
-        'RPM[all]': 'RPM',
-        'RPM[0]': 'RPM [1]',
-        'RPM[1]': 'RPM [2]',
-        'RPM[2]': 'RPM [3]',
-        'RPM[3]': 'RPM [4]',
-        'RPM[4]': 'RPM [5]',
-        'RPM[5]': 'RPM [6]',
-        'RPM[6]': 'RPM [7]',
-        'RPM[7]': 'RPM [8]',
+        'eRPM(/100)[all]': 'RPM',
+        'eRPM(/100)[0]': 'RPM [1]',
+        'eRPM(/100)[1]': 'RPM [2]',
+        'eRPM(/100)[2]': 'RPM [3]',
+        'eRPM(/100)[3]': 'RPM [4]',
+        'eRPM(/100)[4]': 'RPM [5]',
+        'eRPM(/100)[5]': 'RPM [6]',
+        'eRPM(/100)[6]': 'RPM [7]',
+        'eRPM(/100)[7]': 'RPM [8]',
 
         'servo[all]': 'Servos',
         'servo[5]': 'Servo Tail',
@@ -1300,15 +1300,16 @@ function FlightLogFieldPresenter() {
             case 'motor[7]':
                 return `${flightLog.rcMotorRawToPctPhysical(value).toFixed(2)} %`;
 
-            case 'RPM[0]':
-            case 'RPM[1]':
-            case 'RPM[2]':
-            case 'RPM[3]':
-            case 'RPM[4]':
-            case 'RPM[5]':
-            case 'RPM[6]':
-            case 'RPM[7]':
-                return (value * 200 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + " rpm / " + (value * 3.333 / flightLog.getSysConfig()['motor_poles']).toFixed(0) + ' hz';
+            case 'eRPM(/100)[0]':
+            case 'eRPM(/100)[1]':
+            case 'eRPM(/100)[2]':
+            case 'eRPM(/100)[3]':
+            case 'eRPM(/100)[4]':
+            case 'eRPM(/100)[5]':
+            case 'eRPM(/100)[6]':
+            case 'eRPM(/100)[7]':
+                let motor_poles = flightLog.getSysConfig()['motor_poles'];
+                return (value * 200 / motor_poles).toFixed(0) + " rpm / " + (value * 3.333 / motor_poles).toFixed(1) + ' hz';
 
             case 'rcCommands[0]':
             case 'rcCommands[1]':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -101,7 +101,7 @@ function GraphConfig(graphConfig) {
                 if ((matches = field.name.match(/^(.+)\[all\]$/))) {
                     var
                         nameRoot = matches[1],
-                        nameRegex = new RegExp("^" + nameRoot + "\[[0-9]+\]$"),
+                        nameRegex = new RegExp("^" + escapeRegExp(nameRoot) + "\[[0-9]+\]$"),
                         colorIndexOffset = 0;
 
                     for (var k = 0; k < logFieldNames.length; k++) {
@@ -267,8 +267,8 @@ GraphConfig.load = function(config) {
                         DSHOT_RANGE / 2 : (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
                     outputRange: 1.0,
                 };
-            } else if (fieldName.match(/^RPM\[/)) {
-                return getCurveForMinMaxFields('RPM[0]', 'RPM[1]', 'RPM[2]', 'RPM[3]', 'RPM[4]', 'RPM[5]', 'RPM[6]', 'RPM[7]');
+            } else if (fieldName.match(/^eRPM\(\/100\)\[/)) {
+                return getCurveForMinMaxFields('eRPM(/100)[0]', 'eRPM(/100)[1]', 'eRPM(/100)[2]', 'eRPM(/100)[3]', 'eRPM(/100)[4]', 'eRPM(/100)[5]', 'eRPM(/100)[6]', 'eRPM(/100)[7]');
             } else if (fieldName.match(/^servo\[/)) {
                 return {
                     offset: -1500,
@@ -958,7 +958,7 @@ GraphConfig.load = function(config) {
             EXAMPLE_GRAPHS.push({label: "Motors (Legacy)",fields: ["motorLegacy[all]", "servo[5]"]});
         }
         if (!flightLog.isFieldDisabled().RPM) {
-            EXAMPLE_GRAPHS.push({label: "RPM",fields: ["RPM[all]"]});
+            EXAMPLE_GRAPHS.push({label: "RPM",fields: ["eRPM(/100)[all]"]});
         }
         if (!flightLog.isFieldDisabled().GYRO) {
             EXAMPLE_GRAPHS.push({label: "Gyros",fields: ["gyroADC[all]"]});

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -955,6 +955,9 @@ GraphConfig.load = function(config) {
             EXAMPLE_GRAPHS.push({label: "Motors",fields: ["motor[all]", "servo[5]"]});
             EXAMPLE_GRAPHS.push({label: "Motors (Legacy)",fields: ["motorLegacy[all]", "servo[5]"]});
         }
+        if (!flightLog.isFieldDisabled().RPM) {
+            EXAMPLE_GRAPHS.push({label: "RPM",fields: ["RPM[all]"]});
+        }
         if (!flightLog.isFieldDisabled().GYRO) {
             EXAMPLE_GRAPHS.push({label: "Gyros",fields: ["gyroADC[all]"]});
         }

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -267,6 +267,8 @@ GraphConfig.load = function(config) {
                         DSHOT_RANGE / 2 : (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
                     outputRange: 1.0,
                 };
+            } else if (fieldName.match(/^RPM\[/)) {
+                return getCurveForMinMaxFields('RPM[0]', 'RPM[1]', 'RPM[2]', 'RPM[3]', 'RPM[4]', 'RPM[5]', 'RPM[6]', 'RPM[7]');
             } else if (fieldName.match(/^servo\[/)) {
                 return {
                     offset: -1500,

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -459,6 +459,7 @@ function HeaderDialog(dialog, onSave) {
             {name: 'Debug', description: 'Debug values'},
             {name: 'Motors', description: 'Motors and tricopter servo values'},
             {name: 'GPS', description: 'All GPS-related values'},
+            {name: 'RPM', description: 'Angular velocity for all motors'},
         ];
 
         const fieldsList_e = $('.fields_list');

--- a/js/tools.js
+++ b/js/tools.js
@@ -467,3 +467,7 @@ function getManifestVersion(manifest) {
         return "-"
     }
 }
+
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
Adds formatting of the RPM field from https://github.com/betaflight/betaflight/pull/12823
The field should show up as just RPM and be decoded as RPM and Hz.
The RPM plots are scaled so that they have the correct height relative to each other, so the same height corresponds to the same RPM for all plots.
Also adds an option in Configure graphs to add a graph with all RPM plots.

![rpm_bb_field](https://user-images.githubusercontent.com/6018638/226839413-aa068cf5-0c16-4853-801b-aff6663dd21c.png)
![bb_erpm_example_graph](https://github.com/betaflight/blackbox-log-viewer/assets/6018638/0b4c85a6-aa7f-47af-8152-9c13ad5428c5)

<hr>
Depends on https://github.com/betaflight/betaflight/pull/12823