### PR TITLE
Resolve issue of computing actual log rate for spectrum chart in case of data gaps in log file

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -31,7 +31,7 @@ import {
 export function FlightLog(logData) {
   let ADDITIONAL_COMPUTED_FIELD_COUNT = 15 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED **/,
     that = this,
-    logIndex = false,
+    logIndex = 0,
     logIndexes = new FlightLogIndex(logData),
     parser = new FlightLogParser(logData),
     iframeDirectory,
@@ -117,26 +117,22 @@ export function FlightLog(logData) {
    * Get the earliest time seen in the log of the given index (in microseconds), or leave off the logIndex
    * argument to fetch details for the current log.
    */
-  this.getMinTime = function (logIndex) {
-    return getRawStats(logIndex).frame["I"].field[
-      FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME
-    ].min;
+  this.getMinTime = function () {
+    return logIndexes.getIntraframeDirectory(logIndex).minTime;
   };
 
   /**
    * Get the latest time seen in the log of the given index (in microseconds), or leave off the logIndex
    * argument to fetch details for the current log.
    */
-  this.getMaxTime = function (logIndex) {
-    return getRawStats(logIndex).frame["I"].field[
-      FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME
-    ].max;
+  this.getMaxTime = function () {
+    return logIndexes.getIntraframeDirectory(logIndex).maxTime;
   };
   
-  this.getActualLoggedTime = function (logIndex) 
+  this.getActualLoggedTime = function () {
     const directory = logIndexes.getIntraframeDirectory(logIndex);
     return directory.maxTime - directory.minTime - directory.unLoggedTime;
-  }
+  };
 
   /**
    * Get the flight controller system information that was parsed for the current log file.

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -132,6 +132,11 @@ export function FlightLog(logData) {
       FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME
     ].max;
   };
+  
+  this.getActualLoggedTime = function (logIndex) 
+    const directory = logIndexes.getIntraframeDirectory(logIndex);
+    return directory.maxTime - directory.minTime - directory.unLoggedTime;
+  }
 
   /**
    * Get the flight controller system information that was parsed for the current log file.

--- a/src/flightlog_index.js
+++ b/src/flightlog_index.js
@@ -127,7 +127,7 @@ export function FlightLogIndex(logData) {
           magADC = false;
         }
         
-        let lastTime;
+        let frameTime;
         parser.onFrameReady = function (
           frameValid,
           frame,
@@ -142,8 +142,7 @@ export function FlightLogIndex(logData) {
           switch (frameType) {
             case "P":
             case "I":
-              let frameTime = frame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME];
-              lastTime = frameTime;
+              frameTime = frame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME];
               if (intraIndex.minTime === false) {
                 intraIndex.minTime = frameTime;
               }
@@ -228,8 +227,8 @@ export function FlightLogIndex(logData) {
               }
 
               if (frame.event == FlightLogEvent.LOGGING_RESUME) {
-                if (lastTime) {
-                  intraIndex.unLoggedTime += frame.data.currentTime - lastTime;
+                if (frameTime) {
+                  intraIndex.unLoggedTime += frame.data.currentTime - frameTime;
                 }
               }
 

--- a/src/flightlog_index.js
+++ b/src/flightlog_index.js
@@ -127,7 +127,7 @@ export function FlightLogIndex(logData) {
           magADC = false;
         }
         
-        let lastTime = undefined;
+        let lastTime;
         parser.onFrameReady = function (
           frameValid,
           frame,
@@ -142,8 +142,7 @@ export function FlightLogIndex(logData) {
           switch (frameType) {
             case "P":
             case "I":
-              let frameTime =
-                frame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME];
+              let frameTime = frame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME];
               lastTime = frameTime;
               if (intraIndex.minTime === false) {
                 intraIndex.minTime = frameTime;

--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -50,12 +50,10 @@ GraphSpectrumCalc.initialize = function(flightLog, sysConfig) {
   }
   this._BetaflightRate = this._blackBoxRate;
 
-  const minTime = this._flightLog.getMinTime(),
-      maxTime = this._flightLog.getMaxTime(),
-      timeRange = maxTime - minTime;
+  const actualLoggedTime = this._flightLog.getActualLoggedTime(),
+        length = flightLog.getCurrentLogRowsCount();
 
-  const length = flightLog.getCurrentLogRowsCount();
-  this._actualeRate = 1e6 * length / timeRange;
+  this._actualeRate = 1e6 * length / actualLoggedTime;
   if (Math.abs(this._BetaflightRate - this._actualeRate) / this._actualeRate > WARNING_RATE_DIFFERENCE)
       this._blackBoxRate = Math.round(this._actualeRate);
 


### PR DESCRIPTION
The actual logging computing rate in spectrum chart has issue in case of data gaps by on/off logging with using transmitter switch. The reason these is wrong actual logging time computing, what includes data gaps time.
![Wrong log rate](https://github.com/user-attachments/assets/acbdfbca-10a7-4c4f-b77a-a78772df9e9d)

This PR resolve these issue. The actual logging rate is computed properly:
![Normal log rate](https://github.com/user-attachments/assets/69db2445-5f01-4c50-8b28-dd9cd81ecc4d)
