### PR TITLE
Added  cartesian gps coords relative home point as additional computed fields

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -852,7 +852,7 @@ export function FlightLog(logData) {
               destFrame[fieldIndex++] = gpsCartesianCoords.x;
               destFrame[fieldIndex++] = gpsCartesianCoords.y;
               destFrame[fieldIndex++] = gpsCartesianCoords.z;
-              destFrame[fieldIndex++] = Math.sqrt(gpsCartesianCoords.x*gpsCartesianCoords.x + gpsCartesianCoords.z*gpsCartesianCoords.z);
+              destFrame[fieldIndex++] = Math.sqrt(gpsCartesianCoords.x * gpsCartesianCoords.x + gpsCartesianCoords.z * gpsCartesianCoords.z);
             } else {
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -848,7 +848,7 @@ export function FlightLog(logData) {
           // Calculate cartesian coords by GPS
           if (!that.isFieldDisabled().GPS) {
             if (gpsTransform && gpsCoord && srcFrame[gpsCoord[0]]) {
-              const gpsCartesianCoords = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]]/10000000, srcFrame[gpsCoord[1]]/10000000, srcFrame[gpsCoord[2]]/10);
+              const gpsCartesianCoords = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]] / 10000000, srcFrame[gpsCoord[1] ] /10000000, srcFrame[gpsCoord[2]] / 10);
               destFrame[fieldIndex++] = gpsCartesianCoords.x;
               destFrame[fieldIndex++] = gpsCartesianCoords.y;
               destFrame[fieldIndex++] = gpsCartesianCoords.z;

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -284,7 +284,7 @@ export function FlightLog(logData) {
       fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
     }
     if (!that.isFieldDisabled().GPS) {
-      fieldNames.push("gpsCartesian[0]", "gpsCartesian[1]", "gpsCartesian[2]", "gpsDistance"); // GPS coords in cartesian system
+      fieldNames.push("gpsCartesianCoords[0]", "gpsCartesianCoords[1]", "gpsCartesianCoords[2]", "gpsDistance"); // GPS coords in cartesian system
     }
 
     fieldNameToIndex = {};
@@ -847,11 +847,11 @@ export function FlightLog(logData) {
           // Calculate cartesian coords by GPS
           if (!that.isFieldDisabled().GPS) {
             if (gpsTransform && gpsCoord && srcFrame[gpsCoord[0]]) {
-              const gpsCartesian = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]]/10000000, srcFrame[gpsCoord[1]]/10000000, srcFrame[gpsCoord[2]]/10);
-              destFrame[fieldIndex++] = gpsCartesian.x;
-              destFrame[fieldIndex++] = gpsCartesian.y;
-              destFrame[fieldIndex++] = gpsCartesian.z;
-              destFrame[fieldIndex++] = Math.sqrt(gpsCartesian.x*gpsCartesian.x + gpsCartesian.z*gpsCartesian.z);
+              const gpsCartesianCoords = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]]/10000000, srcFrame[gpsCoord[1]]/10000000, srcFrame[gpsCoord[2]]/10);
+              destFrame[fieldIndex++] = gpsCartesianCoords.x;
+              destFrame[fieldIndex++] = gpsCartesianCoords.y;
+              destFrame[fieldIndex++] = gpsCartesianCoords.z;
+              destFrame[fieldIndex++] = Math.sqrt(gpsCartesianCoords.x*gpsCartesianCoords.x + gpsCartesianCoords.z*gpsCartesianCoords.z);
             } else {
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -524,7 +524,8 @@ export function FlightLog(logData) {
                 }
                 break;
               case "H":
-                gpsTransform = new GPS_transform(frame[0]/10000000, frame[1]/10000000, 0.0, 0.0);
+                const homeAltitude = frame.length == 3 ? frame[2]*10 : 0;
+                gpsTransform = new GPS_transform(frame[0]/10000000, frame[1]/10000000, homeAltitude, 0.0);
               case "G":
                 // The frameValid can be false, when no GPS home (the G frames contains GPS position as diff of GPS Home position).
                 // But other data from the G frame can be valid (time, num sats)

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -524,7 +524,7 @@ export function FlightLog(logData) {
                 }
                 break;
               case "H":
-                const homeAltitude = frame.length > 2 ? frame[2 ] /10 : 0; // will work after BF firmware improvement
+                const homeAltitude = frame.length > 2 ? frame[2] / 10 : 0; // will work after BF firmware improvement
                 gpsTransform = new GPS_transform(frame[0] / 10000000, frame[1] / 10000000, homeAltitude, 0.0);
                 break;
               case "G":

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -523,10 +523,11 @@ export function FlightLog(logData) {
                   lastSlow[i] = frame[i];
                 }
                 break;
-              case "H":
+              case "H": {
                 const homeAltitude = frame.length > 2 ? frame[2] / 10 : 0; // will work after BF firmware improvement
                 gpsTransform = new GPS_transform(frame[0] / 10000000, frame[1] / 10000000, homeAltitude, 0.0);
                 break;
+              }
               case "G":
                 // The frameValid can be false, when no GPS home (the G frames contains GPS position as diff of GPS Home position).
                 // But other data from the G frame can be valid (time, num sats)

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -526,6 +526,7 @@ export function FlightLog(logData) {
               case "H":
                 const homeAltitude = frame.length == 3 ? frame[2]*10 : 0;
                 gpsTransform = new GPS_transform(frame[0]/10000000, frame[1]/10000000, homeAltitude, 0.0);
+                break;
               case "G":
                 // The frameValid can be false, when no GPS home (the G frames contains GPS position as diff of GPS Home position).
                 // But other data from the G frame can be valid (time, num sats)

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -524,8 +524,8 @@ export function FlightLog(logData) {
                 }
                 break;
               case "H":
-                const homeAltitude = frame.length > 2 ? frame[2]/10 : 0; // will work after BF firmware improvement
-                gpsTransform = new GPS_transform(frame[0]/10000000, frame[1]/10000000, homeAltitude, 0.0);
+                const homeAltitude = frame.length > 2 ? frame[2 ] /10 : 0; // will work after BF firmware improvement
+                gpsTransform = new GPS_transform(frame[0] / 10000000, frame[1] / 10000000, homeAltitude, 0.0);
                 break;
               case "G":
                 // The frameValid can be false, when no GPS home (the G frames contains GPS position as diff of GPS Home position).

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -30,7 +30,7 @@ import {
  * Window based smoothing of fields is offered.
  */
 export function FlightLog(logData) {
-  let ADDITIONAL_COMPUTED_FIELD_COUNT = 18 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord**/,
+  let ADDITIONAL_COMPUTED_FIELD_COUNT = 19 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord**/,
     that = this,
     logIndex = 0,
     logIndexes = new FlightLogIndex(logData),
@@ -284,7 +284,7 @@ export function FlightLog(logData) {
       fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
     }
     if (!that.isFieldDisabled().GPS) {
-      fieldNames.push("gpsCartesian[0]", "gpsCartesian[1]", "gpsCartesian[2]"); // GPS coords in cartesian system
+      fieldNames.push("gpsCartesian[0]", "gpsCartesian[1]", "gpsCartesian[2]", "gpsDistance"); // GPS coords in cartesian system
     }
 
     fieldNameToIndex = {};
@@ -850,7 +850,9 @@ export function FlightLog(logData) {
               destFrame[fieldIndex++] = gpsCartesian.x;
               destFrame[fieldIndex++] = gpsCartesian.y;
               destFrame[fieldIndex++] = gpsCartesian.z;
+              destFrame[fieldIndex++] = Math.sqrt(gpsCartesian.x*gpsCartesian.x + gpsCartesian.z*gpsCartesian.z);
             } else {
+              destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -524,7 +524,7 @@ export function FlightLog(logData) {
                 }
                 break;
               case "H":
-                const homeAltitude = frame.length == 3 ? frame[2]*10 : 0;
+                const homeAltitude = frame.length > 2 ? frame[2]/10 : 0; // will work after BF firmware improvement
                 gpsTransform = new GPS_transform(frame[0]/10000000, frame[1]/10000000, homeAltitude, 0.0);
                 break;
               case "G":

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -848,7 +848,7 @@ export function FlightLog(logData) {
           // Calculate cartesian coords by GPS
           if (!that.isFieldDisabled().GPS) {
             if (gpsTransform && gpsCoord && srcFrame[gpsCoord[0]]) {
-              const gpsCartesianCoords = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]] / 10000000, srcFrame[gpsCoord[1] ] /10000000, srcFrame[gpsCoord[2]] / 10);
+              const gpsCartesianCoords = gpsTransform.WGS_BS(srcFrame[gpsCoord[0]] / 10000000, srcFrame[gpsCoord[1]] / 10000000, srcFrame[gpsCoord[2]] / 10);
               destFrame[fieldIndex++] = gpsCartesianCoords.x;
               destFrame[fieldIndex++] = gpsCartesianCoords.y;
               destFrame[fieldIndex++] = gpsCartesianCoords.z;

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -125,11 +125,11 @@ const FRIENDLY_FIELD_NAMES = {
   GPS_speed: "GPS Speed",
   GPS_ground_course: "GPS Heading",
   
-  "gpsCartesian[all]": "Positions",
-  "gpsCartesian[0]": "Position X",
-  "gpsCartesian[1]": "Position Y",
-  "gpsCartesian[2]": "Position Z",
-  gpsDistance:     "Home distance",
+  "gpsCartesianCoords[all]": "GPS Coords",
+  "gpsCartesianCoords[0]": "GPS Coords [X]",
+  "gpsCartesianCoords[1]": "GPS Coords [H]",
+  "gpsCartesianCoords[2]": "GPS Coords [Z]",
+  gpsDistance:     "GPS Home distance",
 };
 
 const DEBUG_FRIENDLY_FIELD_NAMES_INITIAL = {
@@ -1646,9 +1646,9 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
     case "GPS_ground_course":
       return `${(value / 10).toFixed(1)} °`;
     
-    case "gpsCartesian[0]":
-    case "gpsCartesian[1]":
-    case "gpsCartesian[2]":
+    case "gpsCartesianCoords[0]":
+    case "gpsCartesianCoords[1]":
+    case "gpsCartesianCoords[2]":
     case "gpsDistance":
         return `${value.toFixed(0)} m`;
 

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -127,7 +127,7 @@ const FRIENDLY_FIELD_NAMES = {
   
   "gpsCartesianCoords[all]": "GPS Coords",
   "gpsCartesianCoords[0]": "GPS Coords [X]",
-  "gpsCartesianCoords[1]": "GPS Coords [H]",
+  "gpsCartesianCoords[1]": "GPS Coords [Y]",
   "gpsCartesianCoords[2]": "GPS Coords [Z]",
   gpsDistance:     "GPS Home distance",
 };

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -124,6 +124,12 @@ const FRIENDLY_FIELD_NAMES = {
   GPS_altitude: "GPS Altitude ASL",
   GPS_speed: "GPS Speed",
   GPS_ground_course: "GPS Heading",
+  
+  "gpsCartesian[all]": "Positions",
+  "gpsCartesian[0]": "Position X",
+  "gpsCartesian[1]": "Position Y",
+  "gpsCartesian[2]": "Position Z",
+  gpsDistance:     "Home distance",
 };
 
 const DEBUG_FRIENDLY_FIELD_NAMES_INITIAL = {

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1639,6 +1639,11 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
       }
     case "GPS_ground_course":
       return `${(value / 10).toFixed(1)} °`;
+    
+    case "gpsCartesian[0]":
+    case "gpsCartesian[1]":
+    case "gpsCartesian[2]":
+        return `${value.toFixed(0)} m`;
 
     case "debug[0]":
     case "debug[1]":

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1643,6 +1643,7 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
     case "gpsCartesian[0]":
     case "gpsCartesian[1]":
     case "gpsCartesian[2]":
+    case "gpsDistance":
         return `${value.toFixed(0)} m`;
 
     case "debug[0]":

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -64,5 +64,6 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
   this.WGS_BS = function (Lat, Lon, H) {
     return this.ECEF_BS(this.WGS_ECEF(Lat, Lon, H));
   };
-
 }
+
+Also please add spaces around operators in this file.

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -64,4 +64,5 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
   this.WGS_BS = function (Lat, Lon, H) {
     return this.ECEF_BS(this.WGS_ECEF(Lat, Lon, H));
   };
+
 }

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -1,9 +1,5 @@
 export function GPS_transform(Lat0, Lon0, H0, Heading) {
 
-  function rad2deg(rad) {
-    return rad * 180.0 / Math.PI;
-  }
-
   function deg2rad(deg) {
     return deg * Math.PI / 180.0;
   }
@@ -52,7 +48,7 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
       y: (N + H)*CosB*SinL,
       z: (N + H - Ecc_2*N) * SinB
     };
-  }
+  };
 
   this.ECEF_BS = function (pos) {
     const PosX1= a11*(pos.x-X0) + a12*(pos.y-Y0) + a13*(pos.z-Z0);
@@ -62,10 +58,10 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
       x: c11*PosX1 + c12*PosZ1,
       y: a31*(pos.x-X0) + a32*(pos.y-Y0) + a33*(pos.z-Z0),
       z: c21*PosX1 + c22*PosZ1
-    }
-  }
+    };
+  };
 
   this.WGS_BS = function (Lat, Lon, H) {
     return this.ECEF_BS(this.WGS_ECEF(Lat, Lon, H));
-  }
+  };
 }

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -46,7 +46,7 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
     return {
       x: (N + H)*CosB*CosL,
       y: (N + H)*CosB*SinL,
-      z: (N + H - Ecc_2*N) * SinB
+      z: (N + H - Ecc_2*N) * SinB,
     };
   };
 
@@ -57,7 +57,7 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
     return {
       x: c11*PosX1 + c12*PosZ1,
       y: a31*(pos.x-X0) + a32*(pos.y-Y0) + a33*(pos.z-Z0),
-      z: c21*PosX1 + c22*PosZ1
+      z: c21*PosX1 + c22*PosZ1,
     };
   };
 

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -1,0 +1,71 @@
+export function GPS_transform(Lat0, Lon0, H0, Heading) {
+
+  function rad2deg(rad) {
+    return rad * 180.0 / Math.PI;
+  }
+
+  function deg2rad(deg) {
+    return deg * Math.PI / 180.0;
+  }
+
+  Lat0 = deg2rad(Lat0);
+  Lon0 = deg2rad(Lon0);
+  const Semimajor = 6378137.0,
+        Flat = 1.0/298.257223563,
+        Ecc_2 = Flat*(2-Flat),
+        SinB = Math.sin(Lat0),
+        CosB = Math.cos(Lat0),
+        SinL = Math.sin(Lon0),
+        CosL = Math.cos(Lon0),
+        N = Semimajor/Math.sqrt(1.0 - Ecc_2*SinB*SinB),
+
+        a11 = -SinB*CosL,
+        a12 = -SinB*SinL,
+        a13 = CosB,
+        a21 = -SinL,
+        a22 = CosL,
+        a23 = 0,
+        a31 = CosL*CosB,
+        a32 = CosB*SinL,
+        a33 = SinB,
+
+        X0 = (N + H0)*CosB*CosL,
+        Y0 = (N + H0)*CosB*SinL,
+        Z0 = (N + H0 - Ecc_2*N) * SinB,
+        c11 = Math.cos( deg2rad(Heading) ),
+        c12 = Math.sin( deg2rad(Heading) ),
+        c21 = -c12,
+        c22 = c11;
+
+  this.WGS_ECEF = function (Lat, Lon, H) {
+    Lat = deg2rad(Lat);
+    Lon = deg2rad(Lon);
+    const 
+      SinB = Math.sin(Lat),
+      CosB = Math.cos(Lat),
+      SinL = Math.sin(Lon),
+      CosL = Math.cos(Lon),
+      N = Semimajor/Math.sqrt(1-Ecc_2*SinB*SinB);
+
+    return {
+      x: (N + H)*CosB*CosL,
+      y: (N + H)*CosB*SinL,
+      z: (N + H - Ecc_2*N) * SinB
+    };
+  }
+
+  this.ECEF_BS = function (pos) {
+    const PosX1= a11*(pos.x-X0) + a12*(pos.y-Y0) + a13*(pos.z-Z0);
+    const PosZ1= a21*(pos.x-X0) + a22*(pos.y-Y0) + a23*(pos.z-Z0);
+
+    return {
+      x: c11*PosX1 + c12*PosZ1,
+      y: a31*(pos.x-X0) + a32*(pos.y-Y0) + a33*(pos.z-Z0),
+      z: c21*PosX1 + c22*PosZ1
+    }
+  }
+
+  this.WGS_BS = function (Lat, Lon, H) {
+    return this.ECEF_BS(this.WGS_ECEF(Lat, Lon, H));
+  }
+}

--- a/src/gps_transform.js
+++ b/src/gps_transform.js
@@ -7,27 +7,27 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
   Lat0 = deg2rad(Lat0);
   Lon0 = deg2rad(Lon0);
   const Semimajor = 6378137.0,
-        Flat = 1.0/298.257223563,
-        Ecc_2 = Flat*(2-Flat),
+        Flat = 1.0 / 298.257223563,
+        Ecc_2 = Flat * (2 - Flat),
         SinB = Math.sin(Lat0),
         CosB = Math.cos(Lat0),
         SinL = Math.sin(Lon0),
         CosL = Math.cos(Lon0),
-        N = Semimajor/Math.sqrt(1.0 - Ecc_2*SinB*SinB),
+        N = Semimajor / Math.sqrt(1.0 - Ecc_2 * SinB * SinB),
 
-        a11 = -SinB*CosL,
-        a12 = -SinB*SinL,
+        a11 = -SinB * CosL,
+        a12 = -SinB * SinL,
         a13 = CosB,
         a21 = -SinL,
         a22 = CosL,
         a23 = 0,
-        a31 = CosL*CosB,
-        a32 = CosB*SinL,
+        a31 = CosL * CosB,
+        a32 = CosB * SinL,
         a33 = SinB,
 
-        X0 = (N + H0)*CosB*CosL,
-        Y0 = (N + H0)*CosB*SinL,
-        Z0 = (N + H0 - Ecc_2*N) * SinB,
+        X0 = (N + H0) * CosB * CosL,
+        Y0 = (N + H0) * CosB * SinL,
+        Z0 = (N + H0 - Ecc_2 * N) * SinB,
         c11 = Math.cos( deg2rad(Heading) ),
         c12 = Math.sin( deg2rad(Heading) ),
         c21 = -c12,
@@ -41,23 +41,23 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
       CosB = Math.cos(Lat),
       SinL = Math.sin(Lon),
       CosL = Math.cos(Lon),
-      N = Semimajor/Math.sqrt(1-Ecc_2*SinB*SinB);
+      N = Semimajor / Math.sqrt(1 - Ecc_2 * SinB * SinB);
 
     return {
-      x: (N + H)*CosB*CosL,
-      y: (N + H)*CosB*SinL,
-      z: (N + H - Ecc_2*N) * SinB,
+      x: (N + H) * CosB * CosL,
+      y: (N + H) * CosB * SinL,
+      z: (N + H - Ecc_2 * N) * SinB,
     };
   };
 
   this.ECEF_BS = function (pos) {
-    const PosX1= a11*(pos.x-X0) + a12*(pos.y-Y0) + a13*(pos.z-Z0);
-    const PosZ1= a21*(pos.x-X0) + a22*(pos.y-Y0) + a23*(pos.z-Z0);
+    const PosX1= a11 * (pos.x - X0) + a12 * (pos.y - Y0) + a13 * (pos.z - Z0);
+    const PosZ1= a21 * (pos.x - X0) + a22 * (pos.y - Y0) + a23 * (pos.z - Z0);
 
     return {
-      x: c11*PosX1 + c12*PosZ1,
-      y: a31*(pos.x-X0) + a32*(pos.y-Y0) + a33*(pos.z-Z0),
-      z: c21*PosX1 + c22*PosZ1,
+      x: c11 * PosX1 + c12 * PosZ1,
+      y: a31 * (pos.x - X0) + a32 * (pos.y - Y0) + a33 * (pos.z - Z0),
+      z: c21 * PosX1 + c22 * PosZ1,
     };
   };
 
@@ -65,5 +65,3 @@ export function GPS_transform(Lat0, Lon0, H0, Heading) {
     return this.ECEF_BS(this.WGS_ECEF(Lat, Lon, H));
   };
 }
-
-Also please add spaces around operators in this file.

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1537,6 +1537,13 @@ GraphConfig.getExampleGraphConfigs = function (flightLog, graphNames) {
         "GPS_coord[all]",
       ],
     });
+    EXAMPLE_GRAPHS.push({
+      label: "GPS Cartesian coords",
+      fields: [
+        "gpsCartesianCoords[all]",
+        "gpsDistance",
+      ],
+    });
   }
 
   for (const srcGraph of EXAMPLE_GRAPHS) {


### PR DESCRIPTION
The log files can include gps coords - latitude, longitude, altitude.
But direct using of raw gps data is not comfortable.
Therefore this PR add computed fields - cartesian coords around home point to show its at the chart:
"gpsCartesianCoords[0]" -  X coord (axis x direction is North)
"gpsCartesianCoords[1]",   Y coord - gps altitude
"gpsCartesianCoords[2]"-  Z coord (axis z direction is East)
"gpsDistance" - distance from home point

The Y coord is absolute GPS altitude at moment. Because we need gps home altitude to compute relative altitude. But it is not exists in log at current time.
When gps home altitude will added to log in BF firmware, the Y coord will show relative altitude around home point.
The BF PR what add logging of gps home altitude is ready and can be published if this PR will aproved.
