### PR TITLE
QMC5883P uses QMC5883 unified driver (for L and P variants)

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -547,8 +547,6 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       ACC_HARDWARE.splice(ACC_HARDWARE.indexOf("LSM303DLHC"), 1);
       ACC_HARDWARE.splice(ACC_HARDWARE.indexOf("LSM6DSV16X") + 1, 0, "IIM42653");
 
-      MAG_HARDWARE.push("QMC5883P");
-
       DEBUG_MODE.splice(DEBUG_MODE.indexOf('GPS_RESCUE_THROTTLE_PID'), 1, 'AUTOPILOT_ALTITUDE');
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("GYRO_SCALED"), 1);
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("RANGEFINDER_QUALITY") + 1, 0, "OPTICALFLOW");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed magnetometer hardware detection when upgrading to firmware version 3.3.0 or newer, ensuring correct sensor configuration and preventing erroneous entries in the hardware identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->