### PR TITLE
Added quaternions checking to prevent negative sqrt argument in attitudes calculation algorithm

### DIFF
--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -737,7 +737,13 @@ export function FlightLog(logData) {
               z: srcFrame[imuQuaternion[2]] / scaleFromFixedInt16,
               w: 1.0,
             };
-            q.w = Math.sqrt(1.0 - (q.x ** 2 + q.y ** 2 + q.z ** 2));
+
+            const m = q.x ** 2 + q.y ** 2 + q.z ** 2;
+            if (m < 1.0) {
+              q.w = Math.sqrt(1.0 - m);
+            } else {
+              q.w = 0.0;
+            }
             const xx = q.x ** 2,
                   xy = q.x * q.y,
                   xz = q.x * q.z,

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -741,7 +741,7 @@ export function FlightLog(logData) {
             let m = q.x ** 2 + q.y ** 2 + q.z ** 2;
             if (m < 1.0) {
                 // reconstruct .w of unit quaternion
-                q.w = Math.sqrt(1.0 - m ** 2);
+                q.w = Math.sqrt(1.0 - m);
             } else {                
                 // normalize [0,x,y,z]
                 m = Math.sqrt(m);

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -738,11 +738,16 @@ export function FlightLog(logData) {
               w: 1.0,
             };
 
-            const m = q.x ** 2 + q.y ** 2 + q.z ** 2;
+            const m = Math.sqrt(q.x ** 2 + q.y ** 2 + q.z ** 2);
             if (m < 1.0) {
-              q.w = Math.sqrt(1.0 - m);
-            } else {
-              q.w = 0.0;
+                // reconstruct .w of unit quaternion
+                q.w = Math.sqrt(1.0 - m ** 2);
+            } else {                
+                // normalize [0,x,y,z]
+                q.x /= m;
+                q.y /= m;
+                q.z /= m;
+                q.w = 0;
             }
             const xx = q.x ** 2,
                   xy = q.x * q.y,

--- a/src/flightlog.js
+++ b/src/flightlog.js
@@ -738,12 +738,13 @@ export function FlightLog(logData) {
               w: 1.0,
             };
 
-            const m = Math.sqrt(q.x ** 2 + q.y ** 2 + q.z ** 2);
+            let m = q.x ** 2 + q.y ** 2 + q.z ** 2;
             if (m < 1.0) {
                 // reconstruct .w of unit quaternion
                 q.w = Math.sqrt(1.0 - m ** 2);
             } else {                
                 // normalize [0,x,y,z]
+                m = Math.sqrt(m);
                 q.x /= m;
                 q.y /= m;
                 q.z /= m;


### PR DESCRIPTION
Resolved [attitudes computing issue ](https://github.com/betaflight/blackbox-log-viewer/pull/790#issuecomment-2669600096) when attitude quaternions x * x +y * y+z * z a tiny more than 1
