### PR TITLE
fix: restore immediate chart refresh on graph config changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -330,7 +330,7 @@ function onGraphConfigSave(newConfig) {
 }
 
 function onGraphConfigUpdate(newConfig) {
-  appStore.newGraphConfig?.(newConfig, false);
+  appStore.newGraphConfig?.(newConfig, true);
 }
 
 function onSaveVideoConfig(cfg) {

--- a/src/main.js
+++ b/src/main.js
@@ -638,6 +638,7 @@ function BlackboxLogViewer() {
   }
 
   appStore.loadFiles = loadFiles;
+  // Note: internal newGraphConfig takes `noRedraw` (inverted). Callers pass `redrawChart` (true = redraw).
   appStore.newGraphConfig = (newConfig, redrawChart) => newGraphConfig(newConfig, !redrawChart);
   appStore.exportCsv = () => {
     setGraphState(GRAPH_STATE_PAUSED);


### PR DESCRIPTION
## Summary

- After the Vue 3 migration (#913), live edits in the graph config dialog (min/max scaling, smoothing, expo, line width, color) no longer refreshed the chart immediately — only clicking "Apply changes" worked
- Root cause: `onGraphConfigUpdate` in `App.vue` passed `false` as `redrawChart`, which through a parameter inversion in the `appStore.newGraphConfig` bridge became `noRedraw=true`, suppressing the `GraphConfig` listener notification and preventing `invalidateGraph()` from firing
- Fix: change `false` → `true` in `onGraphConfigUpdate` so live edits trigger an immediate chart redraw; add a clarifying comment at the inversion point in `main.js`

## Test plan

- [ ] Open a log file, open "Configure graphs", change a min/max value — chart should rescale immediately without clicking Apply
- [ ] Change smoothing, expo, or line width — chart should update immediately  
- [ ] Click "Apply changes" — still works as before
- [ ] Click "Cancel" after making edits — chart reverts to pre-edit state visually
- [ ] Workspace switching and keyboard zoom shortcuts still trigger chart redraws correctly

## Changes

- `src/App.vue:333` — `onGraphConfigUpdate`: `false` → `true` (the fix)
- `src/main.js:641` — add comment explaining the `redrawChart` / `noRedraw` inversion at the store bridge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Graph configuration updates now redraw charts correctly when changes are applied.

* **Documentation**
  * Added clarification comments explaining the graph configuration update system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/blackbox-log-viewer/pull/917)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->