### PR TITLE
Add missing GPS Rescue Throttle PID debug fields

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1252,7 +1252,7 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "Not Used",
       };
       DEBUG_FRIENDLY_FIELD_NAMES.GPS_RESCUE_THROTTLE_PID = {
-        "debug[all]": "GPS Rescue Altitude",
+        "debug[all]": "GPS Rescue Throttle PID",
         "debug[0]": "Throttle P",
         "debug[1]": "Throttle D",
         "debug[2]": "Altitude",
@@ -1287,17 +1287,6 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[6]": "Not Used",
         "debug[7]": "Not Used",
       };
-      DEBUG_FRIENDLY_FIELD_NAMES.GPS_RESCUE_THROTTLE_PID = {
-        "debug[all]": "GPS Rescue throttle PIDs",
-        "debug[0]": "Throttle P",
-        "debug[1]": "Throttle D",
-        "debug[2]": "Altitude",
-        "debug[3]": "Target altitude",
-        "debug[4]": "Not Used",
-        "debug[5]": "Not Used",
-        "debug[6]": "Not Used",
-        "debug[7]": "Not Used",
-      };
     }
 
     if (semver.gte(firmwareVersion, '4.5.0')) {
@@ -1313,7 +1302,7 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "dcmKp gain",
       };
       DEBUG_FRIENDLY_FIELD_NAMES.GPS_RESCUE_THROTTLE_PID = {
-        "debug[all]": "GPS Rescue throttle PIDs",
+        "debug[all]": "GPS Rescue throttle PID",
         "debug[0]": "Throttle P",
         "debug[1]": "Throttle D",
         "debug[2]": "Altitude",
@@ -2163,7 +2152,9 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
       case "GPS_RESCUE_THROTTLE_PID":
         switch (fieldName) {
           case "debug[0]": // Throttle P added uS
-          case "debug[1]": // Throttle D added * uS
+          case "debug[1]": // Throttle D added uS
+          case "debug[4]": // Throttle I added uS
+          case "debug[6]": // Throttle D before lp smoothing uS
             return `${value.toFixed(0)} uS`;
           case "debug[2]": // current altitude in m
           case "debug[3]": // TARGET altitude in m
@@ -2912,6 +2903,8 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
         switch (fieldName) {
           case "debug[0]": // Throttle P added uS
           case "debug[1]": // Throttle D added * uS
+          case "debug[4]": // Throttle I added uS
+          case "debug[6]": // Throttle D before lp smoothing uS
             return value; // ' uS';
           case "debug[2]": // current altitude in m
           case "debug[3]": // TARGET altitude in m


### PR DESCRIPTION
- fixes #680 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved, human-friendly labels and expanded field set for GPS Rescue throttle PID debug metrics on newer firmwares (≈4.5.0+). Added readable names for Throttle P/I/D, Altitude, Target altitude, Tilt adjustment, pre-smoothing Throttle D, and Throttle adjustment. Logs and charts now recognize and convert the additional fields for consistent display and unit handling. No user action required; changes apply automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->