### PR TITLE
Added using of actual flight mode flags field

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -27,6 +27,7 @@ export const FlightLogEvent = makeReadOnly({
 
   GTUNE_CYCLE_RESULT: 20,
   FLIGHT_MODE: 30,
+  ACTUAL_FLIGHT_MODE: 31,
   TWITCH_TEST: 40, // Feature for latency testing
 
   CUSTOM: 250, // Virtual Event Code - Never part of Log File.

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -111,7 +111,8 @@ const FRIENDLY_FIELD_NAMES = {
   "magADC[1]": "Compass [Y]",
   "magADC[2]": "Compass [Z]",
 
-  flightModeFlags: "Flight Mode Flags",
+  flightModeFlags: "RC BOX Flight Mode Flags",
+  actualFlightModeFlags: "Flight Mode Flags",
   stateFlags: "State Flags",
   failsafePhase: "Failsafe Phase",
   rxSignalReceived: "RX Signal Received",
@@ -1594,6 +1595,7 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
       );
 
     case "flightModeFlags":
+    case "actualFlightModeFlags":
       return FlightLogFieldPresenter.presentFlags(
         value,
         FLIGHT_LOG_FLIGHT_MODE_NAME
@@ -2238,6 +2240,7 @@ FlightLogFieldPresenter.ConvertFieldValue = function (
             );
 
     case "flightModeFlags":
+    case "actualFlightModeFlags":
       return value;
 
     case "stateFlags":

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1595,11 +1595,16 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
       );
 
     case "flightModeFlags":
-    case "actualFlightModeFlags":
       return FlightLogFieldPresenter.presentFlags(
         value,
         FLIGHT_LOG_FLIGHT_MODE_NAME
       );
+      
+    case "actualFlightModeFlags":
+      return value != 0 ? FlightLogFieldPresenter.presentFlags(
+        value<<1,
+        FLIGHT_LOG_FLIGHT_MODE_NAME
+      ) : "ACRO";
 
     case "stateFlags":
       return FlightLogFieldPresenter.presentFlags(

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -1617,6 +1617,7 @@ export function FlightLogParser(logData) {
         lastEvent.time = lastEvent.data.time;
         break;
       case FlightLogEvent.FLIGHT_MODE: // get the flag status change
+      case FlightLogEvent.ACTUAL_FLIGHT_MODE:
         lastEvent.data.newFlags = stream.readUnsignedVB();
         lastEvent.data.lastFlags = stream.readUnsignedVB();
         break;

--- a/src/graph_legend.js
+++ b/src/graph_legend.js
@@ -182,7 +182,7 @@ export function GraphLegend(
     try {
       // New function to show values on legend.
       let currentFlightMode =
-        frame[flightLog.getMainFieldIndexByName("flightModeFlags")];
+        frame[flightLog.getMainFieldIndexByName("flightModeFlags")];  //TODO use actualFlightModeFlags for new BF versions
       let graphs = config.getGraphs(),
         i,
         j;

--- a/src/grapher.js
+++ b/src/grapher.js
@@ -625,7 +625,7 @@ export function FlightLogGrapher(
           2
         );
         break;
-      case FlightLogEvent.FLIGHT_MODE:
+      case FlightLogEvent.ACTUAL_FLIGHT_MODE:
         drawEventLine(
           x,
           labelY,

--- a/src/grapher.js
+++ b/src/grapher.js
@@ -630,8 +630,8 @@ export function FlightLogGrapher(
           x,
           labelY,
           FlightLogFieldPresenter.presentChangeEvent(
-            event.data.newFlags,
-            event.data.lastFlags,
+            event.data.newFlags<<1,
+            event.data.lastFlags<<1,
             FLIGHT_LOG_FLIGHT_MODE_NAME
           ),
           "rgba(0,0,255,0.75)",

--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,7 @@ function BlackboxLogViewer() {
 
     if (frame) {
       let currentFlightMode =
-        frame[flightLog.getMainFieldIndexByName("flightModeFlags")];
+        frame[flightLog.getMainFieldIndexByName("flightModeFlags")];  //TODO: use actualFlightModeFlags for new BF versions
 
       if (hasTable || hasTableOverlay) {
         // Only redraw the table if it is enabled

--- a/src/sticks.js
+++ b/src/sticks.js
@@ -277,7 +277,7 @@ export function FlightLogSticks(flightLog, rcCommandFields, canvas) {
         if (userSettings.stickUnits != null) {
           if (userSettings.stickUnits) {
             let currentFlightMode =
-              frame[flightLog.getMainFieldIndexByName("flightModeFlags")];
+              frame[flightLog.getMainFieldIndexByName("flightModeFlags")];  //TODO use actualFlightModeFlags for new BF versions
             rcCommandLabels[stickIndex] =
               FlightLogFieldPresenter.decodeFieldToFriendly(
                 flightLog,


### PR DESCRIPTION
Added using of actual flight mode flags field.
This PR works with [Betaflight PR](https://github.com/betaflight/betaflight/pull/13893)
There is a start work by using of actual flight mode flags.
In future will possible to draw events markers by actual flight mode flags.