### PR TITLE
Show spin buttons into number input fields of users settings dialog

### DIFF
--- a/src/css/user_settings_dialog.css
+++ b/src/css/user_settings_dialog.css
@@ -122,7 +122,6 @@
 .user-settings-dialog input[type="number"]::-webkit-outer-spin-button
 {
   -webkit-appearance: auto !important;
-  -moz-appearance: auto !important;
   appearance: auto !important;
   opacity: 1 !important;
   height: auto !important;


### PR DESCRIPTION
Show spin button into number input fields of users settings dialog
![config_spin_button](https://github.com/user-attachments/assets/13859d0e-59b9-4f95-96bc-6e7a28983fdd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Improved visibility and appearance of spin buttons for number input fields in the user settings dialog, ensuring they display consistently across browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->