### PR TITLE
Fix undefined video export dialog

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import "./vendor.js";
 import { throttle } from "throttle-debounce";
 import { MapGrapher } from "./graph_map.js";
 import { FlightLogGrapher } from "./grapher.js";
+import { VideoExportDialog } from "./video_export_dialog.js";
 import { FlightLogVideoRenderer } from "./flightlog_video_renderer.js";
 import { UserSettingsDialog } from "./user_settings_dialog.js";
 import { GraphConfigurationDialog } from "./graph_config_dialog.js";


### PR DESCRIPTION
This pull request includes a change to the `src/main.js` file to import a new module.

* [`src/main.js`](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R6): Added an import statement for the `VideoExportDialog` module to support video export functionality.