### PR TITLE
Resolved issue of wrong log time computing

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -117,20 +117,23 @@ export function FlightLog(logData) {
    * Get the earliest time seen in the log of the given index (in microseconds), or leave off the logIndex
    * argument to fetch details for the current log.
    */
-  this.getMinTime = function () {
-    return logIndexes.getIntraframeDirectory(logIndex).minTime;
+  this.getMinTime = function (index) {
+    index = index ?? logIndex;
+    return logIndexes.getIntraframeDirectory(index).minTime;
   };
 
   /**
    * Get the latest time seen in the log of the given index (in microseconds), or leave off the logIndex
    * argument to fetch details for the current log.
    */
-  this.getMaxTime = function () {
-    return logIndexes.getIntraframeDirectory(logIndex).maxTime;
+  this.getMaxTime = function (index) {
+    index = index ?? logIndex;
+    return logIndexes.getIntraframeDirectory(index).maxTime;
   };
   
-  this.getActualLoggedTime = function () {
-    const directory = logIndexes.getIntraframeDirectory(logIndex);
+  this.getActualLoggedTime = function (index) {
+    index = index ?? logIndex;
+    const directory = logIndexes.getIntraframeDirectory(index);
     return directory.maxTime - directory.minTime - directory.unLoggedTime;
   };
 


### PR DESCRIPTION
This PR is Bug fix, what i've missed in PR #762.
As result - the wrong log time are showed at the chart legend:
after PR #762:
![badLegendTime](https://github.com/user-attachments/assets/64d1f9f3-ec37-489f-b708-2b504375e0ff)

After this PR:
![goodLegendTime](https://github.com/user-attachments/assets/73c7d455-f40a-45d9-a534-7dbc26967579)
