### PR TITLE
Added ALTHOLD flight mode marker at the chart for 4.6 BF firmware

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -134,7 +134,7 @@ export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3 = makeReadOnly([
   "LAUNCHCONTROL",
 ]);
 
-export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_6 = makeReadOnly([
+export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_5 = makeReadOnly([
   "ARM",
   "ANGLE",
   "HORIZON",
@@ -532,9 +532,8 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
 
     // Flight mode names
     if (semver.gte(firmwareVersion, "4.6.0")) {
-      FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_6.slice(0);
-    }
-    else {
+      FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_5.slice(0);
+    } else {
       FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3.slice(0);
       if (semver.lt(firmwareVersion, "3.4.0")) {
         FLIGHT_LOG_FLIGHT_MODE_NAME.splice(

--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -134,6 +134,49 @@ export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3 = makeReadOnly([
   "LAUNCHCONTROL",
 ]);
 
+export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_6 = makeReadOnly([
+  "ARM",
+  "ANGLE",
+  "HORIZON",
+  "MAG",
+  "ALTHOLD",
+  "HEADFREE",
+  "PASSTHRU",
+  "FAILSAFE",
+  "GPSRESCUE",
+  "ANTIGRAVITY",
+  "HEADADJ",
+  "CAMSTAB",
+  "BEEPER",
+  "LEDLOW",
+  "CALIB",
+  "OSD",
+  "TELEMETRY",
+  "SERVO1",
+  "SERVO2",
+  "SERVO3",
+  "BLACKBOX",
+  "AIRMODE",
+  "3D",
+  "FPVANGLEMIX",
+  "BLACKBOXERASE",
+  "CAMERA1",
+  "CAMERA2",
+  "CAMERA3",
+  "FLIPOVERAFTERCRASH",
+  "PREARM",
+  "BEEPGPSCOUNT",
+  "VTXPITMODE",
+  "USER1",
+  "USER2",
+  "USER3",
+  "USER4",
+  "PIDAUDIO",
+  "ACROTRAINER",
+  "VTXCONTROLDISABLE",
+  "LAUNCHCONTROL",
+]);
+
 export const FLIGHT_LOG_FEATURES = makeReadOnly([
   "RX_PPM",
   "VBAT",
@@ -488,53 +531,59 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
     DEBUG_MODE = makeReadOnly(DEBUG_MODE);
 
     // Flight mode names
-    FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3.slice(0);
-    if (semver.lt(firmwareVersion, "3.4.0")) {
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSRESCUE"),
-        1
-      );
+    if (semver.gte(firmwareVersion, "4.6.0")) {
+      FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_6.slice(0);
     }
-    if (semver.gte(firmwareVersion, "3.5.0")) {
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("RANGEFINDER"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("CAMTRIG"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("LEDMAX"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("LLIGHTS"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GOV"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GTUNE"),
-        1
-      );
+    else {
+      FLIGHT_LOG_FLIGHT_MODE_NAME = FLIGHT_LOG_FLIGHT_MODE_NAME_POST_3_3.slice(0);
+      if (semver.lt(firmwareVersion, "3.4.0")) {
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSRESCUE"),
+          1
+        );
+      }
+      if (semver.gte(firmwareVersion, "3.5.0")) {
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("RANGEFINDER"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("CAMTRIG"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("LEDMAX"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("LLIGHTS"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GOV"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GTUNE"),
+          1
+        );
+      }
+      if (semver.gte(firmwareVersion, "4.0.0")) {
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("BARO"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSHOME"),
+          1
+        );
+        FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
+          FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSHOLD"),
+          1
+        );
+      }
     }
-    if (semver.gte(firmwareVersion, "4.0.0")) {
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("BARO"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSHOME"),
-        1
-      );
-      FLIGHT_LOG_FLIGHT_MODE_NAME.splice(
-        FLIGHT_LOG_FLIGHT_MODE_NAME.indexOf("GPSHOLD"),
-        1
-      );
-    }
+    
     FLIGHT_LOG_FLIGHT_MODE_NAME = makeReadOnly(FLIGHT_LOG_FLIGHT_MODE_NAME);
   } else {
     DEBUG_MODE = DEBUG_MODE_COMPLETE;


### PR DESCRIPTION
Seems i 've marked my #766 PR as draft only, but it was closed. Never mind...

I've thought, that 766 PR was not helpfull without previouse, what fixed wrong mirrors flight mode issue. This PR include that.

This PR like PR766 add "ALT HOLD" caption for @ctzsnooze  [AltHold #1386](https://github.com/betaflight/betaflight/pull/13816)  Mode at the chart.
