### PR TITLE
revert samples

### DIFF
--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -330,7 +330,7 @@ GraphSpectrumCalc._getFlightSamplesFreq = function(scaled = true) {
   }
 
   return {
-    samples : samples.slice(0, samplesCount),
+    samples : samples,
     count : samplesCount,
   };
 };


### PR DESCRIPTION
`graph_spectrum_calc.js`:
```
  return {
    samples : samples,
    count : samplesCount,
  };
```

fixes breakage cause by #819

this PR based on a branch. #828 was master by mistake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted internal handling of sample arrays in frequency calculations, which may result in the returned data containing additional unused elements beyond the reported count. No changes to visible features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->