### PR TITLE
support rc_smoothing_rx_smoothed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1915,7 +1915,7 @@
                                                         <label>RX Average (ms)</label>
                                                         <input type="text" step="0.1" min="0"/>
                                                     </td>
-                                                    <td name="rcSmoothingRxSmoothed" id="rcSmoothingRxSmoothed">
+                                                    <td name="rc_smoothing_rx_smoothed" id="rc_smoothing_rx_smoothed">
                                                         <label>RX Smoothed (Hz)</label>
                                                         <input type="text" step="1" min="0"/>
                                                     </td>

--- a/index.html
+++ b/index.html
@@ -1911,9 +1911,13 @@
                                                             <!-- list generated here -->
                                                         </select>
                                                     </td>
-                                                    <td name="rcSmoothingRxAverage">
+                                                    <td name="rcSmoothingRxAverage" id="rcSmoothingRxAverage">
                                                         <label>RX Average (ms)</label>
                                                         <input type="text" step="0.1" min="0"/>
+                                                    </td>
+                                                    <td name="rcSmoothingRxSmoothed" id="rcSmoothingRxSmoothed">
+                                                        <label>RX Smoothed (Hz)</label>
+                                                        <input type="text" step="1" min="0"/>
                                                     </td>
                                                     <td name='rcSmoothingDebugAxis'>
                                                         <label>Debug Axis</label>

--- a/index.html
+++ b/index.html
@@ -1915,7 +1915,7 @@
                                                         <label>RX Average (ms)</label>
                                                         <input type="text" step="0.1" min="0"/>
                                                     </td>
-                                                    <td name="rc_smoothing_rx_smoothed" id="rc_smoothing_rx_smoothed">
+                                                    <td name="rcSmoothingRxSmoothed" id="rcSmoothingRxSmoothed">
                                                         <label>RX Smoothed (Hz)</label>
                                                         <input type="text" step="1" min="0"/>
                                                     </td>

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -407,6 +407,7 @@ export function FlightLogParser(logData) {
       rc_smoothing_setpoint_cutoff: "rc_smoothing_setpoint_hz",
       rc_smoothing_throttle_cutoff: "rc_smoothing_throttle_hz",
       rc_smoothing_type: "rc_smoothing_mode",
+      rc_smoothing_rx_smoothed: "rc_smoothing_rx_average",
       rc_yaw_expo: "rcYawExpo",
       rcExpo: "rc_expo",
       rcRate: "rc_rates",

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -314,6 +314,7 @@ export function FlightLogParser(logData) {
       rc_smoothing_throttle_hz: null, // RC Smoothing manual cutoff for throttle
       rc_smoothing_auto_factor_throttle: null, // RC Smoothing cutoff for throttle
       rc_smoothing_active_cutoffs_ff_sp_thr: [null, null, null], // RC Smoothing active cutoffs feedforward, setpoint, throttle
+      rc_smoothing_rx_smoothed: null,
       dyn_notch_count: null, // Number of dynamic notches 4.3
       rpm_filter_fade_range_hz: null, // Fade range for RPM notch filters in Hz
       dyn_idle_p_gain: null,
@@ -407,7 +408,6 @@ export function FlightLogParser(logData) {
       rc_smoothing_setpoint_cutoff: "rc_smoothing_setpoint_hz",
       rc_smoothing_throttle_cutoff: "rc_smoothing_throttle_hz",
       rc_smoothing_type: "rc_smoothing_mode",
-      rc_smoothing_rx_smoothed: "rc_smoothing_rx_average",
       rc_yaw_expo: "rcYawExpo",
       rcExpo: "rc_expo",
       rcRate: "rc_rates",
@@ -651,6 +651,7 @@ export function FlightLogParser(logData) {
       case "rc_smoothing_type":
       case "rc_smoothing_debug_axis":
       case "rc_smoothing_rx_average":
+      case "rc_smoothing_rx_smoothed":
       case "rc_smoothing_mode": // 4.3 rc smoothing stuff
       case "rc_smoothing_auto_factor_setpoint":
       case "rc_smoothing_auto_factor_throttle":

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -1568,7 +1568,7 @@ export function HeaderDialog(dialog, onSave) {
 
     if (semver.gte(activeSysConfig.firmwareVersion, "4.5.0")) {
       setParameter("rcSmoothingRxSmoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
-      $("#rc_smoothing_rx_smoothed").show();
+      $("#rcSmoothingRxSmoothed").show();
       $("#rcSmoothingRxAverage").hide();
     } else {
       setParameter("rcSmoothingRxAverage", sysConfig.rc_smoothing_rx_average, 3);

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -1567,13 +1567,13 @@ export function HeaderDialog(dialog, onSave) {
     $(".dshot_bidir_required").toggle(sysConfig.dshot_bidir == 1);
 
     if (semver.gte(activeSysConfig.firmwareVersion, "4.5.0")) {
-      setParameter("rc_smoothing_rx_smoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
+      setParameter("rcSmoothingRxSmoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
       $("#rc_smoothing_rx_smoothed").show();
       $("#rcSmoothingRxAverage").hide();
     } else {
       setParameter("rcSmoothingRxAverage", sysConfig.rc_smoothing_rx_average, 3);
       $("#rcSmoothingRxAverage").show();
-      $("#rc_smoothing_rx_smoothed").hide();
+      $("#rcSmoothingRxSmoothed").hide();
     }
 
     renderSelect(

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -383,6 +383,12 @@ export function HeaderDialog(dialog, onSave) {
       name: "rc_smoothing_rx_average",
       type: FIRMWARE_TYPE_BETAFLIGHT,
       min: "3.5.0",
+      max: "4.4.999",
+    },
+    {
+      name: "rc_smoothing_rx_smoothed",
+      type: FIRMWARE_TYPE_BETAFLIGHT,
+      min: "4.5.0",
       max: "999.9.9",
     },
     {

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -1567,11 +1567,13 @@ export function HeaderDialog(dialog, onSave) {
     $(".dshot_bidir_required").toggle(sysConfig.dshot_bidir == 1);
 
     if (semver.gte(activeSysConfig.firmwareVersion, "4.5.0")) {
-      setParameter("rcSmoothingRxSmoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
+      setParameter("rc_smoothing_rx_smoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
+      $("#rc_smoothing_rx_smoothed").show();
       $("#rcSmoothingRxAverage").hide();
     } else {
       setParameter("rcSmoothingRxAverage", sysConfig.rc_smoothing_rx_average, 3);
-      $("#rcSmoothingRxSmoothed").hide();
+      $("#rcSmoothingRxAverage").show();
+      $("#rc_smoothing_rx_smoothed").hide();
     }
 
     renderSelect(

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -1566,7 +1566,14 @@ export function HeaderDialog(dialog, onSave) {
 
     $(".dshot_bidir_required").toggle(sysConfig.dshot_bidir == 1);
 
-    setParameter("rcSmoothingRxAverage", sysConfig.rc_smoothing_rx_average, 3);
+    if (semver.gte(activeSysConfig.firmwareVersion, "4.5.0")) {
+      setParameter("rcSmoothingRxSmoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
+      $("#rcSmoothingRxAverage").hide();
+    } else {
+      setParameter("rcSmoothingRxAverage", sysConfig.rc_smoothing_rx_average, 3);
+      $("#rcSmoothingRxSmoothed").hide();
+    }
+
     renderSelect(
       "rcSmoothingDebugAxis",
       sysConfig.rc_smoothing_debug_axis,


### PR DESCRIPTION
4.5.0 before:
![image](https://github.com/user-attachments/assets/c17a519b-b754-498c-9628-5560ffbbd287)

4.5.0 after:
![image](https://github.com/user-attachments/assets/b2535737-f26f-4e9b-b831-888579f710f6)

still supports pre-4.5.0:
![image](https://github.com/user-attachments/assets/a4375443-90ae-4307-a9ff-eb3cdf8e139d)

`rc_smoothing_rx_smoothed` first seen in 4.5-RC1 via https://github.com/betaflight/betaflight/pull/12605 