### PR TITLE
Removed superfluous dataBuffer in graph_spectrum to prevent the random spectrum type change bug

### DIFF
--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -19,12 +19,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
     analyserZoomY = 1.0 /* 100% */,
     dataReload = false,
     fftData = null,
-    prefs = new PrefStorage(),
-    dataBuffer = {
-      fieldIndex: 0,
-      curve: null,
-      fieldName: null,
-    };
+    prefs = new PrefStorage();
 
   try {
     let isFullscreen = false;

--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -100,8 +100,10 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
       });
     };
 
-    let dataLoad = function () {
-      GraphSpectrumCalc.setDataBuffer(dataBuffer);
+    const dataLoad = function (fieldIndex, curve, fieldName) {
+      if (fieldIndex > 0 && curve != null && fieldName != null) {
+        GraphSpectrumCalc.setDataBuffer(fieldIndex, curve, fieldName);
+      }
 
       switch (userSettings.spectrumType) {
         case SPECTRUM_TYPE.FREQ_VS_THROTTLE:
@@ -127,15 +129,10 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
            It is only used to record the current curve positions, collect the data and draw the
            analyser on screen*/
     this.plotSpectrum = function (fieldIndex, curve, fieldName) {
-      // Store the data pointers
-      dataBuffer.fieldIndex = fieldIndex;
-      dataBuffer.curve = curve;
-      dataBuffer.fieldName = fieldName;
-
       // Detect change of selected field.... reload and redraw required.
       if (fftData == null || fieldIndex != fftData.fieldIndex || dataReload) {
         dataReload = false;
-        dataLoad();
+        dataLoad(fieldIndex, curve, fieldName);
         GraphSpectrumPlot.setData(fftData, userSettings.spectrumType);
       }
 
@@ -206,20 +203,9 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           userSettings.spectrumType = optionSelected;
           saveOneUserSetting("spectrumType", userSettings.spectrumType);
 
-          // Restore dataBuffer if it was corrupted
-          if (!dataBuffer.curve) {
-            dataBuffer.curve = GraphSpectrumCalc._dataBuffer.curve;
-            dataBuffer.fieldName = GraphSpectrumCalc._dataBuffer.fieldName;
-            dataBuffer.fieldIndex = GraphSpectrumCalc._dataBuffer.fieldIndex;
-            console.warn("The dataBuffer was corrupted (set to default zeroes) in FlightLogAnalyser.spectrumTypeElem.change event");
-          }
           // Recalculate the data, for the same curve than now, and draw it
           dataReload = true;
-          that.plotSpectrum(
-            dataBuffer.fieldIndex,
-            dataBuffer.curve,
-            dataBuffer.fieldName,
-          );
+          that.plotSpectrum(-1, null, null); // Update fft data only
         }
 
         // Hide overdraw and zoomY if needed

--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -84,10 +84,10 @@ GraphSpectrumCalc.setOutTime = function(time) {
   return this._analyserTimeRange.out;
 };
 
-GraphSpectrumCalc.setDataBuffer = function(dataBuffer) {
-  this._dataBuffer.curve = dataBuffer.curve;
-  this._dataBuffer.fieldName = dataBuffer.fieldName;
-  this._dataBuffer.fieldIndex = dataBuffer.fieldIndex;
+GraphSpectrumCalc.setDataBuffer = function(fieldIndex, curve, fieldName) {
+  this._dataBuffer.curve = curve;
+  this._dataBuffer.fieldName = fieldName;
+  this._dataBuffer.fieldIndex = fieldIndex;
   return undefined;
 };
 


### PR DESCRIPTION
The continue of #837 #838 #839 PRs.
The last #839 PR has not [full the random dataBuffer destroing bug prevention](https://github.com/betaflight/blackbox-log-viewer/pull/839#issuecomment-2948480393)
There is no dataBuffer, there is no this bug by using this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved data buffer management for spectrum graphs, reducing reliance on global state and enhancing stability when switching spectrum types. No visible changes to the user interface or workflow.
- **Chores**
  - Updated internal methods for handling spectrum data to use explicit parameter passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->