### PR TITLE
Add system load field to GYRO_SAMPLE debug

### DIFF
--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1949,12 +1949,10 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
       case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
-        switch (fieldName) {
-          case "debug[4]": // Avg System Load %
-            return `${value.toFixed(0)} %`;
-          default:
-            return `${Math.round(flightLog.gyroRawToDegreesPerSecond(value))} °/s`;
+        if (fieldName === "debug[4]") {
+          return `${value.toFixed(0)} %`; // Avg System Load %
         }
+        return `${Math.round(flightLog.gyroRawToDegreesPerSecond(value))} °/s`;
       case "ANGLERATE":
         return `${value.toFixed(0)} °/s`;
       case "ESC_SENSOR":
@@ -2710,14 +2708,12 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
       case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
-        switch (fieldName) {
-          case "debug[4]": // Avg System Load %
-            return value;
-          default:
-            return toFriendly
-              ? flightLog.gyroRawToDegreesPerSecond(value)
-              : value / flightLog.gyroRawToDegreesPerSecond(1.0); // °/s;
+        if (fieldName === "debug[4]") {
+          return value; // Avg System Load %
         }
+        return toFriendly
+          ? flightLog.gyroRawToDegreesPerSecond(value)
+          : value / flightLog.gyroRawToDegreesPerSecond(1.0); // °/s;
       case "ANGLERATE":
         return value; // °/s;
       case "ESC_SENSOR":

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1503,6 +1503,10 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "Valid Count",
       };
     }
+    if (semver.gte(firmwareVersion, "2026.6.0")) {
+      DEBUG_FRIENDLY_FIELD_NAMES.GYRO_SAMPLE["debug[4]"] =
+        "Avg System Load %";
+    }
   }
 };
 
@@ -1945,7 +1949,12 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
       case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
-        return `${Math.round(flightLog.gyroRawToDegreesPerSecond(value))} °/s`;
+        switch (fieldName) {
+          case "debug[4]": // Avg System Load %
+            return `${value.toFixed(0)} %`;
+          default:
+            return `${Math.round(flightLog.gyroRawToDegreesPerSecond(value))} °/s`;
+        }
       case "ANGLERATE":
         return `${value.toFixed(0)} °/s`;
       case "ESC_SENSOR":
@@ -2701,9 +2710,14 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
       case "MULTI_GYRO_SCALED":
       case "NOTCH":
       case "GYRO_SAMPLE":
-        return toFriendly
-          ? flightLog.gyroRawToDegreesPerSecond(value)
-          : value / flightLog.gyroRawToDegreesPerSecond(1.0); // °/s;
+        switch (fieldName) {
+          case "debug[4]": // Avg System Load %
+            return value;
+          default:
+            return toFriendly
+              ? flightLog.gyroRawToDegreesPerSecond(value)
+              : value / flightLog.gyroRawToDegreesPerSecond(1.0); // °/s;
+        }
       case "ANGLERATE":
         return value; // °/s;
       case "ESC_SENSOR":

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1504,8 +1504,10 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
       };
     }
     if (semver.gte(firmwareVersion, "2026.6.0")) {
-      DEBUG_FRIENDLY_FIELD_NAMES.GYRO_SAMPLE["debug[4]"] =
-        "Avg System Load %";
+      DEBUG_FRIENDLY_FIELD_NAMES.GYRO_SAMPLE = {
+        ...DEBUG_FRIENDLY_FIELD_NAMES.GYRO_SAMPLE,
+        "debug[4]": "Avg System Load %",
+      };
     }
   }
 };

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -969,6 +969,14 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   max: maxDegreesSecond(gyroScaleMargin * highResolutionScale),
                 },
               };
+            case "debug[4]": // Avg System Load %
+              return {
+                power: 1,
+                MinMax: {
+                  min: 0,
+                  max: 100,
+                },
+              };
             default:
               return getCurveForMinMaxFields(fieldName);
           }


### PR DESCRIPTION
- supplements https://github.com/betaflight/betaflight/pull/15096

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system load debug field to display as an integer percentage (0–100%) on newer firmware releases instead of incorrect gyro units.
  * Updated graph configuration and scaling so system load is visualized with an appropriate 0–100 range and linear curve for accurate display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->