### PR TITLE
Resolved vertical sliders issue on Mozila firefox browser

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -678,11 +678,13 @@ html.has-analyser-fullscreen.has-analyser
 }
 
 .analyser input#analyserZoomY {
-  width: 10px;
-  height: 100px;
-  -webkit-appearance: slider-vertical;
+  width: 100px;
+  height: 10px;
   left: 1085px;
-  top: 30px;
+  top: 130px;
+  float: right;
+  transform: rotate(-90grad);
+  transform-origin: left top;
 }
 
 .analyser input#analyserMinPSD::-webkit-inner-spin-button,


### PR DESCRIPTION
Resolved vertical sliders issue on Mozila firefox browser.
The vertical sliders implementation is changed in main.css file.
It is checked on browsers:
- Microsoft Edge
- Mozila girefox
- Google Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Converted the analyser Y zoom control from a vertical slider to a horizontal orientation for improved usability and consistency.
  - Repositioned the control within the interface for clearer visibility and easier access.
  - Adjusted alignment and orientation to enhance interaction on various screen sizes and layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->