### PR TITLE
Add AUTOPILOT_POSITION and OPTICALFLOW debug modes

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -530,12 +530,14 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
     if (semver.gte(firmwareVersion, "4.6.0")) {
       DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_RESCUE_THROTTLE_PID'), 1, 'AUTOPILOT_ALTITUDE');
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("GYRO_SCALED"), 1);
+      DEBUG_MODE.splice(DEBUG_MODE.indexOf("RANGEFINDER_QUALITY") + 1, 0, "OPTICALFLOW");
       DEBUG_MODE.push('TPA');
       DEBUG_MODE.push('S_TERM');
       DEBUG_MODE.push('SPA');
       DEBUG_MODE.push('TASK');
       DEBUG_MODE.push('GIMBAL');
       DEBUG_MODE.push('WING_SETPOINT');
+      DEBUG_MODE.push('AUTOPILOT_POSITION');
     }
 
     DEBUG_MODE = makeReadOnly(DEBUG_MODE);

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -32,7 +32,7 @@ const FRIENDLY_FIELD_NAMES = {
   "axisF[0]": "PID Feedforward [roll]",
   "axisF[1]": "PID Feedforward [pitch]",
   "axisF[2]": "PID Feedforward [yaw]",
-  
+
   "axisS[all]": "PID S",
   "axisS[0]": "PID S [roll]",
   "axisS[1]": "PID S [pitch]",
@@ -129,7 +129,7 @@ const FRIENDLY_FIELD_NAMES = {
   GPS_altitude: "GPS Altitude ASL",
   GPS_speed: "GPS Speed",
   GPS_ground_course: "GPS Heading",
-  
+
   "gpsCartesianCoords[all]": "GPS Coords",
   "gpsCartesianCoords[0]": "GPS Coords [X]",
   "gpsCartesianCoords[1]": "GPS Coords [Y]",
@@ -1388,6 +1388,26 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         'debug[4]': 'Current Setpoint [yaw]',
         'debug[5]': 'Adjusted Setpoint [yaw]',
       };
+      DEBUG_FRIENDLY_FIELD_NAMES.OPTICALFLOW = {
+        'debug[all]': 'Optical Flow',
+        'debug[0]': 'Quality',
+        'debug[1]': 'Raw flow rates X',
+        'debug[2]': 'Raw flow rates Y',
+        'debug[3]': 'Processed flow rates X',
+        'debug[4]': 'Processed flow rates Y',
+        'debug[5]': 'Delta time',
+      };
+      DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_POSITION = {
+        'debug[all]': 'Autopilot Position',
+        'debug[0]': 'Distance',
+        'debug[1]': 'GPS Distance',
+        'debug[2]': 'PID Sum EF',
+        'debug[3]': 'Angle',
+        'debug[4]': 'pidP',
+        'debug[5]': 'pidI',
+        'debug[6]': 'pidD',
+        'debug[7]': 'pidA',
+      };
     }
   }
 };
@@ -1728,7 +1748,7 @@ FlightLogFieldPresenter.decodeFieldToFriendly = function (
       }
     case "GPS_ground_course":
       return `${(value / 10).toFixed(1)} °`;
-    
+
     case "gpsCartesianCoords[0]":
     case "gpsCartesianCoords[1]":
     case "gpsCartesianCoords[2]":
@@ -2151,6 +2171,16 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
         return value.toFixed(0);
       case "EZLANDING":
         return `${(value / 100.0).toFixed(2)} %`;
+      case "OPTICALFLOW":
+        switch (fieldName) {
+          case "debug[1]":
+          case "debug[2]":
+          case "debug[3]":
+          case "debug[4]":
+            return `${(value / 1000).toFixed(1)}`;
+          default:
+            return value.toFixed(0);
+        }
     }
     return value.toFixed(0);
   }
@@ -2816,6 +2846,16 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
         return value;
       case "DSHOT_TELEMETRY_COUNTS":
         return value;
+      case "OPTICALFLOW":
+        switch (fieldName) {
+          case "debug[1]":
+          case "debug[2]":
+          case "debug[3]":
+          case "debug[4]":
+            return toFriendly ? value / 1000 : value * 1000;
+          default:
+            return value;
+        }
     }
   }
   return value;

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -2179,7 +2179,19 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
           case "debug[4]":
             return `${(value / 1000).toFixed(1)}`;
           default:
-            return value.toFixed(0);
+            return value.toFixed(1);
+        }
+      case "AUTOPILOT_POSITION":
+        switch (fieldName) {
+          case "debug[2]":
+          case "debug[3]":
+          case "debug[4]":
+          case "debug[5]":
+          case "debug[6]":
+          case "debug[7]":
+            return `${(value / 10).toFixed(1)}`;
+          default:
+            return value.toFixed(1);
         }
     }
     return value.toFixed(0);
@@ -2853,6 +2865,18 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
           case "debug[3]":
           case "debug[4]":
             return toFriendly ? value / 1000 : value * 1000;
+          default:
+            return value;
+        }
+      case "AUTOPILOT_POSITION":
+        switch (fieldName) {
+          case "debug[2]":
+          case "debug[3]":
+          case "debug[4]":
+          case "debug[5]":
+          case "debug[6]":
+          case "debug[7]":
+            return toFriendly ? value / 10 : value * 10;
           default:
             return value;
         }


### PR DESCRIPTION
There are debug modes bugs after OPTICALFLOW debug was added. The GYRO_SAMPLE and other debugs did not work properly.
Resolved by updating debug modes list for BF 4.6.
Log file for testing: 
[gyro_sample.txt](https://github.com/user-attachments/files/18232639/gyro_sample.txt)

The BF Configurator is improved in this PR: https://github.com/betaflight/betaflight-configurator/pull/4284
