### PR TITLE
The min and max heatmap PSD values settings are stored for continous using

### DIFF
--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -286,7 +286,8 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           $(this).val(analyserMinPSD.val()).trigger("input");
         }
       })
-      .val(analyserMinPSD.val());
+      .val(analyserMinPSD.val())
+      .trigger("input");
 
     // Spectrum type to show
     userSettings.spectrumType =

--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -226,6 +226,17 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
       })
       .val(DEFAULT_ZOOM);
 
+    if (userSettings.psdHeatmapMin == undefined) {
+      userSettings.psdHeatmapMin = DEFAULT_PSD_HEATMAP_MIN;
+    }
+    GraphSpectrumPlot.setMinPSD(userSettings.psdHeatmapMin);
+    GraphSpectrumPlot.setLowLevelPSD(userSettings.psdHeatmapMin);
+
+    if (userSettings.psdHeatmapMax == undefined) {
+      userSettings.psdHeatmapMax = DEFAULT_PSD_HEATMAP_MAX;
+    }
+    GraphSpectrumPlot.setMaxPSD(userSettings.psdHeatmapMax);
+
     analyserMinPSD
       .on(
         "input",
@@ -246,8 +257,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           $(this).val(userSettings.psdHeatmapMin).trigger("input");
         }
       })
-      .val(userSettings.psdHeatmapMin ?? DEFAULT_PSD_HEATMAP_MIN)
-      .trigger("input");
+      .val(userSettings.psdHeatmapMin);
 
     analyserMaxPSD
       .on(
@@ -269,8 +279,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           $(this).val(userSettings.psdHeatmapMax).trigger("input");
         }
       })
-      .val(userSettings.psdHeatmapMax ?? DEFAULT_PSD_HEATMAP_MAX)
-      .trigger("input");
+      .val(userSettings.psdHeatmapMax);
 
     analyserLowLevelPSD
       .on(
@@ -286,8 +295,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
           $(this).val(analyserMinPSD.val()).trigger("input");
         }
       })
-      .val(analyserMinPSD.val())
-      .trigger("input");
+      .val(analyserMinPSD.val());
 
     // Spectrum type to show
     userSettings.spectrumType =

--- a/src/graph_spectrum.js
+++ b/src/graph_spectrum.js
@@ -4,8 +4,6 @@ import {
   GraphSpectrumPlot,
   SPECTRUM_TYPE,
   SPECTRUM_OVERDRAW_TYPE,
-  DEFAULT_MIN_DBM_VALUE,
-  DEFAULT_MAX_DBM_VALUE,
 } from "./graph_spectrum_plot";
 import { PrefStorage } from "./pref_storage";
 import { SpectrumExporter } from "./spectrum-exporter";
@@ -17,7 +15,9 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
     ANALYSER_LARGE_WIDTH_MARGIN = 20;
 
   const that = this,
-    prefs = new PrefStorage();
+    prefs = new PrefStorage(),
+    DEFAULT_PSD_HEATMAP_MIN = -40,
+    DEFAULT_PSD_HEATMAP_MAX = 10;
   let analyserZoomX = 1.0 /* 100% */,
     analyserZoomY = 1.0 /* 100% */,
     dataReload = false,
@@ -232,6 +232,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
         debounce(100, function () {
           const min = parseInt(analyserMinPSD.val());
           GraphSpectrumPlot.setMinPSD(min);
+          saveOneUserSetting("psdHeatmapMin", min);
           analyserLowLevelPSD.prop("min", min);
           analyserMaxPSD.prop("min", min + 5);
           if (analyserLowLevelPSD.val() < min) {
@@ -242,10 +243,11 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
       )
       .dblclick(function (e) {
         if (e.ctrlKey) {
-          $(this).val(DEFAULT_MIN_DBM_VALUE).trigger("input");
+          $(this).val(userSettings.psdHeatmapMin).trigger("input");
         }
       })
-      .val(DEFAULT_MIN_DBM_VALUE);
+      .val(userSettings.psdHeatmapMin ?? DEFAULT_PSD_HEATMAP_MIN)
+      .trigger("input");
 
     analyserMaxPSD
       .on(
@@ -253,6 +255,7 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
         debounce(100, function () {
           const max = parseInt(analyserMaxPSD.val());
           GraphSpectrumPlot.setMaxPSD(max);
+          saveOneUserSetting("psdHeatmapMax", max);
           analyserMinPSD.prop("max", max - 5);
           analyserLowLevelPSD.prop("max", max);
           if (analyserLowLevelPSD.val() > max) {
@@ -263,10 +266,11 @@ export function FlightLogAnalyser(flightLog, canvas, analyserCanvas) {
       )
       .dblclick(function (e) {
         if (e.ctrlKey) {
-          $(this).val(DEFAULT_MAX_DBM_VALUE).trigger("input");
+          $(this).val(userSettings.psdHeatmapMax).trigger("input");
         }
       })
-      .val(DEFAULT_MAX_DBM_VALUE);
+      .val(userSettings.psdHeatmapMax ?? DEFAULT_PSD_HEATMAP_MAX)
+      .trigger("input");
 
     analyserLowLevelPSD
       .on(

--- a/src/graph_spectrum_plot.js
+++ b/src/graph_spectrum_plot.js
@@ -48,9 +48,10 @@ export const GraphSpectrumPlot = window.GraphSpectrumPlot || {
   _sysConfig: null,
   _zoomX: 1.0,
   _zoomY: 1.0,
-  _minPSD: -40,
-  _maxPSD: 10,
-  _lowLevelPSD: -40,
+  // _minPSD, _maxPSD, _lowLevelPSD will initialize later in FlightLogAnalyser from stored settings
+  _minPSD: 0,
+  _maxPSD: 0,
+  _lowLevelPSD: 0,
   _drawingParams: {
     fontSizeFrameLabel: "6",
     fontSizeFrameLabelFullscreen: "9",

--- a/src/graph_spectrum_plot.js
+++ b/src/graph_spectrum_plot.js
@@ -14,9 +14,6 @@ const BLUR_FILTER_PIXEL = 1,
   ZOOM_X_MAX = 5,
   MAX_SPECTRUM_LINE_COUNT = 30000;
 
-export const DEFAULT_MIN_DBM_VALUE = -40,
-  DEFAULT_MAX_DBM_VALUE = 10;
-
 export const SPECTRUM_TYPE = {
   FREQUENCY: 0,
   FREQ_VS_THROTTLE: 1,
@@ -51,9 +48,9 @@ export const GraphSpectrumPlot = window.GraphSpectrumPlot || {
   _sysConfig: null,
   _zoomX: 1.0,
   _zoomY: 1.0,
-  _minPSD: DEFAULT_MIN_DBM_VALUE,
-  _maxPSD: DEFAULT_MAX_DBM_VALUE,
-  _lowLevelPSD: DEFAULT_MIN_DBM_VALUE,
+  _minPSD: -40,
+  _maxPSD: 10,
+  _lowLevelPSD: -40,
   _drawingParams: {
     fontSizeFrameLabel: "6",
     fontSizeFrameLabelFullscreen: "9",

--- a/src/user_settings_dialog.js
+++ b/src/user_settings_dialog.js
@@ -213,7 +213,7 @@ export function UserSettingsDialog(dialog, onLoad, onSave) {
     analyserHanning: true, // use a hanning window on the analyser sample data
     eraseBackground: true, // Set to false if you want the graph to draw on top of an existing canvas image
     spectrumType: 0, // By default, frequency Spectrum
-    overdrawSpectrumType: 0, // By default, show all filters,
+    overdrawSpectrumType: 0, // By default, show all filters
     psdHeatmapMin: -40,
     psdHeatmapMax: 10,
     craft: {

--- a/src/user_settings_dialog.js
+++ b/src/user_settings_dialog.js
@@ -213,7 +213,9 @@ export function UserSettingsDialog(dialog, onLoad, onSave) {
     analyserHanning: true, // use a hanning window on the analyser sample data
     eraseBackground: true, // Set to false if you want the graph to draw on top of an existing canvas image
     spectrumType: 0, // By default, frequency Spectrum
-    overdrawSpectrumType: 0, // By default, show all filters
+    overdrawSpectrumType: 0, // By default, show all filters,
+    psdHeatmapMin: -40,
+    psdHeatmapMax: 10,
     craft: {
       left: "15%", // position from left (as a percentage of width)
       top: "48%", // position from top (as a percentage of height)


### PR DESCRIPTION
The min and max heatmap PSD values settings are stored for continous using.
![storable](https://github.com/user-attachments/assets/73dd7821-d58c-4b9d-bf2b-be4d03535b6e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * PSD heatmap minimum and maximum values now persist according to user settings and are initialized from saved preferences or new defaults.
  * Added new default settings for PSD heatmap min/max values.

* **Bug Fixes**
  * PSD heatmap controls now immediately reflect changes and reset to user-saved values on double-click, ensuring consistent UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->