### PR TITLE
Added CHIRP flight mode title

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -141,6 +141,7 @@ export const FLIGHT_LOG_FLIGHT_MODE_NAME_POST_4_5 = makeReadOnly([
   "MAG",
   "ALTHOLD",
   "HEADFREE",
+  "CHIRP",
   "PASSTHRU",
   "FAILSAFE",
   "POSHOLD",


### PR DESCRIPTION
Added CHIRP mode title.
The log file:
[chirp_pids.txt](https://github.com/user-attachments/files/20738544/chirp_pids.txt)
The CHRP mode marker title was broken before, it was looked as PASSTHRU mode. 
The PR result. 
![Chirp](https://github.com/user-attachments/assets/1c20bc3e-3dbb-4038-9141-613b26de52f8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "CHIRP" flight mode for firmware versions after 4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->