### PR TITLE
Add Thrust Linear

### DIFF
--- a/index.html
+++ b/index.html
@@ -1278,7 +1278,6 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    </td>
                                                     <td name="abs_control_gain">
                                                         <label>Absolute Control</label>
                                                         <input type="text" step="1" min="0" max="999" />

--- a/index.html
+++ b/index.html
@@ -1287,6 +1287,9 @@
                                                     <td name='use_integrated_yaw'>
                                                         <label>Integrated Yaw</label>
                                                         <select>
+                                                    <td name='thrust_linear'>
+                                                        <label>Thrust Linear</label>
+                                                        <select>
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>

--- a/index.html
+++ b/index.html
@@ -1287,6 +1287,9 @@
                                                     <td name='use_integrated_yaw'>
                                                         <label>Integrated Yaw</label>
                                                         <select>
+                                                            <!-- list generated here -->
+                                                        </select>
+                                                    </td>
                                                     <td name='thrust_linear'>
                                                         <label>Thrust Linear</label>
                                                         <select>

--- a/index.html
+++ b/index.html
@@ -1291,7 +1291,7 @@
                                                     </td>
                                                     <td name='thrust_linear'>
                                                         <label>Thrust Linear</label>
-                                                        <input type="text" step="1" min="0" max="999" />
+                                                        <input type="text" step="1" min="0" max="150"/>
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>

--- a/index.html
+++ b/index.html
@@ -1291,6 +1291,7 @@
                                                     </td>
                                                     <td name='thrust_linear'>
                                                         <label>Thrust Linear</label>
+                                                        <input type="text" step="1" min="0" max="999" />
                                                         <select>
                                                             <!-- list generated here -->
                                                         </select>

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -694,6 +694,7 @@ export function FlightLogParser(logData) {
             case "dterm_filter_type":
             case "dterm_filter2_type":
             case "pidAtMinThrottle":
+            case "thrust_linear":
             case "pidSumLimit":
             case "pidSumLimitYaw":
             case "anti_gravity_threshold":

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -70,6 +70,7 @@ export function HeaderDialog(dialog, onSave) {
         {name:'dterm_filter_type'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'dterm_filter2_type'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'pidAtMinThrottle'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
+        {name:'thrust_linear'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'itermThrottleGain'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'3.0.1'},
         {name:'ptermSRateWeight'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'3.0.0'},
         {name:'dtermSetpointWeight'          , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'3.4.0'},


### PR DESCRIPTION
Hackerman is back with an attempt to add Thrust Linear value to BBE

As far as I can tell the TL value is not currently present in BBE Header fields

I've added it to the 'Miscellaneous' box if this works as hoped... 