### PR TITLE
The units converters are added for TPA debug fields

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -2193,6 +2193,16 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
           default:
             return value.toFixed(1);
         }
+      case "TPA":
+        switch (fieldName) {
+          case "debug[1]":
+          case "debug[2]":
+            return `${(value / 10).toFixed(1)} °`;
+          case "debug[4]":
+            return `${(value / 10).toFixed(1)} m/s`;
+          default:
+            return value.toFixed(1);
+        }
     }
     return value.toFixed(0);
   }
@@ -2876,6 +2886,15 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
           case "debug[5]":
           case "debug[6]":
           case "debug[7]":
+            return toFriendly ? value / 10 : value * 10;
+          default:
+            return value;
+        }
+      case "TPA":
+        switch (fieldName) {
+          case "debug[1]":
+          case "debug[2]":
+          case "debug[4]":
             return toFriendly ? value / 10 : value * 10;
           default:
             return value;


### PR DESCRIPTION
The improvement for WING TPA debug mode:
- added units converters for pitch, roll [grad] and estimation speed [m/s] fields.
@limonspb do you need unit converters for other TPA debug fields (throttle, tpa value, ... )?
