### PR TITLE
Replace non valid values with NaN instead of "" in csv export

### DIFF
--- a/js/webworkers/csv-export-worker.js
+++ b/js/webworkers/csv-export-worker.js
@@ -26,13 +26,13 @@ onmessage = function(event) {
     }
 
     /**
-     * Converts `null` and other empty non-numeric values to zero value string.
+     * Converts `null` and other empty non-numeric values to NaN value string.
      * 
      * @param {object} value is not a number
      * @returns {string}
      */
-    function normalizeEmptyToZero(value) {
-        return !!value ? value : "0";
+    function normalizeEmptyToNaN(value) {
+        return !!value ? value : "NaN";
     }
 
     /**
@@ -44,7 +44,7 @@ onmessage = function(event) {
             .map(value => 
                 _.isNumber(value)
                 ? value
-                : normalizeEmptyToZero(value))
+                : normalizeEmptyToNaN(value))
             .join(opts.columnDelimiter);
     }
 

--- a/js/webworkers/csv-export-worker.js
+++ b/js/webworkers/csv-export-worker.js
@@ -34,7 +34,7 @@ onmessage = function(event) {
     function joinColumnValues(columns) {
         return _(columns)
             .map(value => 
-                _.isNumber(value)
+                (_.isNumber(value) || _.value)
                 ? value
                 : "NaN")
             .join(opts.columnDelimiter);

--- a/js/webworkers/csv-export-worker.js
+++ b/js/webworkers/csv-export-worker.js
@@ -25,6 +25,29 @@ onmessage = function(event) {
             .join(opts.columnDelimiter);
     }
 
+    /**
+     * Converts `null` and other empty non-numeric values to zero value string.
+     * 
+     * @param {object} value is not a number
+     * @returns {string}
+     */
+    function normalizeEmptyToZero(value) {
+        return !!value ? value : "0";
+    }
+
+    /**
+     * @param {array} columns 
+     * @returns {string}
+     */
+    function joinColumnValues(columns) {
+        return _(columns)
+            .map(value => 
+                _.isNumber(value)
+                ? value
+                : normalizeEmptyToZero(value))
+            .join(opts.columnDelimiter);
+    }
+
     let opts = event.data.opts,
         stringDelim = opts.quoteStrings
             ? opts.stringDelimiter
@@ -32,7 +55,7 @@ onmessage = function(event) {
         mainFields = _([joinColumns(event.data.fieldNames)])
             .concat(_(event.data.frames)
                 .flatten()
-                .map(row => joinColumns(row))
+                .map(row => joinColumnValues(row))
                 .value())
             .join("\n"),
         headers = _(event.data.sysConfig)

--- a/js/webworkers/csv-export-worker.js
+++ b/js/webworkers/csv-export-worker.js
@@ -32,7 +32,7 @@ onmessage = function(event) {
      * @returns {string}
      */
     function normalizeEmptyToNaN(value) {
-        return !!value ? value : "NaN";
+        return value ? value : "NaN";
     }
 
     /**

--- a/js/webworkers/csv-export-worker.js
+++ b/js/webworkers/csv-export-worker.js
@@ -26,16 +26,8 @@ onmessage = function(event) {
     }
 
     /**
-     * Converts `null` and other empty non-numeric values to NaN value string.
+     * Converts `null` entries in columns and other empty non-numeric values to NaN value string.
      * 
-     * @param {object} value is not a number
-     * @returns {string}
-     */
-    function normalizeEmptyToNaN(value) {
-        return value ? value : "NaN";
-    }
-
-    /**
      * @param {array} columns 
      * @returns {string}
      */
@@ -44,7 +36,7 @@ onmessage = function(event) {
             .map(value => 
                 _.isNumber(value)
                 ? value
-                : normalizeEmptyToNaN(value))
+                : "NaN")
             .join(opts.columnDelimiter);
     }
 


### PR DESCRIPTION
Edited:
null and other empty non-numeric values are new replaced by a NaN in the *.csv export. On master these values are replaced by "" which leads to problems with some offline data analysis tools like octave.

I would be glad to get some recommendation to the implementation of the change since i don't really understand javascript in detail.

I tested this with several new / newer *.bbl files and it worked as intended.
