### PR TITLE
Adding cloudflare preview builds

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --commit-dirty=true
+          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch ${{ github.head_ref }} --commit-dirty=true
 
       - name: Add deployment comment
         uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,50 @@
+name: 'Preview Deployment'
+on:
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules/
+          key: node_modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - run: npm install yarn -g
+      - run: yarn install
+      - run: yarn build
+
+      - name: Deploy to Cloudflare
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --commit-dirty=true
+
+      - name: Add deployment comment
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+             Preview URL: ${{ steps.deploy.outputs.deployment-url }}
+          reactions: eyes, rocket
+          comment-tag: 'Preview URL'
+          mode: recreate


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate preview deployments for pull requests targeting the `master` branch. The workflow includes steps for building the project, deploying to Cloudflare, and commenting the preview URL back on the pull request.

### New GitHub Actions Workflow for Preview Deployments:
* [`.github/workflows/deploy-preview.yml`](diffhunk://#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0R1-R50): Added a new workflow named `Preview Deployment` that triggers on pull requests targeting the `master` branch. The workflow includes steps for caching dependencies, installing Node.js, building the project with Yarn, deploying to Cloudflare using the Wrangler action, and commenting the preview URL on the pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated preview deployments for pull requests targeting the master branch. Deployment URLs are posted directly on the pull request for easy access and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->