### PR TITLE
RC filter update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1947,7 +1947,7 @@
                                                         <label>Setpoint Hz</label>
                                                         <input type="text" step="1" min="0" max="255" />
                                                     </td>
-                                                    <td name="rcSmoothingFeedforwardHz">
+                                                    <td name="rcSmoothingFeedforwardHz" id="rcSmoothingFeedforwardHz">
                                                         <label>Feedforward Hz</label>
                                                         <input type="text" step="1" min="0" max="255" />
                                                     </td>
@@ -1968,7 +1968,7 @@
                                                         <label>Setpoint</label>
                                                         <input type="text" step="1" min="0"/>
                                                     </td>
-                                                    <td name='rcSmoothingActiveCutoffsFf'>
+                                                    <td name='rcSmoothingActiveCutoffsFf' id="rcSmoothingActiveCutoffsFf">
                                                         <label>Feedforward</label>
                                                         <input type="text" step="1" min="0"/>
                                                     </td>

--- a/src/header_dialog.js
+++ b/src/header_dialog.js
@@ -623,7 +623,7 @@ export function HeaderDialog(dialog, onSave) {
       name: "rc_smoothing_active_cutoffs_ff",
       type: FIRMWARE_TYPE_BETAFLIGHT,
       min: "4.3.0",
-      max: "999.9.9",
+      max: "4.5.999",
     },
     {
       name: "rc_smoothing_active_cutoffs_sp",
@@ -1572,6 +1572,21 @@ export function HeaderDialog(dialog, onSave) {
 
     $(".dshot_bidir_required").toggle(sysConfig.dshot_bidir == 1);
 
+    // RC Smoothing
+    if (activeSysConfig.firmwareType === FIRMWARE_TYPE_BETAFLIGHT) {
+      if (semver.gte(activeSysConfig.firmwareVersion, "4.6.0")) {
+        $("#rcSmoothingFeedforwardHz").hide();
+        $("#rcSmoothingActiveCutoffsFf").hide();
+        setParameter("rcSmoothingActiveCutoffsSp", sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[0], 0);
+        setParameter("rcSmoothingActiveCutoffsThr", sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[1], 0);
+      } else if (semver.gte(activeSysConfig.firmwareVersion, "4.3.0")) {
+        setParameter("rcSmoothingFeedforwardHz", sysConfig.rc_smoothing_feedforward_hz, 0);
+        setParameter("rcSmoothingActiveCutoffsFf", sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[0], 0);
+        setParameter("rcSmoothingActiveCutoffsSp", sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[1], 0);
+        setParameter("rcSmoothingActiveCutoffsThr", sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[2], 0);
+      }
+    }
+
     if (semver.gte(activeSysConfig.firmwareVersion, "4.5.0")) {
       setParameter("rcSmoothingRxSmoothed", sysConfig.rc_smoothing_rx_smoothed, 0);
       $("#rcSmoothingRxSmoothed").show();
@@ -1598,11 +1613,6 @@ export function HeaderDialog(dialog, onSave) {
         RC_SMOOTHING_MODE
       );
       setParameter(
-        "rcSmoothingFeedforwardHz",
-        sysConfig.rc_smoothing_feedforward_hz,
-        0
-      );
-      setParameter(
         "rcSmoothingSetpointHz",
         sysConfig.rc_smoothing_setpoint_hz,
         0
@@ -1620,21 +1630,6 @@ export function HeaderDialog(dialog, onSave) {
       setParameter(
         "rcSmoothingAutoFactorThrottle",
         sysConfig.rc_smoothing_auto_factor_throttle,
-        0
-      );
-      setParameter(
-        "rcSmoothingActiveCutoffsFf",
-        sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[0],
-        0
-      );
-      setParameter(
-        "rcSmoothingActiveCutoffsSp",
-        sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[1],
-        0
-      );
-      setParameter(
-        "rcSmoothingActiveCutoffsThr",
-        sysConfig.rc_smoothing_active_cutoffs_ff_sp_thr[2],
         0
       );
     } else if (


### PR DESCRIPTION
- follow up for https://github.com/betaflight/betaflight/pull/14411

Before:

<img width="612" height="291" alt="image" src="https://github.com/user-attachments/assets/5922b5a7-79ba-4952-8b23-c7971bad5b76" />

After:

<img width="612" height="285" alt="image" src="https://github.com/user-attachments/assets/b8a140eb-4df4-4dc6-83a6-7e85a880990a" />

Log from 4.5:

<img width="612" height="291" alt="image" src="https://github.com/user-attachments/assets/3abd2e82-eda3-4c0f-88d2-9b0026bd5dd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hide the “RC Smoothing Feedforward (Hz)” control on BetaFlight 4.6.0 and newer; keep it visible and populated on earlier versions.
  * Limit the “RC Smoothing Active Cutoffs (FF)” control to firmware up through 4.5.x and ensure correct value initialization for BetaFlight 4.3.0–4.5.x.

* **Chores**
  * Added a DOM id to a configuration table cell to improve element targeting (non-functional UI attribute).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->