### PR TITLE
The blackbox DEBUG_ATTITUDE mode is improved

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1016,10 +1016,11 @@ const DEBUG_FRIENDLY_FIELD_NAMES_INITIAL = {
   },
   ATTITUDE: {
     "debug[all]": "Attitude",
-    "debug[0]": "IMU Gain",
-    "debug[1]": "EZ_EF",
-    "debug[2]": "GroundSpeedError",
-    "debug[3]": "VelocityFactor",
+    "debug[0]": "Roll angle",
+    "debug[1]": "Pitch angle",
+    "debug[2]": "Ground speed factor",
+    "debug[3]": "Heading error",
+    "debug[7]": "Error gain",
   },
   VTX_MSP: {
     "debug[all]": "VTX MSP",
@@ -2022,10 +2023,10 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
         }
       case "ATTITUDE":
         switch (fieldName) {
-          case "debug[0]": // accADC X
-          case "debug[1]": // accADC Y
-          case "debug[2]": // setpoint Roll
-          case "debug[3]": // setpoint Pitch
+          case "debug[0]": // Roll angle
+          case "debug[1]": // Pitch angle
+          case "debug[3]": // Heading error
+            return `${(value / 10).toFixed(1)} °`;
           default:
             return value.toFixed(0);
         }
@@ -2678,10 +2679,10 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
         }
       case "ATTITUDE":
         switch (fieldName) {
-          case "debug[0]": // accADC X
-          case "debug[1]": // accADC Y
-          case "debug[2]": // setpoint Roll
-          case "debug[3]": // setpoint Pitch
+          case "debug[0]": // Roll angle
+          case "debug[1]": // Pitch angle
+          case "debug[3]": // Heading error
+            return toFriendly ? value / 10 : value * 10;
           default:
             return value;
         }

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1331,6 +1331,25 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
             inputRange: 5000,
             outputRange: 1.0,
           };
+        case "ATTITUDE":
+          switch (fieldName) {
+            case "debug[0]": // Roll angle
+              return {
+                power: 1.0,
+                MinMax: {
+                  min: -180,
+                  max: 180,
+                },
+              };
+            case "debug[1]": // Pitch angle
+              return {
+                power: 1.0,
+                MinMax: {
+                  min: -90,
+                  max: 90,
+                },
+              }; 
+          }
       }
     }
     // if not found above then


### PR DESCRIPTION
The blackbox DEBUG_ATTITUDE mode is improved.
I've needed actual flight pitch and roll today and i've found its in this debug.
But i've found, that its field had wrong names and showed wrong units values at the curves chart.
These issues were resolved. The friendly name, data units and min-max values are improved for this debug. 
I do not know about true names and units for some values in this debug fields. Please fix, if i've made any mistakes.

P.S.
Really, we do not have the all actual attitude data in the logs, because:
- The DEBUG ANGLE logs have the roll angle in Angle or Horizon mode only
- The  DEBUG_ATTITUDE does not include actual flights Yaw
- the heading[pitch], heading[roll], heading[yaw] fields are computed in blackbox explorer and its value are different by compare with the real flight attitude FC values. Sometime its close to actual flight, sometime it is not.
The DEBUG_ATTITUDE  has empty cells, the one may fill the flight yaw angle value, but maybe will better to log the actual attitude state directly in the log? There are 3 values only.