### PR TITLE
Display gps unit connection debug data

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -346,6 +346,7 @@ let
         "GPS_RESCUE_VELOCITY",
         "GPS_RESCUE_HEADING",
         "GPS_RESCUE_TRACKING",
+        "GPS_UNIT_CONNECTION",
         "ATTITUDE",
         "VTX_MSP",
         "GPS_DOP",

--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -346,7 +346,7 @@ let
         "GPS_RESCUE_VELOCITY",
         "GPS_RESCUE_HEADING",
         "GPS_RESCUE_TRACKING",
-        "GPS_UNIT_CONNECTION",
+        "GPS_CONNECTION",
         "ATTITUDE",
         "VTX_MSP",
         "GPS_DOP",

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -990,6 +990,17 @@ function FlightLogFieldPresenter() {
             'debug[6]':'Not Used',
             'debug[7]':'Not Used',
         },
+        'GPS_UNIT_CONNECTION' : {
+            'debug[all]':'GPS Unit Connection',
+            'debug[0]':'Nav Model',
+            'debug[1]':'Package Count',
+            'debug[2]':'Interval ms',
+            'debug[3]':'Baud Rate',
+            'debug[4]':'Main State',
+            'debug[5]':'Position State',
+            'debug[6]':'Ack State',
+            'debug[7]':'Not Used',
+        },
         'ATTITUDE' : {
             'debug[all]':'Attitude',
             'debug[0]':'accADC X',
@@ -1716,6 +1727,20 @@ function FlightLogFieldPresenter() {
                         case 'debug[2]': // altitude cm
                         case 'debug[3]': // altitude target cm
                             return (value / 100).toFixed(1) + ' m';
+                        default:
+                            return value.toFixed(0);
+                    }
+                case 'GPS_UNIT_CONNECTION':
+                    switch (fieldName) {
+                        case 'debug[0]': // Model
+                        case 'debug[1]': // Counter
+                        case 'debug[2]': // Interval
+                            return value.toFixed(0);
+                        case 'debug[3]': // Baud Rate
+                            return (value * 100).toFixed(0);
+                        case 'debug[4]': // main state
+                        case 'debug[5]': // position state
+                        case 'debug[6]': // ack state
                         default:
                             return value.toFixed(0);
                     }

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -990,16 +990,16 @@ function FlightLogFieldPresenter() {
             'debug[6]':'Not Used',
             'debug[7]':'Not Used',
         },
-        'GPS_UNIT_CONNECTION' : {
-            'debug[all]':'GPS Unit Connection',
+        'GPS_CONNECTION' : {
+            'debug[all]':'GPS Connection',
             'debug[0]':'Nav Model',
-            'debug[1]':'Package Count',
-            'debug[2]':'Interval ms',
-            'debug[3]':'Baud Rate',
-            'debug[4]':'Main State',
-            'debug[5]':'Position State',
+            'debug[1]':'GPS Nav interval',
+            'debug[2]':'Task timer',
+            'debug[3]':'Baud Rate / FC interval',
+            'debug[4]':'State*100 +SubState',
+            'debug[5]':'ExecuteTime',
             'debug[6]':'Ack State',
-            'debug[7]':'Not Used',
+            'debug[7]':'Rx buffer size',
         },
         'ATTITUDE' : {
             'debug[all]':'Attitude',
@@ -1730,18 +1730,18 @@ function FlightLogFieldPresenter() {
                         default:
                             return value.toFixed(0);
                     }
-                case 'GPS_UNIT_CONNECTION':
+                case 'GPS__CONNECTION':
                     switch (fieldName) {
-                        case 'debug[0]': // Model
-                        case 'debug[1]': // Counter
-                        case 'debug[2]': // Interval
+                        case 'debug[0]': // Flight model
+                        case 'debug[1]': // GPS Nav packet interval
+                        case 'debug[2]': // FC Nav data time
                             return value.toFixed(0);
-                        case 'debug[3]': // Baud Rate
+                        case 'debug[3]': // Baud Rate / Nav interval
                             return (value * 100).toFixed(0);
-                        case 'debug[4]': // main state
-                        case 'debug[5]': // position state
+                        case 'debug[4]': // main state * 100 + subState
+                        case 'debug[5]': // executeTimeUs
                         case 'debug[6]': // ack state
-                        default:
+                        case 'debug[7]': // serial Rx buffer
                             return value.toFixed(0);
                     }
                 case 'ATTITUDE':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -865,6 +865,15 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                             }
+                    case 'GPS_UNIT_CONNECTION':
+                        switch (fieldName) {
+                            case 'debug[0]': // model
+                            case 'debug[1]': // packetCounter
+                            case 'debug[2]': // interval
+                            case 'debug[3]': // baudRate
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
                     case 'ALTITUDE':
                         switch (fieldName) {
                             case 'debug[0]': // GPS Trust

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -843,7 +843,7 @@ GraphConfig.load = function(config) {
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
-                            }
+                        }
                     case 'GPS_RESCUE_TRACKING':
                         switch (fieldName) {
                             case 'debug[0]': // velocity to home cm/s
@@ -864,16 +864,51 @@ GraphConfig.load = function(config) {
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
-                            }
-                    case 'GPS_UNIT_CONNECTION':
+                        }
+                    case 'GPS_CONNECTION':
                         switch (fieldName) {
-                            case 'debug[0]': // model
-                            case 'debug[1]': // packetCounter
-                            case 'debug[2]': // interval
-                            case 'debug[3]': // baudRate
+                            case 'debug[0]': // GPS flight model
+                            case 'debug[1]': // Nav Data interval
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 200,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[2]': // task interval
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 200,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[3]': // Baud rate / resolved packet interval
+                            case 'debug[4]': // State*100 + SubState
+                                return getCurveForMinMaxFields(fieldName);
+                            case 'debug[5]': // ExecuteTimeUs
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 100,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[6]': // ackState
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 10,
+                                    outputRange: 1.0,
+                                };
+                            case 'debug[7]': // Incoming buffer
+                                return {
+                                    offset: 0,
+                                    power: 1.0,
+                                    inputRange: 100,
+                                    outputRange: 1.0,
+                                };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
-                            }
+                        }
                     case 'ALTITUDE':
                         switch (fieldName) {
                             case 'debug[0]': // GPS Trust
@@ -916,7 +951,6 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                         }
-    
                     case 'BARO':
                         switch (fieldName) {
                             case 'debug[0]': // Baro state 0-10
@@ -937,7 +971,7 @@ GraphConfig.load = function(config) {
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
-                            }
+                        }
                     }
             }
             // if not found above then


### PR DESCRIPTION
Debug to display GPS hardware connection data from modified PR12799 code.

Not for merging; purely for test purposes at this point in time.
