### PR TITLE
Toggle trace/field visibility

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -792,13 +792,6 @@ html.has-config .configuration-list {
     padding-right: 0.7em;
 }
 
-.graph-legend-field {
-    margin-bottom: 0.5em;
-    cursor:pointer;
-    padding-left:  0.7em;
-    padding-right: 0.7em;
-}
-
 .graph-legend-field-name:hover {
     text-decoration: underline;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -792,6 +792,17 @@ html.has-config .configuration-list {
     padding-right: 0.7em;
 }
 
+.graph-legend-field {
+    margin-bottom: 0.5em;
+    cursor:pointer;
+    padding-left:  0.7em;
+    padding-right: 0.7em;
+}
+
+.graph-legend-field-name:hover {
+    text-decoration: underline;
+}
+
 .graph-legend-field-value {
     float: right;
 }
@@ -810,6 +821,11 @@ html.has-config .configuration-list {
 }
 
 .graph-legend-field > .glyphicon-equalizer {
+    float: right;
+    margin-left: 0.7em;
+}
+
+.graph-legend-field-visibility {
     float: right;
     margin-left: 0.7em;
 }

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -141,7 +141,6 @@ function GraphConfig(graphConfig) {
         } else {
             hiddenGraphFields.add(item);
         }
-        notifyListeners();
     };
 
     this.isGraphFieldHidden = (graphIndex, fieldIndex) => {

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -19,6 +19,8 @@ function GraphConfig(graphConfig) {
     this.highlightGraphIndex = null;
     this.highlightFieldIndex = null;
 
+    const hiddenGraphFields = new Set();
+
     this.getGraphs = function() {
         return graphs;
     };
@@ -28,6 +30,8 @@ function GraphConfig(graphConfig) {
      */
     this.setGraphs = function(newGraphs) {
         graphs = newGraphs;
+
+        hiddenGraphFields.clear();
 
         notifyListeners();
     };
@@ -128,6 +132,20 @@ function GraphConfig(graphConfig) {
 
     this.addListener = function(listener) {
         listeners.push(listener);
+    };
+
+    this.toggleGraphField = (graphIndex, fieldIndex) => {
+        const item = graphIndex + ":" + fieldIndex;
+        if (hiddenGraphFields.has(item)) {
+            hiddenGraphFields.delete(item);
+        } else {
+            hiddenGraphFields.add(item);
+        }
+        notifyListeners();
+    };
+
+    this.isGraphFieldHidden = (graphIndex, fieldIndex) => {
+        return hiddenGraphFields.has(graphIndex + ":" + fieldIndex);
     };
 }
 

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -64,7 +64,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
         });
 
         // Add a trigger on legend; select the analyser graph/field to plot
-        $('.graph-legend-field-name').on('click', function (e) {
+        $('.graph-legend-field-name, .graph-legend-field-settings, .graph-legend-field-value').on('click', function (e) {
 
             if(e.which!=1) return; // only accept left mouse clicks
 

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -148,6 +148,17 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                 fieldIndex = $this.attr('field');
 
             config.toggleGraphField(graphIndex, fieldIndex);
+            onHighlightChange();
+
+            if (config.isGraphFieldHidden(graphIndex, fieldIndex)) {
+                $this.removeClass("glyphicon-eye-open");
+                $this.addClass("glyphicon-eye-close");
+            } else {
+                $this.addClass("glyphicon-eye-open");
+                $this.removeClass("glyphicon-eye-close");
+            }
+
+            e.preventDefault();
         });
     }
 

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -139,7 +139,9 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
 
         // Add a trigger on legend; select the analyser graph/field to plot
         $('.graph-legend-field-visibility').on('click', function (e) {
-            if (e.which != 1) return; // only accept left mouse clicks
+            if (e.which != 1) {
+                return; // only accept left mouse clicks
+            }
 
             const $this = $(this),
                 graphIndex = $this.attr('graph'),

--- a/js/graph_legend.js
+++ b/js/graph_legend.js
@@ -8,7 +8,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
         var 
             graphs = config.getGraphs(),
             i, j;
-        
+
         targetElem.empty();
 
         for (i = 0; i < graphs.length; i++) {
@@ -27,10 +27,11 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
                     li = $('<li class="graph-legend-field field-quick-adjust" name="' + field.name + '" graph="' + i + '" field="' + j +'"></li>'),
                     nameElem = $('<span class="graph-legend-field-name field-quick-adjust" name="' + field.name + '" graph="' + i + '" field="' + j +'"></span>'),
                     valueElem = $('<span class="graph-legend-field-value field-quick-adjust" name="' + field.name + '" graph="' + i + '" field="' + j +'"></span>'),
-                    settingsElem = $('<div class="graph-legend-field-settings field-quick-adjust" name="' + field.name + '" graph="' + i + '" field="' + j +'"></div>'),
-                    analyseElem = $('<span class="glyphicon glyphicon-equalizer"></span>');
+                    settingsElem = $('<div class="graph-legend-field-settings field-quick-adjust" name="' + field.name + '" graph="' + i + '" field="' + j + '"></div>'),
+                    visibilityIcon = config.isGraphFieldHidden(i, j) ? "glyphicon-eye-close" : "glyphicon-eye-open",
+                    visibilityElem = $('<span class="glyphicon ' + visibilityIcon + ' graph-legend-field-visibility" graph="' + i + '" field="' + j + '"></span>');
                 li.append(nameElem);
-                li.append(analyseElem);
+                li.append(visibilityElem);
                 li.append(valueElem);
                 li.append(settingsElem);
 
@@ -63,7 +64,7 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
         });
 
         // Add a trigger on legend; select the analyser graph/field to plot
-        $('.graph-legend-field').on('click', function(e) {
+        $('.graph-legend-field-name').on('click', function (e) {
 
             if(e.which!=1) return; // only accept left mouse clicks
 
@@ -134,7 +135,18 @@ function GraphLegend(targetElem, config, onVisibilityChange, onNewSelectionChang
         });
 
         // on first show, hide the analyser button
-        if(!config.selectedFieldName) $('.hide-analyser-window').hide();
+        if (!config.selectedFieldName) $('.hide-analyser-window').hide();
+
+        // Add a trigger on legend; select the analyser graph/field to plot
+        $('.graph-legend-field-visibility').on('click', function (e) {
+            if (e.which != 1) return; // only accept left mouse clicks
+
+            const $this = $(this),
+                graphIndex = $this.attr('graph'),
+                fieldIndex = $this.attr('field');
+
+            config.toggleGraphField(graphIndex, fieldIndex);
+        });
     }
 
     this.updateValues = function (flightLog, frame) {

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -800,6 +800,9 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                         drawAxisBackground(canvas.height * graph.height);
                     
                     for (j = 0; j < graph.fields.length; j++) {
+                        if (graphConfig.isGraphFieldHidden(i, j)) {
+                            continue;
+                        }
                         var field = graph.fields[j];
                         plotField(chunks, startFrameIndex, field.index, field.curve, canvas.height * graph.height / 2, 
                             field.color ? field.color : GraphConfig.PALETTE[j % GraphConfig.PALETTE.length],


### PR DESCRIPTION
Fixes #380. I removed the equalizer icon from the legend because it had no real function and clicking on the field name had the same functionality (opening the analyzer display). Instead I replaced that icon with a toggle button to show/hide individual traces within a graph. The field names are now underlined on hover to indicate that they are clickable and open the analyser display just like before.

![Screenshot from 2023-10-19 14-44-46](https://github.com/betaflight/blackbox-log-viewer/assets/33358/e9c645c7-d503-4a15-af6b-d168bb0ea086)
