### PR TITLE
Added setting of minimum and maximum values of curves on the graph.

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -258,7 +258,9 @@ GraphConfig.load = function(config) {
                 offset: -(mm.max + mm.min) / 2,
                 power: 1.0,
                 inputRange: Math.max((mm.max - mm.min) / 2, 1.0),
-                outputRange: 1.0
+                outputRange: 1.0,
+				MinMax: mm,
+                EnabledMinMax: false
             };
         }
 
@@ -269,13 +271,15 @@ GraphConfig.load = function(config) {
                 offset: 0,
                 power: 1.0,
                 inputRange: Math.max(Math.max(Math.abs(mm.max), Math.abs(mm.min)), 1.0),
-                outputRange: 1.0
+                outputRange: 1.0,
+				MinMax: mm,
+                EnabledMinMax: false
             };
         }
 
         const gyroScaleMargin = 1.20; // Give a 20% margin for gyro graphs
         const highResolutionScale = sysConfig.blackbox_high_resolution > 0 ? 10 : 1;
-
+        var mm = getMinMaxForFields(fieldName);
         try {
             if (fieldName.match(/^motor\[/)) {
                 return {
@@ -285,6 +289,8 @@ GraphConfig.load = function(config) {
                     inputRange: flightLog.isDigitalProtocol() ?
                         DSHOT_RANGE / 2 : (sysConfig.maxthrottle - sysConfig.minthrottle) / 2,
                     outputRange: 1.0,
+                    MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^eRPM\[/)) {
                 return getCurveForMinMaxFields('eRPM[0]', 'eRPM[1]', 'eRPM[2]', 'eRPM[3]', 'eRPM[4]', 'eRPM[5]', 'eRPM[6]', 'eRPM[7]');
@@ -293,21 +299,27 @@ GraphConfig.load = function(config) {
                     offset: -1500,
                     power: 1.0,
                     inputRange: 500,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^accSmooth\[/)) {
                 return {
                     offset: 0,
                     power: 0.5,
                     inputRange: sysConfig.acc_1G * 16.0, /* Reasonable typical maximum for acc */
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == "rcCommands[3]") { // Throttle scaled
                 return {
                     offset: -50,
                     power: 1.0, /* Make this 1.0 to scale linearly */
                     inputRange: 50,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^axisError\[/)  ||     // Gyro, Gyro Scaled, RC Command Scaled and axisError
                        fieldName.match(/^rcCommands\[/) ||     // These use the same scaling as they are in the
@@ -317,77 +329,99 @@ GraphConfig.load = function(config) {
                     offset: 0,
                     power: 0.25, /* Make this 1.0 to scale linearly */
                     inputRange: maxDegreesSecond(gyroScaleMargin * highResolutionScale), // Maximum grad/s + 20%
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^axis.+\[/)) {
                 return {
                     offset: 0,
                     power: 0.3,
                     inputRange: 1000, // Was 400 ?
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == "rcCommand[3]") { // Throttle
                 return {
                     offset: -1500 * highResolutionScale,
                     power: 1.0,
                     inputRange: 500 * highResolutionScale,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^rcCommand\[/)) {
                 return {
                     offset: 0,
                     power: 0.25,
                     inputRange: 500 * highResolutionScale * gyroScaleMargin, // +20% to let compare in the same scale with the rccommands
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == "heading[2]") {
                 return {
                     offset: -Math.PI,
                     power: 1.0,
                     inputRange: Math.PI,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^heading\[/)) {
                 return {
                     offset: 0,
                     power: 1.0,
                     inputRange: Math.PI,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^sonar.*/)) {
                 return {
                     offset: -200,
                     power: 1.0,
                     inputRange: 200,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+					MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^rssi.*/)) {
                 return {
                     offset: -512,
                     power: 1.0,
                     inputRange: 512,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+                    MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == 'GPS_ground_course') {
                 return {
                     offset: -1800,
                     power: 1.0,
                     inputRange: 1800,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+                    MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == 'GPS_numSat') {
                 return {
                     offset: -20,
                     power: 1.0,
                     inputRange: 20,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+                    MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName == 'GPS_speed') {
                 return {
                     offset: 0,
                     power: 1.0,
                     inputRange: 1000,
-                    outputRange: 1.0
+                    outputRange: 1.0,
+                    MinMax: mm,
+                    EnabledMinMax: false
                 };
             } else if (fieldName.match(/^debug.*/) && sysConfig.debug_mode!=null) {
 
@@ -400,14 +434,18 @@ GraphConfig.load = function(config) {
                                     offset: -50,
                                     power: 1,
                                     inputRange: 50,
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return {
                                     offset: -1000,    // zero offset
                                     power: 1.0,
                                     inputRange: 1000, //  0-2000uS
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+									MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                         }
                     case 'PIDLOOP':
@@ -415,7 +453,9 @@ GraphConfig.load = function(config) {
                                 offset: -250,    // zero offset
                                 power: 1.0,
                                 inputRange: 250, //  0-500uS
-                                outputRange: 1.0
+                                outputRange: 1.0,
+								MinMax: mm,
+                                EnabledMinMax: false
                             };
                     case 'GYRO':
                     case 'GYRO_FILTERED':
@@ -432,21 +472,27 @@ GraphConfig.load = function(config) {
                             offset: 0,
                             power: 0.25,
                             inputRange: maxDegreesSecond(gyroScaleMargin), // Maximum grad/s + 20%
-                            outputRange: 1.0
+                            outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'ACCELEROMETER':
                         return {
                             offset: 0,
                             power: 0.5,
                             inputRange: sysConfig.acc_1G * 16.0, /* Reasonable typical maximum for acc */
-                            outputRange: 1.0
+                            outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'MIXER':
                         return {
                             offset: -(sysConfig.motorOutput[1] + sysConfig.motorOutput[0]) / 2,
                             power: 1.0,
                             inputRange: (sysConfig.motorOutput[1] - sysConfig.motorOutput[0]) / 2,
-                            outputRange: 1.0
+                            outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'BATTERY':
                         switch (fieldName) {
@@ -455,14 +501,18 @@ GraphConfig.load = function(config) {
                                     offset: -2048,
                                     power: 1,
                                     inputRange: 2048,
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return {
                                     offset: -130,
                                     power: 1.0,
                                     inputRange: 130, // 0-26.0v
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                         }
                     case 'RC_INTERPOLATION':
@@ -480,7 +530,9 @@ GraphConfig.load = function(config) {
                                     offset: 0,
                                     power: 0.25,
                                     inputRange: 500 * gyroScaleMargin, // +20% to let compare in the same scale with the rccommands
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // raw RC command derivative
                             case 'debug[2]': // smoothed RC command derivative
@@ -501,7 +553,9 @@ GraphConfig.load = function(config) {
                             offset: 0,
                             power: 0.25, /* Make this 1.0 to scale linearly */
                             inputRange: maxDegreesSecond(gyroScaleMargin), // Maximum grad/s + 20%
-                            outputRange: 1.0
+                            outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'ALTITUDE':
                         switch (fieldName) {
@@ -511,6 +565,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // Baro Alt
                             case 'debug[2]': // GPS Alt
@@ -519,6 +575,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // Vario
                                 return {
@@ -526,6 +584,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 500,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -539,7 +599,9 @@ GraphConfig.load = function(config) {
                                     offset: 0,
                                     power: 1.0,
                                     inputRange: maxDegreesSecond(gyroScaleMargin), // Maximum grad/s + 20%
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -555,7 +617,9 @@ GraphConfig.load = function(config) {
                                     offset: 0,
                                     power: 1.0,
                                     inputRange: maxDegreesSecond(gyroScaleMargin), // Maximum grad/s + 20%
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -571,7 +635,9 @@ GraphConfig.load = function(config) {
                                     offset: 0,
                                     power: 0.25,
                                     inputRange: maxDegreesSecond(gyroScaleMargin), // Maximum grad/s + 20%
-                                    outputRange: 1.0
+                                    outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -581,7 +647,9 @@ GraphConfig.load = function(config) {
                             offset: 0,
                             power: 1.0,
                             inputRange: 100,
-                            outputRange: 1.0
+                            outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'ESC_SENSOR_RPM':
                     case 'DSHOT_RPM_TELEMETRY':
@@ -616,6 +684,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // Clip or Count
                                 return {
@@ -623,6 +693,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -635,6 +707,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: maxDegreesSecond(gyroScaleMargin),
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // feedforward delta element
                             case 'debug[2]': // feedforward boost element
@@ -643,6 +717,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // rcCommand delta
                                 return {
@@ -650,6 +726,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -661,6 +739,8 @@ GraphConfig.load = function(config) {
                             power: 1.0,
                             inputRange: 300,
                             outputRange: 1.0,
+                            MinMax: mm,
+                            EnabledMinMax: false
                         };
                     case 'BARO':
                         switch (fieldName) {
@@ -670,6 +750,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 20,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // Baro Temp
                             case 'debug[2]': // Baro Raw
@@ -679,6 +761,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -692,6 +776,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // Altitude
                             case 'debug[3]': // Target Altitude
@@ -700,6 +786,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -714,6 +802,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // in 4.3 and 4.2 is minRPS
                                 return {
@@ -721,6 +811,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -733,6 +825,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             // debug 1 is Count of Unknown Frames
                             // debug 2 and 3 not used
@@ -750,6 +844,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 128,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // LQ percent
                                 return {
@@ -757,6 +853,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 50,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -769,6 +867,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // ID of late task
                             case 'debug[2]': // task delay time 100us in middle
@@ -777,6 +877,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // gyro skew 100 = 10us
                                 return {
@@ -784,6 +886,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 500,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -797,6 +901,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 50,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // total delay in last second
                                 return {
@@ -804,6 +910,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 500,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // total tasks per second
                                 return {
@@ -811,6 +919,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -823,6 +933,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 50,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             // debug 0 = Lost connection count
                             // debug 1 = RSSI
@@ -849,6 +961,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // Velocity in cm/s
                             case 'debug[3]': // Velocity to home in cm/s
@@ -857,6 +971,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 500,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -869,6 +985,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // GPS GroundCourse
                             case 'debug[2]': // Yaw attitude * 10
@@ -879,6 +997,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1800,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[5]': // magYaw * 10
                                 return {
@@ -886,6 +1006,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[6]': // roll angle *100
                                 return {
@@ -893,6 +1015,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 900,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[7]': // yaw rate deg/s
                                 return {
@@ -900,6 +1024,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 100,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -912,6 +1038,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 4000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // Rescue Phase
                             case 'debug[2]': // Failure code
@@ -920,6 +1048,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // Failure counters coded
                                 return {
@@ -927,6 +1057,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -940,6 +1072,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // altitude m
                             case 'debug[3]': // Target altitude m
@@ -948,6 +1082,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -961,6 +1097,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // task interval
                                 return {
@@ -968,6 +1106,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // Baud rate / resolved packet interval
                             case 'debug[4]': // State*100 + SubState
@@ -978,6 +1118,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 100,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[6]': // ackState
                                 return {
@@ -985,6 +1127,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[7]': // Incoming buffer
                                 return {
@@ -992,6 +1136,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 100,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1007,6 +1153,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1022,6 +1170,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1035,6 +1185,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[1]': // angle error correction
                             case 'debug[2]': // angle feedforward
@@ -1043,6 +1195,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 5000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1058,6 +1212,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 200,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1073,6 +1229,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[4]': // X Cal
                             case 'debug[5]': // Y Cal
@@ -1082,6 +1240,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 500,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[7]': // Lambda
                                 return {
@@ -1089,6 +1249,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1102,6 +1264,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 1000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[2]': // Data Interval
                                 return {
@@ -1109,6 +1273,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[3]': // Execute Time
                                 return {
@@ -1116,6 +1282,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 20,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[4]': // Bus Busy Check
                             case 'debug[5]': // Read State Check
@@ -1124,6 +1292,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 2,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             case 'debug[6]': // Time since previous task uS
                                 return {
@@ -1131,6 +1301,8 @@ GraphConfig.load = function(config) {
                                     power: 1.0,
                                     inputRange: 10000,
                                     outputRange: 1.0,
+                                    MinMax: mm,
+                                    EnabledMinMax: false
                                 };
                             default:
                                 return getCurveForMinMaxFields(fieldName);
@@ -1145,7 +1317,9 @@ GraphConfig.load = function(config) {
                 offset: 0,
                 power: 1.0,
                 inputRange: 500,
-                outputRange: 1.0
+                outputRange: 1.0,
+                MinMax: mm,
+                EnabledMinMax: false
             };
         }
     };

--- a/js/graph_config_dialog.js
+++ b/js/graph_config_dialog.js
@@ -87,10 +87,24 @@ function GraphConfigurationDialog(dialog, onSave) {
             if(field.curve!=null) {
                 $('input[name=power]',elem).val((field.curve.power!=null)?(field.curve.power*100).toFixed(0)+'%':(GraphConfig.getDefaultCurveForField(flightLog, field.name).power*100)+'%');
                 $('input[name=scale]',elem).val((field.curve.outputRange!=null)?(field.curve.outputRange*100).toFixed(0)+'%':(GraphConfig.getDefaultCurveForField(flightLog, field.name).outputRange*100)+'%');
+                $('input[name=EnabledMinMax]',elem).attr("checked", (field.curve.EnabledMinMax)? field.curve.EnabledMinMax:false);				
+				if(field.curve.MinMax!=null) {
+					// Set the line MinMax values !!!
+					$('input[name=MinValue]',elem).val((field.curve.MinMax.min)?field.curve.MinMax.min:(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.min));		
+					$('input[name=MaxValue]',elem).val((field.curve.MinMax.max)?field.curve.MinMax.max:(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.max));
+				}
+				else{
+					$('input[name=MinValue]',elem).val(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.min);
+					$('input[name=MaxValue]',elem).val(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.max);
+				}
+				
             } else
             {
                 $('input[name=power]',elem).val((GraphConfig.getDefaultCurveForField(flightLog, field.name).power*100).toFixed(0)+'%');
                 $('input[name=scale]',elem).val((GraphConfig.getDefaultCurveForField(flightLog, field.name).outputRange*100).toFixed(0)+'%');
+				$('input[name=MinValue]',elem).val(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.min);
+				$('input[name=MaxValue]',elem).val(GraphConfig.getDefaultCurveForField(flightLog, field.name).MinMax.max);
+				$('input[name=EnabledMinMax]',elem).attr("checked", false);
             }
         }
     }
@@ -110,6 +124,9 @@ function GraphConfigurationDialog(dialog, onSave) {
                     + '<td><input name="linewidth" class="form-control" type="text"/></td>'
                     + '<td><select class="color-picker"></select></td>'
                     + '<td><input name="grid" type="checkbox"/></td>'
+					+ '<td><input name="EnabledMinMax" type="checkbox"/></td>'
+					+ '<td><input name="MinValue" class="form-control" type="text"/></td>'
+					+ '<td><input name="MaxValue" class="form-control" type="text"/></td>'
                     + '<td><button type="button" class="btn btn-default btn-sm"><span class="glyphicon glyphicon-trash"></span></button></td>'
                 + '</tr>'
             ),
@@ -187,6 +204,9 @@ function GraphConfigurationDialog(dialog, onSave) {
                                                     + '<th name="line">Line</th>'
                                                     + '<th name="color">Color</th>'
                                                     + '<th name="grid">Grid</th>'
+                                                    + '<th name="on_minmax">MinMax</th>'
+                                                    + '<th name="MinValue">Minimum</th>'
+                                                    + '<th name="MaxValue">Maximum</th>'    
                                                 + '</tr>'
                                             + '</thead>'
                                             + '<tbody>'
@@ -315,12 +335,22 @@ function GraphConfigurationDialog(dialog, onSave) {
                     smoothing: parseInt($("input[name=smoothing]", this).val())*100,        // Value 0-100%    = 0-10000uS (higher values are more smooth, 30% is typical)
                     curve: {
                         power: parseInt($("input[name=power]", this).val())/100.0,          // Value 0-100%    = 0-1.0 (lower values exaggerate center values - expo)
-                        outputRange: parseInt($("input[name=scale]", this).val())/100.0     // Value 0-100%    = 0-1.0 (higher values > 100% zoom in graph vertically)
+                        outputRange: parseInt($("input[name=scale]", this).val())/100.0,     // Value 0-100%    = 0-1.0 (higher values > 100% zoom in graph vertically)
+						MinMax: {
+							min: parseInt($("input[name=MinValue]", this).val()),
+							max: parseInt($("input[name=MaxValue]", this).val())
+						},
+						EnabledMinMax: $('input[name=EnabledMinMax]', this).is(':checked')
                     },
                     default: { // These are used to restore configuration if using mousewheel adjustments
                         smoothing: parseInt($("input[name=smoothing]", this).val())*100,
                         power: parseInt($("input[name=power]", this).val())/100.0,
-                        outputRange: parseInt($("input[name=scale]", this).val())/100.0
+                        outputRange: parseInt($("input[name=scale]", this).val())/100.0,
+						MinMax: {
+							min: parseInt($("input[name=MinValue]", this).val()),
+							max: parseInt($("input[name=MaxValue]", this).val())
+						},
+						EnabledMinMax: $('input[name=EnabledMinMax]', this).is(':checked')
                     },
                     color: $('select.color-picker option:selected', this).val(),
                     lineWidth: parseInt($("input[name=linewidth]", this).val()),

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -911,6 +911,12 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                 
                 field.index = flightLog.getMainFieldIndexByName(field.name);
                 
+                // Convert data if use MinMax
+                if(field.curve.EnabledMinMax)
+                {
+                    field.curve.inputRange = (field.curve.MinMax.max - field.curve.MinMax.min) / 2;
+                    field.curve.offset = -(field.curve.MinMax.max + field.curve.MinMax.min) / 2;
+                }
                 // Convert the field's curve settings into an actual expo curve object:
                 field.curve = new ExpoCurve(field.curve.offset, 
                                             ((options.graphExpoOverride)?1.0:field.curve.power), 


### PR DESCRIPTION
Added setting of minimum and maximum values of curves on the graph.
The revision is fully compatible with the previous scaling method.

To use it, you need to:

Open "Configure graphs" dialog box.
Check new "MM" checbox on curve settings.
Set required values for minimum and maximum chart values for curve (there are real min max values as default).
You need to input min and max values in primary units as in logfile. You can look it at default min max values in text fields,
Click "Save changes".
This is the most versatile way to configure curves.
If it is necessary to plot curves along the same axis, then you need to set the same or proportional ranges of values for them.

With unchecked "MM" checkbox the curve scaled in the standard way, as before.

There is a first step for improvment of curve scales. It will be improved in the future.
For example, it will be possible to automatically combine several curves on one axis.