### PR TITLE
Remove special charachters from eRPM field

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -73,15 +73,15 @@ function FlightLogFieldPresenter() {
         'motor[6]': 'Motor [7]',
         'motor[7]': 'Motor [8]',
 
-        'eRPM(/100)[all]': 'RPM',
-        'eRPM(/100)[0]': 'RPM [1]',
-        'eRPM(/100)[1]': 'RPM [2]',
-        'eRPM(/100)[2]': 'RPM [3]',
-        'eRPM(/100)[3]': 'RPM [4]',
-        'eRPM(/100)[4]': 'RPM [5]',
-        'eRPM(/100)[5]': 'RPM [6]',
-        'eRPM(/100)[6]': 'RPM [7]',
-        'eRPM(/100)[7]': 'RPM [8]',
+        'eRPM[all]': 'RPM',
+        'eRPM[0]': 'RPM [1]',
+        'eRPM[1]': 'RPM [2]',
+        'eRPM[2]': 'RPM [3]',
+        'eRPM[3]': 'RPM [4]',
+        'eRPM[4]': 'RPM [5]',
+        'eRPM[5]': 'RPM [6]',
+        'eRPM[6]': 'RPM [7]',
+        'eRPM[7]': 'RPM [8]',
 
         'servo[all]': 'Servos',
         'servo[5]': 'Servo Tail',
@@ -1308,14 +1308,14 @@ function FlightLogFieldPresenter() {
             case 'motor[7]':
                 return `${flightLog.rcMotorRawToPctPhysical(value).toFixed(2)} %`;
 
-            case 'eRPM(/100)[0]':
-            case 'eRPM(/100)[1]':
-            case 'eRPM(/100)[2]':
-            case 'eRPM(/100)[3]':
-            case 'eRPM(/100)[4]':
-            case 'eRPM(/100)[5]':
-            case 'eRPM(/100)[6]':
-            case 'eRPM(/100)[7]':
+            case 'eRPM[0]':
+            case 'eRPM[1]':
+            case 'eRPM[2]':
+            case 'eRPM[3]':
+            case 'eRPM[4]':
+            case 'eRPM[5]':
+            case 'eRPM[6]':
+            case 'eRPM[7]':
                 let motor_poles = flightLog.getSysConfig()['motor_poles'];
                 return (value * 200 / motor_poles).toFixed(0) + " rpm / " + (value * 3.333 / motor_poles).toFixed(1) + ' hz';
 

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -286,8 +286,8 @@ GraphConfig.load = function(config) {
                         DSHOT_RANGE / 2 : (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
                     outputRange: 1.0,
                 };
-            } else if (fieldName.match(/^eRPM\(\/100\)\[/)) {
-                return getCurveForMinMaxFields('eRPM(/100)[0]', 'eRPM(/100)[1]', 'eRPM(/100)[2]', 'eRPM(/100)[3]', 'eRPM(/100)[4]', 'eRPM(/100)[5]', 'eRPM(/100)[6]', 'eRPM(/100)[7]');
+            } else if (fieldName.match(/^eRPM\[/)) {
+                return getCurveForMinMaxFields('eRPM[0]', 'eRPM[1]', 'eRPM[2]', 'eRPM[3]', 'eRPM[4]', 'eRPM[5]', 'eRPM[6]', 'eRPM[7]');
             } else if (fieldName.match(/^servo\[/)) {
                 return {
                     offset: -1500,
@@ -1000,7 +1000,7 @@ GraphConfig.load = function(config) {
             EXAMPLE_GRAPHS.push({label: "Motors (Legacy)",fields: ["motorLegacy[all]", "servo[5]"]});
         }
         if (!flightLog.isFieldDisabled().RPM) {
-            EXAMPLE_GRAPHS.push({label: "RPM",fields: ["eRPM(/100)[all]"]});
+            EXAMPLE_GRAPHS.push({label: "RPM",fields: ["eRPM[all]"]});
         }
         if (!flightLog.isFieldDisabled().GYRO) {
             EXAMPLE_GRAPHS.push({label: "Gyros",fields: ["gyroADC[all]"]});


### PR DESCRIPTION
The labels of the RPM fields was changed from `eRPM(/100)` to `eRPM` in 
https://github.com/betaflight/betaflight/pull/13123 . This PR does the same in log viewer to so the RPM fields are once again correctly formatted.