### PR TITLE
Added high precise mode for the curves min-max values change step

### DIFF
--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -164,7 +164,8 @@
                   <div style="display: contents;" @contextmenu="(e) => onContextMenu(e, graph, field)">
                     <UInputNumber
                       :model-value="field.curve?.MinMax?.min ?? -500"
-                      :step="10"
+                      :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                      :class="{ 'italic': field.curve?.highPrecise }"
                       :format-options="noGrouping"
                       size="xs"
                       orientation="vertical"
@@ -177,10 +178,17 @@
                         resetMin(field);
                         emitUpdate();
                       "
+                      @keydown="(e) => {
+                        if (e.ctrlKey && field.curve) {
+                          e.preventDefault();
+                          field.curve.highPrecise = !field.curve.highPrecise;
+                        }
+                      }"
                     />
                     <UInputNumber
                       :model-value="field.curve?.MinMax?.max ?? 500"
-                      :step="10"
+                      :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                      :class="{ 'italic': field.curve?.highPrecise }"
                       :format-options="noGrouping"
                       size="xs"
                       orientation="vertical"
@@ -193,6 +201,12 @@
                         resetMax(field);
                         emitUpdate();
                       "
+                      @keydown="(e) => {
+                        if (e.ctrlKey && field.curve) {
+                          e.preventDefault();
+                          field.curve.highPrecise = !field.curve.highPrecise;
+                        }
+                      }"
                     />
                   </div>
                 </UContextMenu>
@@ -607,8 +621,31 @@ watch(open, (val) => {
   if (props.graphConfig) {
     localGraphs.value = props.graphConfig.getGraphs().map(cloneGraphToLocal);
     prevConfig.value = convertToConfig();
+    defineFieldsResolution();
   }
 });
+
+// Set curves min-max values changes step. Switch between normal 10 or precesion 0.1 step by using Ctrl key.
+// The precesion value input has italic font.
+
+const normalMinMaxStep = 10;
+const smallMinMaxStep = 0.1;
+
+function defineFieldsResolution() {
+  for (const graph of localGraphs.value) {
+    for (const field of graph.fields) {
+      const min = field?.curve?.MinMax?.min;
+      const max = field?.curve?.MinMax?.max;
+      if (min && max) {
+        field.curve.highPrecise = min % normalMinMaxStep !== 0 || max % normalMinMaxStep !== 0;
+      }
+    }
+  }
+}
+
+// Context menu to manage curves min-max values
+// Right mouse click at min-max input to show simple menu
+// Shift + right mouse click to show extended menu
 
 const currentState = ref({
   graph: null,

--- a/src/components/GraphConfigDialog.vue
+++ b/src/components/GraphConfigDialog.vue
@@ -179,8 +179,7 @@
                         emitUpdate();
                       "
                       @keydown="(e) => {
-                        if (e.ctrlKey && field.curve) {
-                          e.preventDefault();
+                        if (e.key === 'Control' && field.curve) {
                           field.curve.highPrecise = !field.curve.highPrecise;
                         }
                       }"
@@ -202,8 +201,7 @@
                         emitUpdate();
                       "
                       @keydown="(e) => {
-                        if (e.ctrlKey && field.curve) {
-                          e.preventDefault();
+                        if (e.key === 'Control' && field.curve) {
                           field.curve.highPrecise = !field.curve.highPrecise;
                         }
                       }"
@@ -636,7 +634,7 @@ function defineFieldsResolution() {
     for (const field of graph.fields) {
       const min = field?.curve?.MinMax?.min;
       const max = field?.curve?.MinMax?.max;
-      if (min && max) {
+      if (min != null && max != null) {
         field.curve.highPrecise = min % normalMinMaxStep !== 0 || max % normalMinMaxStep !== 0;
       }
     }


### PR DESCRIPTION
The current version has fixed step (10) to change min-max values at the graphs setup page. But the 10 value is not comfortable for some fields, because the all values rounding up to 10.
This PR adds high precise mode for the curves min-max values change step.
Press the Ctrl key on selected Min-Max field input, to switch On/Off this mode
The min-max values change step is 0.1 in the high precise mode. It is possible to input any value.
The high precise input shows italic font.
<img width="1905" height="725" alt="StepForMinMax" src="https://github.com/user-attachments/assets/8a921615-c71a-4758-8fac-cd2be2f10986" />
   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added high-precision mode for curve min/max bounds in the graph configuration dialog.
  * Numeric step switches between coarse and fine increments when high-precision is enabled.
  * High-precision values are detected automatically when non-standard bounds are present.
  * Hold Ctrl while editing min/max to toggle between precision modes; active mode is indicated visually (italic).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/blackbox-log-viewer/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->