### PR TITLE
Bug fix: The spectrum graph is sometimes not displayed after change s…

### DIFF
--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -17,14 +17,14 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
   let that = this,
     analyserZoomX = 1.0 /* 100% */,
     analyserZoomY = 1.0 /* 100% */,
-    dataBuffer = {
-      fieldIndex: 0,
-      curve: 0,
-      fieldName: null,
-    },
     dataReload = false,
     fftData = null,
-    prefs = new PrefStorage();
+    prefs = new PrefStorage(),
+    dataBuffer = {
+      fieldIndex: 0,
+      curve: null,
+      fieldName: null,
+    };
 
   try {
     let isFullscreen = false;
@@ -128,11 +128,9 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
            analyser on screen*/
     this.plotSpectrum = function (fieldIndex, curve, fieldName) {
       // Store the data pointers
-      dataBuffer = {
-        fieldIndex: fieldIndex,
-        curve: curve,
-        fieldName: fieldName,
-      };
+      dataBuffer.fieldIndex = fieldIndex;
+      dataBuffer.curve = curve;
+      dataBuffer.fieldName = fieldName;
 
       // Detect change of selected field.... reload and redraw required.
       if (fftData == null || fieldIndex != fftData.fieldIndex || dataReload) {
@@ -208,6 +206,13 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           userSettings.spectrumType = optionSelected;
           saveOneUserSetting("spectrumType", userSettings.spectrumType);
 
+          // Restore dataBuffer if it was corrupted
+          if (!dataBuffer.curve) {
+            dataBuffer.curve = GraphSpectrumCalc._dataBuffer.curve;
+            dataBuffer.fieldName = GraphSpectrumCalc._dataBuffer.fieldName;
+            dataBuffer.fieldIndex = GraphSpectrumCalc._dataBuffer.fieldIndex;
+            console.warn("The dataBuffer was corrupted (set to default zeroes) in FlightLogAnalyser.spectrumTypeElem.change event");
+          }
           // Recalculate the data, for the same curve than now, and draw it
           dataReload = true;
           that.plotSpectrum(

--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -29,7 +29,7 @@ export const GraphSpectrumCalc = {
   _blackBoxRate : 0,
   _dataBuffer : {
       fieldIndex: 0,
-      curve: 0,
+      curve: null,
       fieldName: null,
   },
   _flightLog : null,
@@ -85,7 +85,9 @@ GraphSpectrumCalc.setOutTime = function(time) {
 };
 
 GraphSpectrumCalc.setDataBuffer = function(dataBuffer) {
-  this._dataBuffer = dataBuffer;
+  this._dataBuffer.curve = dataBuffer.curve;
+  this._dataBuffer.fieldName = dataBuffer.fieldName;
+  this._dataBuffer.fieldIndex = dataBuffer.fieldIndex;
   return undefined;
 };
 


### PR DESCRIPTION
The continue of #837 #838 PRs
The debug shows, that SpectrumCalc._dataBuff is valid while spectrumAnalyzer.dataBuff is wrong (is set to default zero values) during spectrum type change handler call.
Therefore it possible to use these properly data to restore corrupted data buffer.
This is random bug. I've checked this code when the bug was happened.
How to test this PR:
- Show some spectrum
- change spectrum type
The spectrum allways must update properly 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency and reliability in spectrum graph display, reducing the risk of data corruption or unexpected resets during spectrum type changes.
  - Enhanced detection and automatic recovery from data buffer issues to ensure smoother user experience when interacting with spectrum analysis features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->