### PR TITLE
The bug fix: empty string names  for the DEBUG traces what are unused

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -1910,7 +1910,7 @@ function FlightLogFieldPresenter() {
                     debugFields = DEBUG_FRIENDLY_FIELD_NAMES[DEBUG_MODE[0]];
                 }
 
-                return debugFields[fieldName];
+                return debugFields[fieldName] ?? fieldName;
             }
         }
         if (FRIENDLY_FIELD_NAMES[fieldName]) {


### PR DESCRIPTION
The bug fix: empty string names for the DEBUG traces what are unused.
This bag was reported by @ctzsnooze
https://github.com/betaflight/blackbox-log-viewer/pull/689#issuecomment-2031647627
