### PR TITLE
rename DUAL_GYRO to MULTI_GYRO (debug mode)

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -550,6 +550,12 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       DEBUG_MODE.push('WING_SETPOINT');
       DEBUG_MODE.push('AUTOPILOT_POSITION');
     }
+    if (semver.gte(firmwareVersion, "4.6.0")) {
+      //rename DUAL_GYRO_ to MULTI_GYRO
+      DEBUG_MODE.splice(DEBUG_MODE.indexOf("DUAL_GYRO_RAW"), 1, "MULTI_GYRO_RAW");
+      DEBUG_MODE.splice(DEBUG_MODE.indexOf("DUAL_GYRO_DIFF"), 1, "MULTI_GYRO_DIFF");
+      DEBUG_MODE.splice(DEBUG_MODE.indexOf("DUAL_GYRO_SCALED"), 1, "MULTI_GYRO_SCALED");
+    }
 
     ACC_HARDWARE = makeReadOnly(ACC_HARDWARE);
     DEBUG_MODE = makeReadOnly(DEBUG_MODE);

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1397,6 +1397,39 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         'debug[4]': 'Processed flow rates Y',
         'debug[5]': 'Delta time',
       };
+      DEBUG_FRIENDLY_FIELD_NAMES.MULTI_GYRO_RAW = {
+        'debug[all]': 'Debug Multi Gyro Raw',
+        'debug[0]': 'Gyro 1 Raw [roll]',
+        'debug[1]': 'Gyro 1 Raw [pitch]',
+        'debug[2]': 'Gyro 2 Raw [roll]',
+        'debug[3]': 'Gyro 2 Raw [pitch]',
+        'debug[4]': 'Gyro 3 Raw [roll]',
+        'debug[5]': 'Gyro 3 Raw [pitch]',
+        'debug[6]': 'Gyro 4 Raw [roll]',
+        'debug[7]': 'Gyro 4 Raw [pitch]',
+      };
+      DEBUG_FRIENDLY_FIELD_NAMES.MULTI_GYRO_DIFF = {
+        'debug[all]': 'Debug Multi Gyro Diff',
+        'debug[0]': 'Gyro 1 Diff [roll]',
+        'debug[1]': 'Gyro 1 Diff [pitch]',
+        'debug[2]': 'Gyro 2 Diff [roll]',
+        'debug[3]': 'Gyro 2 Diff [pitch]',
+        'debug[4]': 'Gyro 3 Diff [roll]',
+        'debug[5]': 'Gyro 3 Diff [pitch]',
+        'debug[6]': 'Gyro 4 Diff [roll]',
+        'debug[7]': 'Gyro 4 Diff [pitch]',
+      };
+      DEBUG_FRIENDLY_FIELD_NAMES.MULTI_GYRO_SCALED = {
+        'debug[all]': 'Multi Gyro Scaled',
+        'debug[0]': 'Gyro 1 [roll]',
+        'debug[1]': 'Gyro 1 [pitch]',
+        'debug[2]': 'Gyro 2 [roll]',
+        'debug[3]': 'Gyro 2 [pitch]',
+        'debug[4]': 'Gyro 3 [roll]',
+        'debug[5]': 'Gyro 3 [pitch]',
+        'debug[6]': 'Gyro 4 [roll]',
+        'debug[7]': 'Gyro 4 [pitch]',
+      };
       DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_POSITION = {
         'debug[all]': 'Autopilot Position',
         'debug[0]': 'Distance',
@@ -1840,6 +1873,9 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
       case "DUAL_GYRO_COMBINED":
       case "DUAL_GYRO_DIFF":
       case "DUAL_GYRO_RAW":
+      case "MULTI_GYRO_DIFF":
+      case "MULTI_GYRO_RAW":
+      case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
         return `${Math.round(flightLog.gyroRawToDegreesPerSecond(value))} °/s`;
@@ -2538,6 +2574,9 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
       case "DUAL_GYRO_COMBINED":
       case "DUAL_GYRO_DIFF":
       case "DUAL_GYRO_RAW":
+      case "MULTI_GYRO_DIFF":
+      case "MULTI_GYRO_RAW":
+      case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
         return toFriendly

--- a/src/flightlog_parser.js
+++ b/src/flightlog_parser.js
@@ -446,6 +446,12 @@ export function FlightLogParser(logData) {
       chirp_frequency_start_deci_hz : "chirp_frequency_start_deci_hz",
       chirp_frequency_end_deci_hz : "chirp_frequency_end_deci_hz",
       chirp_time_seconds : "chirp_time_seconds",
+      // MULTI_GYRO to DUAL_GYRO debug mode aliases
+      multi_gyro: "dual_gyro",
+      multi_gyro_raw: "dual_gyro_raw", 
+      multi_gyro_combined: "dual_gyro_combined",
+      multi_gyro_diff: "dual_gyro_diff",
+      multi_gyro_scaled: "dual_gyro_scaled",
     },
     frameTypes,
     // Blackbox state:


### PR DESCRIPTION
AI generated to support [#14533](https://github.com/betaflight/betaflight/pull/14533) with backward compatibility.
- tested only briefly.

Summary of Changes Committed:
Added version-gated DUAL_GYRO to MULTI_GYRO renaming for firmware 4.6.0+ in flightlog_fielddefs.js
Added MULTI_GYRO debug field display names in flightlog_fields_presenter.js supporting up to 4 gyros
Added MULTI_GYRO debug mode aliases in flightlog_parser.js for backward compatibility
Updated case statements to handle the new MULTI_GYRO debug modes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multi-gyro debug modes, including new field names and friendly display for multi-gyro data.
  * Enhanced value conversion and display for multi-gyro debug fields, showing data in degrees per second.

* **Bug Fixes**
  * Improved compatibility by mapping new multi-gyro debug field names to legacy dual-gyro equivalents for seamless parsing and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->