### PR TITLE
Scale and display EZLANDING debug fields as percentages

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -1885,6 +1885,8 @@ function FlightLogFieldPresenter() {
                     return value.toFixed(0);
                 case 'DSHOT_TELEMETRY_COUNTS':
                     return value.toFixed(0);
+                case 'EZLANDING':
+                    return `${(value / 100.0).toFixed(2)} %`;
             }
             return value.toFixed(0);
         }

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -1150,6 +1150,13 @@ GraphConfig.load = function(config) {
                             default:
                                 return getCurveForMinMaxFields(fieldName);
                         }
+                    case 'EZLANDING':
+                        return {
+                            offset: -5000,
+                            power: 1.0,
+                            inputRange: 5000,
+                            outputRange: 1.0,
+                        };
                 }
             }
             // if not found above then


### PR DESCRIPTION
Scales EZLANDING debug values to match each other and throttle setpoint.  Also displays the values as percentages rather than raw values.
![image](https://github.com/betaflight/blackbox-log-viewer/assets/6018638/039cb295-fa6e-467d-88d6-66f158edeae6)
