### PR TITLE
Flightlog min-max stat data computing is improved

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -80,16 +80,21 @@ function FlightLog(logData) {
      * that the flightlog presents as one merged frame.
      */
     this.getStats = function(logIndex) {
-        var
-            rawStats = getRawStats(logIndex);
+        let rawStats = getRawStats(logIndex);
 
-        // Just modify the raw stats variable to add this field, the parser won't mind the extra field appearing:
-        if (rawStats.frame.S) {
-            rawStats.field = rawStats.frame.I.field.concat(rawStats.frame.S.field);
-        } else {
-            rawStats.field = rawStats.frame.I.field;
+        if (rawStats.field == undefined) {
+            rawStats.field = [];
+            for (let i=0; i<rawStats.frame.I.field.length; ++i) {
+                rawStats.field[i] = {
+                    min: Math.min(rawStats.frame.I.field[i].min, rawStats.frame.P.field[i].min),
+                    max: Math.max(rawStats.frame.I.field[i].max, rawStats.frame.P.field[i].max)
+                };
+            }
+
+            if (rawStats.frame.S) {
+                rawStats.field = rawStats.field.concat(rawStats.frame.S.field);
+            }
         }
-
         return rawStats;
     };
 

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -228,13 +228,13 @@ GraphConfig.load = function(config) {
 
         var getMinMaxForFields = function(/* fieldName1, fieldName2, ... */) {
             // helper to make a curve scale based on the combined min/max of one or more fields
-            var
+            let
                 stats = flightLog.getStats(),
                 min = Number.MAX_VALUE,
-                max = Number.MIN_VALUE;
+                max = -Number.MAX_VALUE;
 
-            for(var i in arguments) {
-                var
+            for(let i in arguments) {
+                let
                     fieldIndex = flightLog.getMainFieldIndexByName(arguments[i]),
                     fieldStat = fieldIndex !== undefined ? stats.field[fieldIndex] : false;
 
@@ -244,7 +244,7 @@ GraphConfig.load = function(config) {
                 }
             }
 
-            if (min != Number.MAX_VALUE && max != Number.MIN_VALUE) {
+            if (min != Number.MAX_VALUE && max != -Number.MAX_VALUE) {
                 return {min:min, max:max};
             }
 


### PR DESCRIPTION
The current flightLog function uses the 'I' frame only (without 'P' frame) to compute stat min-max curves information. Therefore it has some error in stat min-max values sometime.
This PR uses 'I'and 'P' log data frames for computing fields min-max values. It get more accurate results.