### PR TITLE
Update battery debug scaling and names

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -145,14 +145,14 @@ function FlightLogFieldPresenter() {
         },
         'BATTERY' : {
             'debug[all]':'Debug Battery',
-            'debug[0]':'Battery Volt ADC',
-            'debug[1]':'Battery Volt',
-            'debug[2]':'Not Used',
-            'debug[3]':'Not Used',
-            'debug[4]':'Not Used',
-            'debug[5]':'Not Used',
-            'debug[6]':'Not Used',
-            'debug[7]':'Not Used',
+            'debug[0]':'Battery Raw',
+            'debug[1]':'Battery Filtered',
+            'debug[2]':'Sag Goodness',
+            'debug[3]':'Sag Attenuation',
+            'debug[4]':'isVoltageStable',
+            'debug[5]':'isVoltageFromBattery',
+            'debug[6]':'VoltageStep',
+            'debug[7]':'voltageState',
         },
         'GYRO' : {
             'debug[all]':'Debug Gyro',
@@ -1547,10 +1547,13 @@ function FlightLogFieldPresenter() {
                     }
                 case 'BATTERY':
                     switch (fieldName) {
-                        case 'debug[0]':
+                        case 'debug[2]':
+                        case 'debug[4]':
+                        case 'debug[5]':
+                        case 'debug[7]':
                             return value.toFixed(0);
                         default:
-                            return (value / 10).toFixed(1) + " V";
+                            return (value / 100).toFixed(2) + " V";
                     }
                 case 'ACCELEROMETER':
                     return flightLog.accRawToGs(value).toFixed(2) + " g";

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -450,18 +450,34 @@ GraphConfig.load = function(config) {
                         };
                     case 'BATTERY':
                         switch (fieldName) {
-                            case 'debug[0]': //Raw Value (0-4095)
+                            case 'debug[0]': // Raw Value (0-4095) but 6S is around 24V so this is OK
+                            case 'debug[1]': // Filtered Voltage value
+                            case 'debug[6]': // Voltage steps during cell count
                                 return {
-                                    offset: -2048,
-                                    power: 1,
-                                    inputRange: 2048,
+                                    offset: -1250,
+                                    power: 1.0,
+                                    inputRange: 1250,
                                     outputRange: 1.0
                                 };
-                            default:
+                            case 'debug[2]': // VBat Sag Goodness 0-100
                                 return {
-                                    offset: -130,
+                                    offset: -100,
                                     power: 1.0,
-                                    inputRange: 130, // 0-26.0v
+                                    inputRange: 100,
+                                    outputRange: 1.0
+                                };
+                            case 'debug[3]': // VBat Sag Attenuation volts * 100 
+                                return {
+                                    offset: -500,
+                                    power: 1.0,
+                                    inputRange: 500,
+                                    outputRange: 1.0,
+                                };
+                            default: // others are counters or boolean
+                                return {
+                                    offset: -10,
+                                    power: 1.0,
+                                    inputRange: 10, // 
                                     outputRange: 1.0
                                 };
                         }


### PR DESCRIPTION
Quick PR to update the battery debug names to suit the recent firmware PR changes.

Allows testing firmware cell count detection.

Temporary only; not for merging.  When the min/max PR is complete, we can update a lot of this stuff.