### PR TITLE
Added curves settings for axis_s log fields (for airplanes)

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -32,6 +32,11 @@ const FRIENDLY_FIELD_NAMES = {
   "axisF[0]": "PID Feedforward [roll]",
   "axisF[1]": "PID Feedforward [pitch]",
   "axisF[2]": "PID Feedforward [yaw]",
+  
+  "axisS[all]": "PID S",
+  "axisS[0]": "PID S [roll]",
+  "axisS[1]": "PID S [pitch]",
+  "axisS[2]": "PID S [yaw]",
 
   //Virtual field
   "axisSum[all]": "PID Sum",
@@ -1525,6 +1530,9 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
     case "axisF[0]":
     case "axisF[1]":
     case "axisF[2]":
+    case "axisS[0]":
+    case "axisS[1]":
+    case "axisS[2]":
       return `${flightLog.getPIDPercentage(value).toFixed(1)} %`;
 
     case "accSmooth[0]":
@@ -2203,6 +2211,9 @@ FlightLogFieldPresenter.ConvertFieldValue = function (
     case "axisF[0]":
     case "axisF[1]":
     case "axisF[2]":
+    case "axisS[0]":
+    case "axisS[1]":
+    case "axisS[2]":
       return toFriendly
         ? flightLog.getPIDPercentage(value)
         : value / flightLog.getPIDPercentage(1.0);


### PR DESCRIPTION
Improvement for BF PR [Logging of the S -term values in blackbox for Fixed wings](https://github.com/betaflight/betaflight/pull/14012)
Added curves settings for axis_s log fields (for airplanes)
![Sterm](https://github.com/user-attachments/assets/6e636081-2ae5-4f2c-9c2c-dcbb64a8481b)


