### PR TITLE
Set gyro_sample graph scaling to the same as other gyro graphs

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -725,6 +725,21 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                             }
+                    case 'GYRO_SAMPLE':
+                        switch (fieldName) {
+                            case 'debug[0]': // Before downsampling
+                            case 'debug[1]': // After downsampling
+                            case 'debug[2]': // After RPM
+                            case 'debug[3]': // After all but Dyn Notch
+                            return {
+                                offset: 0,
+                                power: 0.25, /* Make this 1.0 to scale linearly */
+                                inputRange: maxDegreesSecond(gyroScaleMargin * highResolutionScale), // Maximum grad/s + 20%
+                                outputRange: 1.0
+                            };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                            }
                     case 'RX_TIMING':
                         switch (fieldName) {
                             case 'debug[0]': // CRC 0 to max int16_t


### PR DESCRIPTION
Mike Nomatter noted, on Discord, that the appearance of the spectrum for the un-filtered gyro in `debug_gyro_sample` differed from the spectrum for unfiltered gyro from the same axis.  

This was because the scaling for `debug_gyro_sample`was not being defaulted to the same as for other gyro traces.

Fixed, I think, with this PR.

![Screen Shot 2024-02-04 at 23 15 21](https://github.com/betaflight/blackbox-log-viewer/assets/11737748/0cdf6cfa-7f65-4d8d-a47e-24893418860a)

