### PR TITLE
Added TELEMETRY_MAVLINK debug fields settings

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -559,9 +559,7 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       DEBUG_MODE.push('GIMBAL');
       DEBUG_MODE.push('WING_SETPOINT');
       DEBUG_MODE.push('AUTOPILOT_POSITION');
-      DEBUG_MODE.push('CHIRP');
-      DEBUG_MODE.push('FLASH_TEST_PRBS');
-      DEBUG_MODE.push('MAVLINK_TELEMETRY');
+      DEBUG_MODE.push('CHIRP', 'FLASH_TEST_PRBS', 'MAVLINK_TELEMETRY');
     }
     if (semver.gte(firmwareVersion, "2025.12.0")) {
       //rename DUAL_GYRO_ to MULTI_GYRO

--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -552,14 +552,18 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_RESCUE_THROTTLE_PID'), 1, 'AUTOPILOT_ALTITUDE');
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("GYRO_SCALED"), 1);
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("RANGEFINDER_QUALITY") + 1, 0, "OPTICALFLOW");
-      DEBUG_MODE.push('TPA');
-      DEBUG_MODE.push('S_TERM');
-      DEBUG_MODE.push('SPA');
-      DEBUG_MODE.push('TASK');
-      DEBUG_MODE.push('GIMBAL');
-      DEBUG_MODE.push('WING_SETPOINT');
-      DEBUG_MODE.push('AUTOPILOT_POSITION');
-      DEBUG_MODE.push('CHIRP', 'FLASH_TEST_PRBS', 'MAVLINK_TELEMETRY');
+      DEBUG_MODE.push(
+				'TPA',
+				'S_TERM',
+				'SPA',
+				'TASK',
+				'GIMBAL',
+				'WING_SETPOINT',
+				'AUTOPILOT_POSITION',
+				'CHIRP',
+				'FLASH_TEST_PRBS',
+				'MAVLINK_TELEMETRY',
+			);
     }
     if (semver.gte(firmwareVersion, "2025.12.0")) {
       //rename DUAL_GYRO_ to MULTI_GYRO
@@ -624,7 +628,7 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
         );
       }
     }
-    
+
     FLIGHT_LOG_FLIGHT_MODE_NAME = makeReadOnly(FLIGHT_LOG_FLIGHT_MODE_NAME);
   } else {
     DEBUG_MODE = DEBUG_MODE_COMPLETE;

--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -559,6 +559,9 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       DEBUG_MODE.push('GIMBAL');
       DEBUG_MODE.push('WING_SETPOINT');
       DEBUG_MODE.push('AUTOPILOT_POSITION');
+      DEBUG_MODE.push('CHIRP');
+      DEBUG_MODE.push('FLASH_TEST_PRBS');
+      DEBUG_MODE.push('MAVLINK_TELEMETRY');
     }
     if (semver.gte(firmwareVersion, "2025.12.0")) {
       //rename DUAL_GYRO_ to MULTI_GYRO

--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -553,17 +553,17 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("GYRO_SCALED"), 1);
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("RANGEFINDER_QUALITY") + 1, 0, "OPTICALFLOW");
       DEBUG_MODE.push(
-				'TPA',
-				'S_TERM',
-				'SPA',
-				'TASK',
-				'GIMBAL',
-				'WING_SETPOINT',
-				'AUTOPILOT_POSITION',
-				'CHIRP',
-				'FLASH_TEST_PRBS',
-				'MAVLINK_TELEMETRY',
-			);
+        'TPA',
+        'S_TERM',
+        'SPA',
+        'TASK',
+        'GIMBAL',
+        'WING_SETPOINT',
+        'AUTOPILOT_POSITION',
+        'CHIRP',
+        'FLASH_TEST_PRBS',
+        'MAVLINK_TELEMETRY',
+      );
     }
     if (semver.gte(firmwareVersion, "2025.12.0")) {
       //rename DUAL_GYRO_ to MULTI_GYRO

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1134,6 +1134,13 @@ const DEBUG_FRIENDLY_FIELD_NAMES_INITIAL = {
     "debug[4]": "Stick Limit",
     "debug[5]": "Speed Limit",
   },
+  MAVLINK_TELEMETRY: {
+    "debug[all]": "MAVLink telemetry",
+    "debug[0]": "Should send telemetry",
+    "debug[1]": "Actual free TX buffers space",
+    "debug[2]": "Estimated free TX buffers space",
+    "debug[3]": "Telemetries call counter",
+  },
 };
 
 let DEBUG_FRIENDLY_FIELD_NAMES = null;

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -596,7 +596,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   min: 0,
                   max: 1,
                 },
-              };            
+              };
             case "debug[6]": // outlier count 0-3
             case "debug[7]": // valid count 0-3
               return {
@@ -605,7 +605,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   min: 0,
                   max: 50, // put them at the very bottom
                 },
-              };            
+              };
             default:
               return getCurveForMinMaxFields(fieldName);
           }
@@ -859,7 +859,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   min: 0,
                   max: 1,
                 },
-              };            
+              };
             case "debug[7]": // smoothed Rx Rate Hz
               return {
                 power: 1.0,
@@ -867,7 +867,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   min: 0,
                   max: 1200,
                 },
-              };            
+              };
             default:
               return getCurveForMinMaxFields(fieldName);
           }
@@ -1449,6 +1449,36 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                 MinMax: {
                   min: -180,
                   max: 180,
+                },
+              };
+            default:
+              return getCurveForMinMaxFields(fieldName);
+          }
+        case "MAVLINK_TELEMETRY":
+          switch (fieldName) {
+            case "debug[0]":
+              return {
+                power: 1.0,
+                MinMax: {
+                  min: 0,
+                  max: 1,
+                },
+              };
+            case "debug[1]":
+            case "debug[2]":
+              return {
+                power: 1.0,
+                MinMax: {
+                  min: 0,
+                  max: 100,
+                },
+              };
+            case "debug[3]":
+              return {
+                power: 1.0,
+                MinMax: {
+                  min: 0,
+                  max: 50,
                 },
               };
             default:

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1458,7 +1458,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           switch (fieldName) {
             case "debug[0]":
               return {
-                power: 1.0,
+                power: 1,
                 MinMax: {
                   min: 0,
                   max: 1,
@@ -1467,7 +1467,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
             case "debug[1]":
             case "debug[2]":
               return {
-                power: 1.0,
+                power: 1,
                 MinMax: {
                   min: 0,
                   max: 100,
@@ -1475,7 +1475,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
               };
             case "debug[3]":
               return {
-                power: 1.0,
+                power: 1,
                 MinMax: {
                   min: 0,
                   max: 50,


### PR DESCRIPTION
Added TELEMETRY_MAVLINK debug fields settings for ["Added flow control for MAVLink telemetry"](https://github.com/betaflight/betaflight/pull/14651) PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MAVLink Telemetry debug mode with user-friendly labels for debug[all] and debug[0–3], so telemetry-related values display clearly.
  * Expanded debug mode options (including CHIRP and FLASH_TEST_PRBS) for firmware 2025.12.0+, and added sensible default graph ranges for MAVLink telemetry fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->