### PR TITLE
NWjs versioning depending on OS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ console.log('osPlatform: '+osPlatform);
 console.log('osRelease: '+osRelease);
 
 switch (osPlatform) {
-    case 'darwin':
+    case 'osx64':
         NWversion ='0.72.0';
         break;
     case 'win32':

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ let NWversion;
 const osPlatform = getDefaultPlatform();
 const osRelease = os.release();
 console.log('osPlatform:', osPlatform);
-console.log('osRelease: '+osRelease);
+console.log('osRelease:', osRelease);
 
 switch (osPlatform) {
     case 'osx64':

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ const LINUX_INSTALL_DIR = '/opt/betaflight';
 let NWversion;
 const osPlatform = getDefaultPlatform();
 const osRelease = os.release();
-console.log('osPlatform: '+osPlatform);
+console.log('osPlatform:', osPlatform);
 console.log('osRelease: '+osRelease);
 
 switch (osPlatform) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,8 +25,27 @@ const RELEASE_DIR = './release/';
 
 const LINUX_INSTALL_DIR = '/opt/betaflight';
 
+var NWversion;
+const osPlatform = getDefaultPlatform();
+const osRelease = os.release();
+console.log('osPlatform: '+osPlatform);
+console.log('osRelease: '+osRelease);
+
+switch (osPlatform) {
+    case 'darwin':
+        NWversion ='0.72.0';
+        break;
+    case 'win32':
+        NWversion ='0.42.6';
+        break;
+    default:
+        NWversion ='0.83.0';
+        break;
+}
+
+console.log('NWjs version: '+NWversion);
 var nwBuilderOptions = {
-    version: '0.83.0',
+    version: NWversion,
     files: './dist/**/*',
     macIcns: './images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Blackbox Explorer'},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ const RELEASE_DIR = './release/';
 
 const LINUX_INSTALL_DIR = '/opt/betaflight';
 
-var NWversion;
+let NWversion;
 const osPlatform = getDefaultPlatform();
 const osRelease = os.release();
 console.log('osPlatform: '+osPlatform);


### PR DESCRIPTION
* NWjs versioning depending on OS; this is not preferred, but maybe necessary
* fixes https://github.com/betaflight/blackbox-log-viewer/issues/696
* proof-of-concept; DRAFT while in discussion/consideration
* this PR will re-test historical failure of GitHub action for NWjs 0.72.0
* win32 was not part of the issue, but added it as such is known to work.
