### PR TITLE
fix pr 819 breakage - this reverts returning samples, not splice of samples.

### DIFF
--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -330,7 +330,7 @@ GraphSpectrumCalc._getFlightSamplesFreq = function(scaled = true) {
   }
 
   return {
-    samples : samples.slice(0, samplesCount),
+    samples : samples,
     count : samplesCount,
   };
 };


### PR DESCRIPTION
`graph_spectrum_calc.js`:
```
  return {
    samples : samples,
    count : samplesCount,
  };
```

fixes breakage cause by #819



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the handling of sample data in spectrum calculations to return the full buffer, which may include unused elements beyond the valid sample count. The count of valid samples remains clearly indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->