### PR TITLE
Give a more clear name under Mobile to the PWA app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "betaflight-blackbox-explorer",
+  "productName": "Blackbox Explorer",
   "displayName": "Betaflight - Blackbox Explorer",
   "description": "Crossplatform blackbox analitics tool for Betaflight flight control system.",
   "version": "4.0.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,8 +16,8 @@ export default {
             },
             includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png'],
             manifest: {
-                name: pkg.name,
-                short_name: 'BBE',
+                name: pkg.displayName,
+                short_name: pkg.productName,
                 description: pkg.description,
                 theme_color: '#ffffff',
                 icons: [
@@ -37,7 +37,7 @@ export default {
                         type: 'image/png',
                     },
                 ],
-            }
-        })
+            },
+        }),
     ],
 }


### PR DESCRIPTION
This is a little for discussion.

I've observed that when I install the PWA app into my Android, the "name" in the drawer is "BBE". Is a little short, and difficult to remember. If I want to search in the drawer I usually use "Betaflight" or "Blackbox". With this search nothing appears.

Some options:
1. The correct way will be "Betaflight Blackbox Explorer" and "Betaflight Configurator", but usually the drawers only show the first 8-10 letters of the name, so it will be confusing between the Configurator and the Blackbox. The good is that they will appear one just near the other, and with the Icon maybe it's enough.
2. "Blackbox Explorer" for the blackbox and "Betaflight Configurator" for the configurator. In the drawer will appear as "Betaflight..." and "Blackbox..." that is more or less what a user expects, but searching for Betaflight will not show the Blackbox and they will not be just near the other in the drawer.
3. "BF Blackbox Explorer" and "BF Configurator", the only problem with this is that searching for Betaflight will show nothing.

Any other suggestion?