### PR TITLE
Added missing slices of data samples arrays in spectrum calc

### DIFF
--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -178,13 +178,13 @@ GraphSpectrumCalc._dataLoadFrequencyVsX = function(vsFieldNames, minValue = Infi
   // blur algorithm to the heat map image
 
   const fftData = {
-      fieldIndex   : this._dataBuffer.fieldIndex,
-      fieldName  : this._dataBuffer.fieldName,
-      fftLength  : fftChunkLength,
-      fftOutput  : matrixFftOutput,
-      maxNoise   : maxNoise,
-      blackBoxRate : this._blackBoxRate,
-      vsRange    : { min: flightSamples.minValue, max: flightSamples.maxValue},
+    fieldIndex   : this._dataBuffer.fieldIndex,
+    fieldName  : this._dataBuffer.fieldName,
+    fftLength  : fftChunkLength,
+    fftOutput  : matrixFftOutput,
+    maxNoise   : maxNoise,
+    blackBoxRate : this._blackBoxRate,
+    vsRange    : { min: flightSamples.minValue, max: flightSamples.maxValue},
   };
 
   return fftData;
@@ -299,7 +299,7 @@ GraphSpectrumCalc._getFlightSamplesFreq = function() {
   }
 
   return {
-    samples : samples,
+    samples : samples.slice(0, samplesCount),
     count : samplesCount,
   };
 };
@@ -379,13 +379,14 @@ GraphSpectrumCalc._getFlightSamplesFreqVsX = function(vsFieldNames, minValue = I
   for (const vsValueArray of vsValues) {
     slicedVsValues.push(vsValueArray.slice(0, samplesCount));
   }
+
   return {
-      samples  : samples.slice(0, samplesCount),
-      vsValues : slicedVsValues,
-      count  : samplesCount,
-      minValue : minValue,
-      maxValue : maxValue,
-       };
+    samples  : samples.slice(0, samplesCount),
+    vsValues : slicedVsValues,
+    count  : samplesCount,
+    minValue : minValue,
+    maxValue : maxValue,
+  };
 };
 
 GraphSpectrumCalc._getFlightSamplesPidErrorVsSetpoint = function(axisIndex) {
@@ -414,8 +415,8 @@ GraphSpectrumCalc._getFlightSamplesPidErrorVsSetpoint = function(axisIndex) {
   }
 
   return {
-    piderror,
-    setpoint,
+    piderror: piderror.slice(0, samplesCount),
+    setpoint: setpoint.slice(0, samplesCount),
     maxSetpoint,
     count: samplesCount,
   };


### PR DESCRIPTION
Resolved issue of missing slices of data samples arrays in spectrum calc.
The FFT used huge rezerved data length input before. 