### PR TITLE
Fix typo in seekbar tooltip: 'Vaue' -> 'Value'

### DIFF
--- a/index.html
+++ b/index.html
@@ -622,7 +622,7 @@
     <div id="log-seek-bar" class="log-seek-bar">
         <canvas width="200" height="100"></canvas>
         <span id="seekbarToolbar" class="non-shift">
-            <div id="seekbarType" class="seekBar-selection" data-toggle="tooltip" title="Vaue to plot">
+            <div id="seekbarType" class="seekBar-selection" data-toggle="tooltip" title="Value to plot">
             </div>
         </span>
     </div>


### PR DESCRIPTION
## Description
Fixed a typo in the seekbar tooltip where "Value to plot" was misspelled as "Vaue to plot".

## Changes
- Corrected tooltip text in index.html line 625
- Changed `title="Vaue to plot"` to `title="Value to plot"`

## Testing
- No other files or functionality affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the seek bar tooltip title, changing “Vaue to plot” to “Value to plot” for clearer guidance.
  * No changes to behavior or interactions.

* **Style**
  * Polished UI copy to improve readability and professionalism in the tooltip text.
  * Ensures consistent wording across the interface without altering layout or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->