### PR TITLE
Added warning at the status bar while actual log rate is less then required

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1712,3 +1712,7 @@ dialog h3 {
     padding-right: 9px;
     line-height: 28px;
 }
+
+.actual-lograte {
+    color: red;
+}

--- a/index.html
+++ b/index.html
@@ -614,6 +614,9 @@
             <span class="lograte">-</span>
         </div>
         <div>
+            <span class="actual-lograte">-</span>
+        </div>
+        <div>
             <span class="flight-mode">-</span>
         </div>
         <div>

--- a/js/graph_spectrum_calc.js
+++ b/js/graph_spectrum_calc.js
@@ -57,9 +57,9 @@ GraphSpectrumCalc.initialize = function(flightLog, sysConfig) {
             actualRate: this._actualeRate,
             betaflightRate: this._BetaflightRate,
         };
-    }
-    else
+    } else {
         $('.actual-lograte').text("");
+    }
 
     return undefined;
 };

--- a/js/graph_spectrum_calc.js
+++ b/js/graph_spectrum_calc.js
@@ -52,11 +52,15 @@ GraphSpectrumCalc.initialize = function(flightLog, sysConfig) {
             this._blackBoxRate = Math.round(this._actualeRate);
 
     if (this._BetaflightRate !== this._blackBoxRate) {
+        $('.actual-lograte').text(this._actualeRate.toFixed(0) + "/" + this._BetaflightRate.toFixed(0)+"Hz");
         return {
             actualRate: this._actualeRate,
             betaflightRate: this._BetaflightRate,
         };
     }
+    else
+        $('.actual-lograte').text("");
+
     return undefined;
 };
 


### PR DESCRIPTION
This PR continue improvements, what started in #711
The actual log samples rate warning is showed at the status bar when it much less then setup setting.
The log file for testing:  
[0.5K Hyro1_RCC_SP_PID_RPM MOTOR 236 bad.TXT](https://github.com/betaflight/blackbox-log-viewer/files/14526392/0.5K.Hyro1_RCC_SP_PID_RPM.MOTOR.236.bad.TXT)

