### PR TITLE
Fix handling of missing G frame

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -388,7 +388,7 @@ function FlightLog(logData) {
                     // The G frames need to be processed always. They are "invalid" if not H (Home) has been detected 
                     // before, but if not processed the viewer shows cuts and gaps. This happens if the quad takes off before 
                     // fixing enough satellites.
-                    if (frameValid || (frameType == 'G')) {
+                    if (frameValid || (frameType == 'G' && frame)) {
                         switch (frameType) {
                             case 'P':
                             case 'I':


### PR DESCRIPTION
I found an edge case in handling G frames when opening a log generated by Betaflight 4.5 ([37f119cf4](https://github.com/betaflight/betaflight/commit/37f119cf4)) (please see the original log [here](https://drive.google.com/file/d/1aYOb-e28adpb-HGhbcJEKizk9qiwxICk/view?usp=sharing)). In case of a corrupt frame the parser ([flightlog_parser.js:1779](https://github.com/betaflight/blackbox-log-viewer/blob/master/js/flightlog_parser.js#L1779)) calls the callback function like this:
```javascript
//Let the caller know there was a corrupt frame (don't give them a pointer to the frame data because it is totally worthless)
if (this.onFrameReady)
    this.onFrameReady(false, null, lastFrameType.marker, frameStart, lastFrameSize);
```
Note in above code `frame` argument is `null`.

But the callee in [flightlog.js:391](https://github.com/betaflight/blackbox-log-viewer/blob/master/js/flightlog.js#L391) currently seems to be missing a condition when processing G frames to avoid reading properties of `frame` (which is `null` in this case).

Without this change I get this exception in the console when opening the log:

![Screenshot from 2023-10-15 11-53-45](https://github.com/betaflight/blackbox-log-viewer/assets/33358/a3c98250-6cba-4a3b-abdc-043814cdf563)

After applying the change in this PR everything seems to be working correctly, file opens normally and eg. GPX Export produces correct output (tested in Google Earth).