### PR TITLE
Associate .bbl and .bfl files with PWA

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2130,6 +2130,18 @@ function BlackboxLogViewer() {
             return false;
         };
 
+        if ("launchQueue" in window) {
+            launchQueue.setConsumer(async (launchParams) => {
+                console.log("Opening files by extension in the desktop:", launchParams);
+                const files = [];
+                for (const fileHandler of launchParams.files) {
+                    console.log("launchQueue file", fileHandler);
+                    files.push(await fileHandler.getFile());
+                }
+                loadFiles(files);
+            });
+        };
+
         prefs.get('videoConfig', function(item) {
             if (item) {
                 videoConfig = item;

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,12 @@ export default {
                         type: 'image/png',
                     },
                 ],
+                file_handlers: [{
+                    action: "/",
+                    accept: {
+                      "application/octet-stream": [".bbl", ".bfl"],
+                    },
+                }],
             },
         }),
     ],


### PR DESCRIPTION
With the pass to PWA we lost the option to open files by extension. This PR adds this feature again. 

After install the application, simply double click in a bbl or bfl file.