### PR TITLE
The azimuth of Home point added as computed field

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -30,7 +30,7 @@ import {
  * Window based smoothing of fields is offered.
  */
 export function FlightLog(logData) {
-  let ADDITIONAL_COMPUTED_FIELD_COUNT = 19 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord**/,
+  let ADDITIONAL_COMPUTED_FIELD_COUNT = 20 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord**/,
     that = this,
     logIndex = 0,
     logIndexes = new FlightLogIndex(logData),
@@ -284,7 +284,7 @@ export function FlightLog(logData) {
       fieldNames.push("axisError[0]", "axisError[1]", "axisError[2]"); // Custom calculated error field
     }
     if (!that.isFieldDisabled().GPS) {
-      fieldNames.push("gpsCartesianCoords[0]", "gpsCartesianCoords[1]", "gpsCartesianCoords[2]", "gpsDistance"); // GPS coords in cartesian system
+      fieldNames.push("gpsCartesianCoords[0]", "gpsCartesianCoords[1]", "gpsCartesianCoords[2]", "gpsDistance", "gpsHomeAzimuth"); // GPS coords in cartesian system
     }
 
     fieldNameToIndex = {};
@@ -854,7 +854,14 @@ export function FlightLog(logData) {
               destFrame[fieldIndex++] = gpsCartesianCoords.y;
               destFrame[fieldIndex++] = gpsCartesianCoords.z;
               destFrame[fieldIndex++] = Math.sqrt(gpsCartesianCoords.x * gpsCartesianCoords.x + gpsCartesianCoords.z * gpsCartesianCoords.z);
+
+              let homeAzimuth = Math.atan2(-gpsCartesianCoords.z, -gpsCartesianCoords.x) * 180 / Math.PI;
+              if (homeAzimuth < 0) {
+                homeAzimuth += 360;
+              }
+              destFrame[fieldIndex++] = homeAzimuth;
             } else {
+              destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;
               destFrame[fieldIndex++] = 0;

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -30,7 +30,7 @@ import {
  * Window based smoothing of fields is offered.
  */
 export function FlightLog(logData) {
-  let ADDITIONAL_COMPUTED_FIELD_COUNT = 20 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord**/,
+  let ADDITIONAL_COMPUTED_FIELD_COUNT = 20 /** attitude + PID_SUM + PID_ERROR + RCCOMMAND_SCALED + GPS coord, distance and azimuth **/,
     that = this,
     logIndex = 0,
     logIndexes = new FlightLogIndex(logData),

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -130,6 +130,7 @@ const FRIENDLY_FIELD_NAMES = {
   "gpsCartesianCoords[1]": "GPS Coords [Y]",
   "gpsCartesianCoords[2]": "GPS Coords [Z]",
   gpsDistance:     "GPS Home distance",
+  gpsHomeAzimuth:     "GPS Home azimuth",
 };
 
 const DEBUG_FRIENDLY_FIELD_NAMES_INITIAL = {
@@ -1651,6 +1652,8 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
     case "gpsCartesianCoords[2]":
     case "gpsDistance":
         return `${value.toFixed(0)} m`;
+    case "gpsHomeAzimuth":
+        return `${value.toFixed(1)} °`;
 
     case "debug[0]":
     case "debug[1]":

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1550,6 +1550,7 @@ GraphConfig.getExampleGraphConfigs = function (flightLog, graphNames) {
       fields: [
         "gpsCartesianCoords[all]",
         "gpsDistance",
+        "gpsHomeAzimuth",
       ],
     });
   }

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -476,6 +476,14 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           max: 100,
         },
       };
+    } else if (fieldName == "gpsHomeAzimuth") {
+      return {
+        power: 1.0,
+        MinMax: {
+          min: 0,
+          max: 360,
+        },
+      };
     } else if (fieldName.match(/^debug.*/) && sysConfig.debug_mode != null) {
       const debugModeName = DEBUG_MODE[sysConfig.debug_mode];
       switch (debugModeName) {


### PR DESCRIPTION
The continue of [adding GPS computed field PR](https://github.com/betaflight/blackbox-log-viewer/pull/773).
The azimuth of home point is added as computed field.
Will be helpfull for looking at work of GPS rescue mode, when flight heading angle can be close to home point azimuth. 