### PR TITLE
don't show old installable version on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,13 @@
                                 </div>
                             </p>
                             <p class="viewer-download">
-                                The latest official version is:<br>
+                                The latest official release is
+                                <a class="btn btn-default btn-md btn-viewer-download" data-toggle="tooltip" title="Goto the latest version download page"
+                                    href="https://github.com/betaflight/blackbox-log-viewer/releases/latest" target="_blank" rel="noopener noreferrer">
+                                    vX.X.XX </a><br>
+                            </p>
+                            <p class="viewer-download">
+                                The latest version is:<br>
                                 <a href="https://blackbox.betaflight.com"
                                 target="_blank"
                                 rel="noopener noreferrer">blackbox.betaflight.com</a>

--- a/index.html
+++ b/index.html
@@ -133,11 +133,15 @@
                             </p>
                             <p class="viewer-download">
                                 The latest official version is:<br>
-                                &nbsp; &nbsp; <a href="https://blackbox.betaflight.com">blackbox.betaflight.com</a><br>
+                                <a href="https://blackbox.betaflight.com"
+                                target="_blank"
+                                rel="noopener noreferrer">blackbox.betaflight.com</a>
                             </p>
                             <p class="viewer-download">
                                 The latest development version is:<br>
-                                &nbsp; &nbsp; <a href="https://master.blackbox.betaflight.com/">master.blackbox.betaflight.com</a>
+                                <a href="https://master.blackbox.betaflight.com/"
+                                target="_blank"
+                                rel="noopener noreferrer">master.blackbox.betaflight.com</a>
                             </p>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -132,10 +132,12 @@
                                 </div>
                             </p>
                             <p class="viewer-download">
-                                The latest official version is
-                                <a class="btn btn-default btn-md btn-viewer-download" data-toggle="tooltip" title="Goto the latest version download page"
-                                    href="https://github.com/betaflight/blackbox-log-viewer/releases/latest" target="_blank" rel="noopener noreferrer">
-                                    vX.X.XX </a>
+                                The latest official version is:<br>
+                                &nbsp; &nbsp; <a href="https://blackbox.betaflight.com">blackbox.betaflight.com</a><br>
+                            </p>
+                            <p class="viewer-download">
+                                The latest development version is:<br>
+                                &nbsp; &nbsp; <a href="https://master.blackbox.betaflight.com/">master.blackbox.betaflight.com</a>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
<img width="385" height="289" alt="image" src="https://github.com/user-attachments/assets/95ef8230-08f9-4dac-b2f2-3eb79c19f88e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the "Version" panel on the welcome page to display separate links for the latest official and development versions, each with improved formatting.
* **Style**
  * Improved layout with line breaks and indentation; removed button styling and tooltips from version links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->