### PR TITLE
Curves MinMax control extended menu migration to Vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,7 +100,7 @@
         v-model:open="appStore.graphConfigDialogOpen"
         :flightLog="logStore.flightLog"
         :graphConfig="graphStore.activeGraphConfig"
-        :grapher="graphStore.graph",
+        :grapher="graphStore.graph"
         @save="onGraphConfigSave"
         @update="onGraphConfigUpdate"
       />

--- a/src/App.vue
+++ b/src/App.vue
@@ -100,6 +100,7 @@
         v-model:open="appStore.graphConfigDialogOpen"
         :flightLog="logStore.flightLog"
         :graphConfig="graphStore.activeGraphConfig"
+        :grapher="graphStore.graph",
         @save="onGraphConfigSave"
         @update="onGraphConfigUpdate"
       />

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -864,7 +864,7 @@ const simpleMenuItems = computed(() => [
 
 function getFieldsCheckboxedSubmenu() {
   const fields = currentState.value.graph?.fields;
-  if (fields) {
+  if (fields && currentState.value.isFieldChecked) {
     return currentState.value.graph.fields.map((field, index) => ({
       type: "checkbox",
       label: friendlyName(field.name),

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -848,7 +848,7 @@ const menuItems = ref([
 function onContextMenu(event, graph, field) {
   currentState.value.graph = graph;
   currentState.value.field = field;
-  menuItems.value[menuItems.value.length - 1][0].label = friendlyName(field?.name) + " \u25B8";
+  menuItems.value[menuItems.value.length - 1][0].label = friendlyName(field?.name);
 }
 
 </script>

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -1038,14 +1038,14 @@ const extendedMenuItems = computed(() => [
           {
             label: "ZOOM IN",
             onSelect(e) {
-              setMinMaxSelectedZoom(1 / zoom, true);
+              setMinMaxZoom(1 / zoom, true);
               e.preventDefault();
             },
           },
           {
             label: "ZOOM OUT",
             onSelect(e) {
-              setMinMaxSelectedZoom(zoom, true);
+              setMinMaxZoom(zoom, true);
               e.preventDefault();
             },
           },

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -612,6 +612,8 @@ watch(open, (val) => {
 const currentState = ref({
   graph: null,
   field: null,
+  isFieldChecked: null,
+  shiftKey: false,
 });
 
 function setMinMaxToDefault() {
@@ -747,7 +749,8 @@ function setMinMaxSelectedToFullRangeDuringAllTime() {
 }
 
 const zoom = 1.1;
-const menuItems = ref([
+
+const simpleMenuItems = computed(() => [
   [
     {
       label: 'Like this one',
@@ -800,7 +803,7 @@ const menuItems = ref([
   ],
   [
     {
-      label: 'current field menu',
+      label: friendlyName(currentState.value.field?.name ?? ""),
       children: [
         [
           {
@@ -845,10 +848,254 @@ const menuItems = ref([
   ],
 ]);
 
+function getFieldsCheckboxedSubmenu() {
+  return currentState.value.graph.fields.map((field, index) => ({
+    type: "checkbox",
+    label: friendlyName(field.name),
+    checked: currentState.value.isFieldChecked[index],
+    onUpdateChecked(state) {
+      currentState.value.isFieldChecked[index] = state;
+    },
+    onSelect(e) {
+      e.preventDefault();
+    },
+  }));
+}
+
+const extendedMenuItems = computed(() => [
+  [
+    {
+      label: 'Like this one',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SET MIN-MAX VALUES",
+          },
+          {
+            type: "label",
+            label: "TO SELECTED CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            label: "SET",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: 'Set full range',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SELECT CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            type: "label",
+            label: "SET FULL RANGE:",
+          },
+        ],
+        [
+          {
+            label: "At the all time",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+          {
+            label: "At the window time",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+          {
+            label: "At the markers time",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: 'One scale',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SELECT CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            label: "SET CURVES TO SAME SCALE",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+    {
+      label: 'Centered',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SELECT CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            label: "SET CURVES TO ZERO OFFSET",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  [
+    {
+      label: 'Zoom',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SELECT CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            label: "ZOOM IN",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+          {
+            label: "ZOOM OUT",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  [
+    {
+      label: 'Default',
+      children: [
+        [
+          {
+            type: "label",
+            label: "SELECT CURVES",
+          },
+        ],
+        getFieldsCheckboxedSubmenu(),
+        [
+          {
+            label: "SET CURVES TO DEFAULT",
+            onSelect(e) {
+              e.preventDefault();
+            },
+          },
+        ],
+      ],
+    },
+  ],
+  [
+    {
+      label: friendlyName(currentState.value.field?.name ?? ""),
+      children: [
+        [
+          {
+            label: 'Full range',
+            children: [
+              [
+                {
+                  label: "At the all time",
+                  onSelect(e) {
+                    e.preventDefault();
+                  },
+                },
+                {
+                  label: "At the window time",
+                  onSelect(e) {
+                    e.preventDefault();
+                  },
+                },
+                {
+                  label: "At the markers time",
+                  onSelect(e) {
+                    e.preventDefault();
+                  },
+                },
+              ],
+            ],
+          },
+          {
+            label: 'Centered',
+            onSelect() {
+              setMinMaxSelectedCentered();
+            },
+          },
+        ],
+        [
+          {
+            label: 'Zoom In',
+            onSelect(e) {
+              e.preventDefault();
+              setMinMaxSelectedZoom(1 / zoom);
+            },
+          },
+          {
+            label: 'Zoom Out',
+            onSelect(e) {
+              e.preventDefault();
+              setMinMaxSelectedZoom(zoom);
+            },
+          },
+        ],
+        [
+          {
+            label: 'Default',
+            onSelect() {
+              setMinMaxSelectedDefault();
+            },
+          },
+        ],
+      ],
+    },
+  ],
+]);
+
+const menuItems = computed(() => {
+  if (currentState.value.shiftKey) {
+    return extendedMenuItems.value;
+  } else {
+    return simpleMenuItems.value;
+  }
+});
+
 function onContextMenu(event, graph, field) {
   currentState.value.graph = graph;
   currentState.value.field = field;
-  menuItems.value[menuItems.value.length - 1][0].label = friendlyName(field?.name);
+  currentState.value.shiftKey = event.shiftKey;
+  currentState.value.isFieldChecked = currentState.value.graph.fields.map(() => true);
 }
 
 </script>

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -849,17 +849,22 @@ const simpleMenuItems = computed(() => [
 ]);
 
 function getFieldsCheckboxedSubmenu() {
-  return currentState.value.graph.fields.map((field, index) => ({
-    type: "checkbox",
-    label: friendlyName(field.name),
-    checked: currentState.value.isFieldChecked[index],
-    onUpdateChecked(state) {
-      currentState.value.isFieldChecked[index] = state;
-    },
-    onSelect(e) {
-      e.preventDefault();
-    },
-  }));
+  const fields = currentState.value.graph?.fields;
+  if (fields) {
+    return currentState.value.graph.fields.map((field, index) => ({
+      type: "checkbox",
+      label: friendlyName(field.name),
+      checked: currentState.value.isFieldChecked[index],
+      onUpdateChecked(state) {
+        currentState.value.isFieldChecked[index] = state;
+      },
+      onSelect(e) {
+        e.preventDefault();
+      },
+    }));
+  } else {
+    return [];
+  }
 }
 
 const extendedMenuItems = computed(() => [

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -247,6 +247,7 @@ const open = defineModel("open", { type: Boolean, default: false });
 const props = defineProps({
   flightLog: { type: Object, default: null },
   graphConfig: { type: Object, default: null },
+  grapher: { type: Object, default: null },
 });
 
 const emit = defineEmits(["save", "update"]);
@@ -751,6 +752,36 @@ function setMinMaxToFullRangeDuringAllTime(setCheckedOnly) {
   }
 }
 
+function getMinMaxForFieldDuringWindowTimeInterval(setCheckedOnly) {
+  if (currentState.value.graph?.fields && props.flightLog && props.grapher) {
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = GraphConfig.getMinMaxForFieldDuringWindowTimeInterval(props.flightLog, props.grapher, field.name);
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          setMin(field, mm.min);
+          setMax(field, mm.max);
+        }
+      }
+    }
+    emitUpdate();
+  }
+}
+
+function getMinMaxForFieldDuringMarkedInterval(setCheckedOnly) {
+  if (currentState.value.graph?.fields && props.flightLog && props.grapher) {
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = GraphConfig.getMinMaxForFieldDuringMarkedInterval(props.flightLog, props.grapher, field.name);
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          setMin(field, mm.min);
+          setMax(field, mm.max);
+        }
+      }
+    }
+    emitUpdate();
+  }
+}
+
 function setMinMaxSelectedToFullRangeDuringAllTime() {
   if (currentState.value.field?.name && props.flightLog) {
     const mm = props.flightLog.getMinMaxForFieldDuringAllTime(currentState.value.field?.name);
@@ -934,15 +965,15 @@ const extendedMenuItems = computed(() => [
           },
           {
             label: "At the window time",
-            disabled: true,
             onSelect(e) {
+              getMinMaxForFieldDuringWindowTimeInterval(true);
               e.preventDefault();
             },
           },
           {
             label: "At the markers time",
-            disabled: true,
             onSelect(e) {
+              getMinMaxForFieldDuringMarkedInterval(true);
               e.preventDefault();
             },
           },

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -616,11 +616,13 @@ const currentState = ref({
   shiftKey: false,
 });
 
-function setMinMaxToDefault() {
+function setMinMaxToDefault(setCheckedOnly) {
   if (currentState.value.graph?.fields) {
-    for (const field of currentState.value.graph.fields) {
-      resetMin(field);
-      resetMax(field);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        resetMin(field);
+        resetMax(field);
+      }
     }
     emitUpdate();
   }
@@ -634,53 +636,61 @@ function setMinMaxSelectedDefault() {
   }
 }
 
-function setMinMaxLikeThis() {
+function setMinMaxLikeThis(setCheckedOnly) {
   const mm = currentState.value.field?.curve?.MinMax;
   if (currentState.value.graph?.fields && mm?.min !== undefined && mm?.max !== undefined) {
     const min = mm.min;
     const max = mm.max;
-    for (const field of currentState.value.graph.fields) {
-      setMin(field, min);
-      setMax(field, max);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        setMin(field, min);
+        setMax(field, max);
+      }
     }
     emitUpdate();
   }
 }
 
-function setMinMaxOneScale() {
+function setMinMaxOneScale(setCheckedOnly) {
   let max = -Number.MAX_VALUE;
   let min = Number.MAX_VALUE;
 
   if (currentState.value.graph?.fields) {
-    for (const field of currentState.value.graph.fields) {
-      const mm = field?.curve?.MinMax;
-      if (mm?.min !== undefined && mm?.max !== undefined) {
-        max = Math.max(max, mm.max);
-        min = Math.min(min, mm.min);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = field?.curve?.MinMax;
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          max = Math.max(max, mm.max);
+          min = Math.min(min, mm.min);
+        }
       }
     }
 
     if (min !== Number.MAX_VALUE) {
-      for (const field of currentState.value.graph.fields) {
-        setMin(field, min);
-        setMax(field, max);
+      for (const [index, field] of currentState.value.graph.fields.entries()) {
+        if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+          setMin(field, min);
+          setMax(field, max);
+        }
       }
       emitUpdate();
     }
   }
 }
 
-function setMinMaxCentered() {
+function setMinMaxCentered(setCheckedOnly) {
   if (currentState.value.graph?.fields) {
-    for (const field of currentState.value.graph.fields) {
-      const mm = field?.curve?.MinMax;
-      if (mm?.min !== undefined && mm?.max !== undefined) {
-        let min = mm.min;
-        let max = mm.max;
-        max = Math.max(Math.abs(min), Math.abs(max));
-        min = -max;
-        setMin(field, min);
-        setMax(field, max);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = field?.curve?.MinMax;
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          let min = mm.min;
+          let max = mm.max;
+          max = Math.max(Math.abs(min), Math.abs(max));
+          min = -max;
+          setMin(field, min);
+          setMax(field, max);
+        }
       }
     }
     emitUpdate();
@@ -698,15 +708,17 @@ function setMinMaxSelectedCentered() {
   }
 }
 
-function setMinMaxZoom(zoom) {
+function setMinMaxZoom(zoom, setCheckedOnly) {
   if (currentState.value.graph?.fields) {
-    for (const field of currentState.value.graph.fields) {
-      const mm = field?.curve?.MinMax;
-      if (mm?.min !== undefined && mm?.max !== undefined) {
-        const middle = (mm.min + mm.max) / 2;
-        const halfRange = (mm.max - mm.min) / 2;
-        setMin(field, middle - halfRange * zoom);
-        setMax(field, middle + halfRange * zoom);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = field?.curve?.MinMax;
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          const middle = (mm.min + mm.max) / 2;
+          const halfRange = (mm.max - mm.min) / 2;
+          setMin(field, middle - halfRange * zoom);
+          setMax(field, middle + halfRange * zoom);
+        }
       }
     }
     emitUpdate();
@@ -724,13 +736,15 @@ function setMinMaxSelectedZoom(zoom) {
   }
 }
 
-function setMinMaxToFullRangeDuringAllTime() {
+function setMinMaxToFullRangeDuringAllTime(setCheckedOnly) {
   if (currentState.value.graph?.fields && props.flightLog) {
-    for (const field of currentState.value.graph.fields) {
-      const mm = props.flightLog.getMinMaxForFieldDuringAllTime(field.name);
-      if (mm?.min !== undefined && mm?.max !== undefined) {
-        setMin(field, mm.min);
-        setMax(field, mm.max);
+    for (const [index, field] of currentState.value.graph.fields.entries()) {
+      if ((!setCheckedOnly || !currentState.value.isFieldChecked) || currentState.value.isFieldChecked[index]) {
+        const mm = props.flightLog.getMinMaxForFieldDuringAllTime(field.name);
+        if (mm?.min !== undefined && mm?.max !== undefined) {
+          setMin(field, mm.min);
+          setMax(field, mm.max);
+        }
       }
     }
     emitUpdate();
@@ -887,6 +901,7 @@ const extendedMenuItems = computed(() => [
           {
             label: "SET",
             onSelect(e) {
+              setMinMaxLikeThis(true);
               e.preventDefault();
             },
           },
@@ -913,17 +928,20 @@ const extendedMenuItems = computed(() => [
           {
             label: "At the all time",
             onSelect(e) {
+              setMinMaxToFullRangeDuringAllTime(true);
               e.preventDefault();
             },
           },
           {
             label: "At the window time",
+            disabled: true,
             onSelect(e) {
               e.preventDefault();
             },
           },
           {
             label: "At the markers time",
+            disabled: true,
             onSelect(e) {
               e.preventDefault();
             },
@@ -945,6 +963,7 @@ const extendedMenuItems = computed(() => [
           {
             label: "SET CURVES TO SAME SCALE",
             onSelect(e) {
+              setMinMaxOneScale(true);
               e.preventDefault();
             },
           },
@@ -965,6 +984,7 @@ const extendedMenuItems = computed(() => [
           {
             label: "SET CURVES TO ZERO OFFSET",
             onSelect(e) {
+              setMinMaxCentered(true);
               e.preventDefault();
             },
           },
@@ -987,12 +1007,14 @@ const extendedMenuItems = computed(() => [
           {
             label: "ZOOM IN",
             onSelect(e) {
+              setMinMaxSelectedZoom(1 / zoom, true);
               e.preventDefault();
             },
           },
           {
             label: "ZOOM OUT",
             onSelect(e) {
+              setMinMaxSelectedZoom(zoom, true);
               e.preventDefault();
             },
           },
@@ -1015,6 +1037,7 @@ const extendedMenuItems = computed(() => [
           {
             label: "SET CURVES TO DEFAULT",
             onSelect(e) {
+              setMinMaxToDefault(true);
               e.preventDefault();
             },
           },
@@ -1034,17 +1057,20 @@ const extendedMenuItems = computed(() => [
                 {
                   label: "At the all time",
                   onSelect(e) {
+                    setMinMaxSelectedToFullRangeDuringAllTime();
                     e.preventDefault();
                   },
                 },
                 {
                   label: "At the window time",
+                  disabled: true,
                   onSelect(e) {
                     e.preventDefault();
                   },
                 },
                 {
                   label: "At the markers time",
+                  disabled: true,
                   onSelect(e) {
                     e.preventDefault();
                   },
@@ -1100,7 +1126,9 @@ function onContextMenu(event, graph, field) {
   currentState.value.graph = graph;
   currentState.value.field = field;
   currentState.value.shiftKey = event.shiftKey;
-  currentState.value.isFieldChecked = currentState.value.graph.fields.map(() => true);
+  if (currentState.value.graph?.fields) {
+    currentState.value.isFieldChecked = currentState.value.graph.fields.map(() => true);
+  }
 }
 
 </script>


### PR DESCRIPTION
The extended MinMax control menu at the charts config dialog box.
Press Shift+Right mouse click at the min-max input fields to show it.

<img width="1319" height="827" alt="ExtendedMenu" src="https://github.com/user-attachments/assets/d0fe4dc4-ecbc-4fc1-9d77-337944bc1ade" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Context menu rebuilt to be state-driven, tracking modifier keys and per-curve checkbox state so menu content and labels update dynamically; dialog now receives current graph context.

* **New Features**
  * Shift-held extended menu shows checkbox submenus for batch operations (min/max, scaling, centering, zoom, full-range).
  * Bulk actions can be scoped to checked curves and honor interval/window selections.

* **Bug Fixes**
  * Multiple bulk-action flows corrected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/blackbox-log-viewer/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->