### PR TITLE
Revert "Added missing slices of data samples arrays in spectrum calc"

### DIFF
--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -205,13 +205,13 @@ GraphSpectrumCalc._dataLoadFrequencyVsX = function(vsFieldNames, minValue = Infi
   // blur algorithm to the heat map image
 
   const fftData = {
-    fieldIndex   : this._dataBuffer.fieldIndex,
-    fieldName  : this._dataBuffer.fieldName,
-    fftLength  : fftChunkLength,
-    fftOutput  : matrixFftOutput,
-    maxNoise   : maxNoise,
-    blackBoxRate : this._blackBoxRate,
-    vsRange    : { min: flightSamples.minValue, max: flightSamples.maxValue},
+      fieldIndex   : this._dataBuffer.fieldIndex,
+      fieldName  : this._dataBuffer.fieldName,
+      fftLength  : fftChunkLength,
+      fftOutput  : matrixFftOutput,
+      maxNoise   : maxNoise,
+      blackBoxRate : this._blackBoxRate,
+      vsRange    : { min: flightSamples.minValue, max: flightSamples.maxValue},
   };
 
   return fftData;
@@ -330,7 +330,7 @@ GraphSpectrumCalc._getFlightSamplesFreq = function(scaled = true) {
   }
 
   return {
-    samples : samples.slice(0, samplesCount),
+    samples : samples,
     count : samplesCount,
   };
 };
@@ -410,14 +410,13 @@ GraphSpectrumCalc._getFlightSamplesFreqVsX = function(vsFieldNames, minValue = I
   for (const vsValueArray of vsValues) {
     slicedVsValues.push(vsValueArray.slice(0, samplesCount));
   }
-
   return {
-    samples  : samples.slice(0, samplesCount),
-    vsValues : slicedVsValues,
-    count  : samplesCount,
-    minValue : minValue,
-    maxValue : maxValue,
-  };
+      samples  : samples.slice(0, samplesCount),
+      vsValues : slicedVsValues,
+      count  : samplesCount,
+      minValue : minValue,
+      maxValue : maxValue,
+       };
 };
 
 GraphSpectrumCalc._getFlightSamplesPidErrorVsSetpoint = function(axisIndex) {
@@ -446,8 +445,8 @@ GraphSpectrumCalc._getFlightSamplesPidErrorVsSetpoint = function(axisIndex) {
   }
 
   return {
-    piderror: piderror.slice(0, samplesCount),
-    setpoint: setpoint.slice(0, samplesCount),
+    piderror,
+    setpoint,
     maxSetpoint,
     count: samplesCount,
   };


### PR DESCRIPTION
Reverts betaflight/blackbox-log-viewer#819
I doubted that it was bug and i've found an answer.
The source spectrum code used FFT zero padding method, to get bigger fft resolution at the chart. It uses big input/output size with big zero values pad. As result we had high fft resolution as fs/N. But zero pad does not change frequency resolution, what is 1/T.
The current PR uses current sample size for fft input, what is not good for fft speed.
I want try to use fft input size as nearest power 2 value and fill zero values in empty cells only.
The both methods is working. But we need to test and compare new method before.
Those methods choice is ground of my next PSD PRs. I will need the big rebase of PSD PRs in any case. I will use new method for PSD.
Therefore i suggest to revert this and PSD :) PRs.
The PSD works good and i have power2 sized version, but let's test and compare the all these before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data consistency by returning complete arrays in certain calculations, ensuring all available data is included in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->