### PR TITLE
Resolved issue of log records count and actual log rate computing 

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -1143,9 +1143,7 @@ export function FlightLog(logData) {
 
     this.getCurrentLogRowsCount = function () {
         const stats = this.getStats(this.getLogIndex());
-        const countI = stats.frame['I'] ? stats.frame['I'].totalCount : 0;
-        const countP = stats.frame['P'] ? stats.frame['P'].totalCount : 0;
-        return countI + countP;
+        return stats.frame['I'].validCount + stats.frame['P'].validCount;
     };
 }
 

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -1777,7 +1777,7 @@ export function FlightLogParser(logData) {
                         validCount: 0,
                         corruptCount: 0,
                         desyncCount: 0,
-                        field: []
+                        field: [],
                     };
                 }
 

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -1792,18 +1792,18 @@ export function FlightLogParser(logData) {
                     if (frameAccepted) {
                         //Update statistics for this frame type
                         frameTypeStats.bytes += lastFrameSize;
-                        ++frameTypeStats.sizeCount[lastFrameSize];
-                        ++frameTypeStats.validCount;
+                        frameTypeStats.sizeCount[lastFrameSize]++;
+                        frameTypeStats.validCount++;
                     } else {
-                        ++frameTypeStats.desyncCount;
+                        frameTypeStats.desyncCount++;
                     }
                 } else {
                     //The previous frame was corrupt
 
                     //We need to resynchronise before we can deliver another main frame:
                     mainStreamIsValid = false;
-                    ++frameTypeStats.corruptCount;
-                    ++this.stats.totalCorruptFrames;
+                    frameTypeStats.corruptCount++;
+                    this.stats.totalCorruptFrames++;
 
                     /*
                      * Start the search for a frame beginning after the first byte of the previous corrupt frame.


### PR DESCRIPTION
Resolved issue of log records count computing this file (the wrong log rate showed in this case):
[test.zip](https://github.com/user-attachments/files/15592858/test.zip).
I've never seen this issue before with other logs.
This file contents many wrong frames, what are not missed current log records count algoritm.  As result - the computed log rate was many grate then real.
The issue solution:
- removed the new totalCount counter, what was added during MinMax control developments.
- resolved issues of frames counters previouse olde source code - the many function did not have return values, therefore the original counters had bad result.
- the corrected original olde source code counters are used for  log records count computing.
