### PR TITLE
Resolved issues of show motor_idle and motors Start inc header fields for BF 4.6 log files

### DIFF
--- a/index.html
+++ b/index.html
@@ -2014,6 +2014,10 @@
                                                         <label>D-Shot Offset %</label>
                                                         <input type="text" step="0.01" min="0" max="1" />
                                                     </td>
+                                                    <td name="motor_idle">
+                                                        <label>Motor idle %</label>
+                                                        <input type="text" step="0.01" min="0" max="1" />
+                                                    </td>
                                                     <td name="motorOutputLow">
                                                         <label>D-Shot Motor Low</label>
                                                         <input type="text" step="10" min="0" max="2047" />

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -817,6 +817,7 @@ export function FlightLogParser(logData) {
         }
         break;
 
+      case "motor_idle":
       case "digitalIdleOffset":
         that.sysConfig[fieldName] = parseInt(fieldValue, 10) / 100.0;
 

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -323,6 +323,12 @@ export function HeaderDialog(dialog, onSave) {
       name: "digitalIdleOffset",
       type: FIRMWARE_TYPE_BETAFLIGHT,
       min: "3.1.0",
+      max: "4.5.1",
+    },
+    {
+      name: "motor_idle",
+      type: FIRMWARE_TYPE_BETAFLIGHT,
+      min: "4.6.0",
       max: "999.9.9",
     },
     {
@@ -1783,6 +1789,7 @@ export function HeaderDialog(dialog, onSave) {
     renderSelect("debug_mode", sysConfig.debug_mode, DEBUG_MODE);
     setParameter("motorOutputLow", sysConfig.motorOutput[0], 0);
     setParameter("motorOutputHigh", sysConfig.motorOutput[1], 0);
+    setParameter("motor_idle", sysConfig.motor_idle, 2);
     setParameter("digitalIdleOffset", sysConfig.digitalIdleOffset, 2);
     renderSelect(
       "antiGravityMode",

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -671,7 +671,7 @@ export function HeaderDialog(dialog, onSave) {
       name: "dyn_idle_start_increase",
       type: FIRMWARE_TYPE_BETAFLIGHT,
       min: "4.5.0",
-      max: "999.9.9",
+      max: "4.5.1",
     },
     {
       name: "dyn_idle_max_increase",


### PR DESCRIPTION
Resolved issues of show motor_idle and motors Start inc header fields for BF 4.6 log files.
Logs for tests: [BF46.TXT](https://github.com/user-attachments/files/17949386/BF46.TXT), [BF451.TXT](https://github.com/user-attachments/files/17949391/BF451.TXT)
The issue of master branch for BF4.6 log
![BF46_master](https://github.com/user-attachments/assets/cef775d4-0412-48b1-a84d-d898d5754c7b)
This PR improvement result:
![BF46_pr](https://github.com/user-attachments/assets/74b56fb8-0683-4ec8-a42a-830447e2db77)
The BF4.5.1 log file is showed as before:
![BF451_pr](https://github.com/user-attachments/assets/4bfc5078-8b57-4b0e-a6cf-c07349729432)







