### PR TITLE
Bug fix: The spectrum graph is sometimes not displayed after change spectrums type

### DIFF
--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -17,14 +17,15 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
   let that = this,
     analyserZoomX = 1.0 /* 100% */,
     analyserZoomY = 1.0 /* 100% */,
-    dataBuffer = {
-      fieldIndex: 0,
-      curve: 0,
-      fieldName: null,
-    },
     dataReload = false,
     fftData = null,
     prefs = new PrefStorage();
+
+  this.dataBuffer = {
+    fieldIndex: 0,
+    curve: 0,
+    fieldName: null,
+  };
 
   try {
     let isFullscreen = false;
@@ -100,9 +101,8 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
       });
     };
 
-    let dataLoad = function () {
-      GraphSpectrumCalc.setDataBuffer(dataBuffer);
-
+    const dataLoad = function () {
+      GraphSpectrumCalc.setDataBuffer(that.dataBuffer);
       switch (userSettings.spectrumType) {
         case SPECTRUM_TYPE.FREQ_VS_THROTTLE:
           fftData = GraphSpectrumCalc.dataLoadFrequencyVsThrottle();
@@ -128,19 +128,16 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
            analyser on screen*/
     this.plotSpectrum = function (fieldIndex, curve, fieldName) {
       // Store the data pointers
-      dataBuffer = {
-        fieldIndex: fieldIndex,
-        curve: curve,
-        fieldName: fieldName,
-      };
 
+      that.dataBuffer.fieldIndex = fieldIndex;
+      that.dataBuffer.curve = curve;
+      that.dataBuffer.fieldName = fieldName;
       // Detect change of selected field.... reload and redraw required.
       if (fftData == null || fieldIndex != fftData.fieldIndex || dataReload) {
         dataReload = false;
         dataLoad();
         GraphSpectrumPlot.setData(fftData, userSettings.spectrumType);
       }
-
       that.draw(); // draw the analyser on the canvas....
     };
 
@@ -211,9 +208,9 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           // Recalculate the data, for the same curve than now, and draw it
           dataReload = true;
           that.plotSpectrum(
-            dataBuffer.fieldIndex,
-            dataBuffer.curve,
-            dataBuffer.fieldName
+            that.dataBuffer.fieldIndex,
+            that.dataBuffer.curve,
+            that.dataBuffer.fieldName
           );
         }
 


### PR DESCRIPTION
The spectrum charts has one random bug.
The spectrum graph is sometimes not displayed after change spectrums type. It needs to click curves legend by mouse to display spectrum again.
The debug window shows next message for this bug:
![error](https://github.com/user-attachments/assets/287a2536-be89-4cc9-a882-6ce0d3c9c234)

My research show reason this bag. The FlightLogAnalyser.plotSpectrum fill dataBuffer struct data for current curves. But spectrumTypeElem.change handler does not see sometime these dataBuffer data - it sees the initial null values. Very starnge that this is random bug. Probably, some closures data access issue in combobox change handler.
The solution - using of dataBuffer as class member with "this".
