### PR TITLE
feat: fix delete workspace on reload

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1062,7 +1062,7 @@ function BlackboxLogViewer() {
 
         // initial load of the configuration defaults if we have them
         prefs.get('workspaceGraphConfigs', function(item) {
-            if(item) {
+            if (item) {
                 workspaceGraphConfigs = upgradeWorkspaceFormat(item);
             } else {
                 workspaceGraphConfigs = [];

--- a/src/main.js
+++ b/src/main.js
@@ -1059,6 +1059,24 @@ function BlackboxLogViewer() {
         }
 
         graphLegend = new GraphLegend($(".log-graph-legend"), activeGraphConfig, onLegendVisbilityChange, onLegendSelectionChange, onLegendHighlightChange, zoomGraphConfig, expandGraphConfig, newGraphConfig);
+
+        // initial load of the configuration defaults if we have them
+        prefs.get('workspaceGraphConfigs', function(item) {
+            if(item) {
+                workspaceGraphConfigs = upgradeWorkspaceFormat(item);
+            } else {
+                workspaceGraphConfigs = [];
+            }
+        });
+
+        prefs.get('activeWorkspace', function (id){
+            if (id) {
+                activeWorkspace = id
+            }
+            else {
+                activeWorkspace = 1
+            }
+        });
         
         workspaceSelection = new WorkspaceSelection($(".log-workspace-selection"), workspaceGraphConfigs, onSwitchWorkspace, onSaveWorkspace);
         onSwitchWorkspace(workspaceGraphConfigs, workspaceSelection);

--- a/src/workspace_selection.js
+++ b/src/workspace_selection.js
@@ -1,3 +1,5 @@
+const UNTITLED = "Untitled";
+
 export function WorkspaceSelection(targetElem, workspaces, onSelectionChange, onSaveWorkspace) {
     var
         numberSpan = null,
@@ -39,7 +41,7 @@ export function WorkspaceSelection(targetElem, workspaces, onSelectionChange, on
         var inputElem = $('<input type="text" onkeyup="event.preventDefault()">');
         inputElem.click((e) => e.stopPropagation()); // Stop click from closing
         titleSpan.replaceWith(inputElem);
-        inputElem.val(workspaces[activeId].title)
+        inputElem.val(workspaces[activeId]?.title)
         inputElem.focus();
         inputElem.on('focusout', () => {
             inputElem.replaceWith(titleSpan);
@@ -88,7 +90,7 @@ export function WorkspaceSelection(targetElem, workspaces, onSelectionChange, on
             var saveButton = $('<span class="glyphicon glyphicon-floppy-disk" aria-hidden="true" data-toggle="tooltip" title="Save current graph setup to this Workspace"></span>');
             saveButton.click((e) => {
                 if (!element) {
-                    onSaveWorkspace(id, "Unnamed");
+                    onSaveWorkspace(id, UNTITLED);
                 }
                 else {
                     onSaveWorkspace(id, element.title);


### PR DESCRIPTION
This PR fixes the issue where if workspace file was loaded in, reloading the page would reset them.

There is still issues it seems with creating new workspace layouts, will address in separate PR