### PR TITLE
Bug fix for flight modes names at the chart

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1337,12 +1337,16 @@ FlightLogFieldPresenter.presentFlags = function (flags, flagNames) {
 FlightLogFieldPresenter.presentChangeEvent = function presentChangeEvent(
   flags,
   lastFlags,
-  flagNames
-) {
+  flagNames)
+{
   let eventState = "";
   let found = false;
-
-  for (let i = 0; i < flagNames.length; i++) {
+  const maxModeNumber = 32;   // int has 32 bit only! We have not to roll bit shift 1<<i for i values grate then 31 !!!
+  let modesCount = flagNames.length
+  if (modesCount > maxModeNumber) {
+    modesCount = maxModeNumber;
+  }
+  for (let i = 0; i < modesCount; i++) {
     if ((1 << i) & (flags ^ lastFlags)) {
       // State Changed
       eventState += `|${flagNames[i]} ${(1 << i) & flags ? "ON" : "OFF"}`;

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1342,7 +1342,7 @@ FlightLogFieldPresenter.presentChangeEvent = function presentChangeEvent(
   let eventState = "";
   let found = false;
   const maxModeNumber = 32;   // int has 32 bit only! We have not to roll bit shift 1<<i for i values grate then 31 !!!
-  let modesCount = flagNames.length
+  let modesCount = flagNames.length;
   if (modesCount > maxModeNumber) {
     modesCount = maxModeNumber;
   }

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1349,7 +1349,7 @@ FlightLogFieldPresenter.presentChangeEvent = function presentChangeEvent(
   for (let i = 0; i < modesCount; i++) {
     if ((1 << i) & (flags ^ lastFlags)) {
       // State Changed
-      eventState += `|${flagNames[i]} ${(1 << i) & flags ? "ON" : "OFF"}`;
+      eventState += `${found ? "|" : ""}${flagNames[i]} ${(1 << i) & flags ? "ON" : "OFF"}`;
       found = true;
     }
   }

--- a/src/grapher.js
+++ b/src/grapher.js
@@ -629,11 +629,11 @@ export function FlightLogGrapher(
         drawEventLine(
           x,
           labelY,
-          `Flight Mode Change${FlightLogFieldPresenter.presentChangeEvent(
+          FlightLogFieldPresenter.presentChangeEvent(
             event.data.newFlags,
             event.data.lastFlags,
             FLIGHT_LOG_FLIGHT_MODE_NAME
-          )}`,
+          ),
           "rgba(0,0,255,0.75)",
           3
         );


### PR DESCRIPTION
This PR resolves issue of wrong additional flight mode names at the charts (The wrong USER3 mode is added to the ANGLE mode for example).
The log file for example:
https://disk.yandex.ru/d/-_Sr2K-atVpA5g
Current BBE version:
![WrongMode](https://github.com/user-attachments/assets/cf53404a-a34b-4afb-b2fa-3cb3d0e5a57c)
This PR:
![NormalMode](https://github.com/user-attachments/assets/2f9fff85-5238-4193-91d2-b376f09ad4c5)

The caption "Flight mode changed " before flight mode is removed, to get shorter text label.
This is first PR to improve flight modes show in BBExplorer charts.
As i look in BF firmware and BBExplorer source, we have some problem with logging flight modes,
because flight modes description count is more then bit count in 32 bit unsigned value, what is written to log file.
Therefore some modes (ACROTRAINER for example) cannot logged. The new ALTHOLD mode (@ctzsnooze PR [#13816](https://github.com/betaflight/betaflight/pull/13816)) has not true description in BBE too.
I will continue to improve these issues in next PR.