### PR TITLE
fix preview checkout

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,20 +6,15 @@ on:
       - master
 
 jobs:
-  deploy:
-    permissions:
-      actions: read
-      contents: read
-      deployments: write
-      issues: write
-      pull-requests: write
+  # Job 1: Build the code (no secrets here)
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false  # Don't persist GitHub token
 
       - name: Cache node_modules
         uses: actions/cache@v4
@@ -35,6 +30,30 @@ jobs:
       - run: npm install yarn -g
       - run: yarn install
       - run: yarn build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-files
+          path: dist
+
+  # Job 2: Deploy with secrets (no PR code checkout)
+  deploy:
+    needs: build  # Wait for build job to complete
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-files
+          path: dist
 
       - name: Deploy to Cloudflare
         id: deploy

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,7 @@ jobs:
       actions: read
       contents: read
       deployments: write
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,6 +1,7 @@
 name: 'Preview Deployment'
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - master
 
@@ -16,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache node_modules
         uses: actions/cache@v4


### PR DESCRIPTION
- ensure checkout of `ref: ${{ github.event.pull_request.head.sha }}` for the Deployment Preview


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated preview deployment workflow to trigger only on specific pull request events and ensure deployments use the exact commit from the pull request.
  - Separated build and deploy processes to improve deployment reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->