### PR TITLE
refactor: remove absolute control for API 1.48

### DIFF
--- a/src/components/HeaderDialog.vue
+++ b/src/components/HeaderDialog.vue
@@ -482,7 +482,8 @@ const pidControllerParams = computed(() => {
     param("I-Term Relax", selectVal(s.iterm_relax, ITERM_RELAX)),
     param("I-Term Relax Type", selectVal(s.iterm_relax_type, ITERM_RELAX_TYPE)),
     param("I-Term Relax Cutoff", fmtVal(s.iterm_relax_cutoff, 0)),
-    param("Abs Control Gain", fmtVal(s.abs_control_gain, 0)),
+    // abs_control_gain removed in BF 2026.6
+    ...(isBF.value && lt("2026.6.0") ? [param("Abs Control Gain", fmtVal(s.abs_control_gain, 0))] : []),
     param("PID At Min Throttle", selectVal(s.pidAtMinThrottle, OFF_ON)),
     param("Use Integrated Yaw", selectVal(s.use_integrated_yaw, OFF_ON)),
   ].filter((p) => !p.missing);

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -2043,7 +2043,7 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
             return `${value.toFixed(0)} °/s`;
           case "debug[1]": // roll I-term relax factor
             return `${value.toFixed(0)} %`;
-          case "debug[3]": // roll absolute control axis error
+          case "debug[3]": // roll absolute control axis error (pre-2026.6; unused/zero in firmware >= 2026.6)
             return `${(value / 10).toFixed(1)} °`;
           default:
             return value.toFixed(0);
@@ -2809,7 +2809,7 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
             return value; // °/s
           case "debug[1]": // roll I-term relax factor
             return value; // %
-          case "debug[3]": // roll absolute control axis error
+          case "debug[3]": // roll absolute control axis error (pre-2026.6; unused/zero in firmware >= 2026.6)
             return toFriendly ? value / 10 : value * 10; // °
           default:
             return value;

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -683,7 +683,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
         case "ITERM_RELAX":
           switch (fieldName) {
             case "debug[2]": // roll I relaxed error
-            case "debug[3]": // roll absolute control axis error
+            case "debug[3]": // roll absolute control axis error (pre-2026.6; unused/zero in firmware >= 2026.6)
               return getCurveForMinMaxFieldsZeroOffset(fieldName);
             default:
               return getCurveForMinMaxFields(fieldName);


### PR DESCRIPTION
## Summary
- Hide `Abs Control Gain` from the header dialog for Betaflight firmware >= 2026.6.0, where absolute control was removed (betaflight/betaflight#15023). Old logs continue to display the value.
- Update `ITERM_RELAX debug[3]` comments in `flightlog_fields_presenter.js` and `graph_config.js` to note the field is unused/zeroed in firmware >= 2026.6; the ÷10 scaling is preserved for backward compatibility with pre-2026.6 logs.

## Test plan
- [ ] Load a pre-2026.6 BF log with `abs_control_gain` in the header → "Abs Control Gain" appears in the header dialog under PID Controller
- [ ] Load a 2026.6+ BF log → "Abs Control Gain" does not appear
- [ ] Load a pre-2026.6 log with ITERM_RELAX debug mode → `debug[3]` displays with ÷10 degree conversion

## Related
- Firmware: betaflight/betaflight#15023
- Configurator: betaflight/betaflight-configurator#5108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added compatibility support for BetaFlight firmware version 2026.6.0 with conditional parameter handling.
  * Updated debug field documentation to reflect firmware-specific behavior changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/blackbox-log-viewer/pull/916)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->