### PR TITLE
fix: spectrum analysis crash on long logs (Freq/PSD vs Throttle/RPM)

### DIFF
--- a/src/graph_spectrum_calc.js
+++ b/src/graph_spectrum_calc.js
@@ -123,6 +123,21 @@ GraphSpectrumCalc.setPointsPerSegmentPSD = function (pointsCount) {
 GraphSpectrumCalc.dataLoadPSD = function (_analyserZoomY) {
   const flightSamples = this._getFlightSamplesFreq(false);
   const totalCount = flightSamples.count; // actual samples, not padded length
+  // Guard an empty selected range: getNearPower2Value(0) is 0 and FFTComplex(0) throws,
+  // so short-circuit before the FFT with a valid empty result the caller can render.
+  if (totalCount === 0) {
+    return {
+      fieldIndex: this._dataBuffer.fieldIndex,
+      fieldName: this._dataBuffer.fieldName,
+      fftLength: 0,
+      fftOutput: new Float64Array(0),
+      blackBoxRate: this._blackBoxRate,
+      minimum: 0,
+      maximum: 0,
+      maxNoiseFrequency: 0,
+      maximalSegmentsLength: 0,
+    };
+  }
   const pointsPerSegment = Math.min(this._pointsPerSegmentPSD, totalCount);
   // Non-overlapping when single full-segment; otherwise 75% overlap
   const overlapCount =
@@ -222,9 +237,17 @@ GraphSpectrumCalc._dataLoadFrequencyVsX = function (
       }
       // Translate the average vs value to a bin index
       const avgVsValue = sumVsValues / fftChunkLength;
-      const vsBinIndex = Math.round(
-        ((NUM_VS_BINS - 1) * (avgVsValue - flightSamples.minValue)) /
-          (flightSamples.maxValue - flightSamples.minValue),
+      // Clamp to a valid bin: a degenerate or out-of-range average must never index
+      // outside the matrix (would dereference an undefined row — issue #922).
+      const vsBinIndex = Math.max(
+        0,
+        Math.min(
+          NUM_VS_BINS - 1,
+          Math.round(
+            ((NUM_VS_BINS - 1) * (avgVsValue - flightSamples.minValue)) /
+              (flightSamples.maxValue - flightSamples.minValue),
+          ),
+        ),
       );
       numberSamples[vsBinIndex]++;
 
@@ -321,9 +344,17 @@ GraphSpectrumCalc._dataLoadPowerSpectralDensityVsX = function (
       }
       // Translate the average vs value to a bin index
       const avgVsValue = sumVsValues / fftChunkLength;
-      const vsBinIndex = Math.round(
-        ((NUM_VS_BINS - 1) * (avgVsValue - flightSamples.minValue)) /
-          (flightSamples.maxValue - flightSamples.minValue),
+      // Clamp to a valid bin: a degenerate or out-of-range average must never index
+      // outside the matrix (would dereference an undefined row — issue #922).
+      const vsBinIndex = Math.max(
+        0,
+        Math.min(
+          NUM_VS_BINS - 1,
+          Math.round(
+            ((NUM_VS_BINS - 1) * (avgVsValue - flightSamples.minValue)) /
+              (flightSamples.maxValue - flightSamples.minValue),
+          ),
+        ),
       );
       numberSamples[vsBinIndex]++;
 
@@ -332,6 +363,14 @@ GraphSpectrumCalc._dataLoadPowerSpectralDensityVsX = function (
         matrixPsdOutput[vsBinIndex][i] += psd.psdOutput[i];
       }
     }
+  }
+
+  // Empty selected range: no chunks were processed, so the lazily-created matrix is
+  // still undefined. Return an empty matrix so fftOutput is never undefined.
+  if (matrixPsdOutput === undefined) {
+    matrixPsdOutput = new Array(NUM_VS_BINS)
+      .fill(null)
+      .map(() => new Float64Array(0));
   }
 
   // Divide the values from the fft in each row (vs value bin) by the number of samples in the bin
@@ -459,9 +498,26 @@ GraphSpectrumCalc._getFlightChunks = function () {
 GraphSpectrumCalc._getFlightSamplesFreq = function (scaled = true) {
   const allChunks = this._getFlightChunks();
 
-  const samples = new Float64Array(
-    (MAX_ANALYSER_LENGTH / (1000 * 1000)) * this._blackBoxRate,
-  );
+  // Size the sample buffer from the real number of logged frames in the selected
+  // chunks, not from a _blackBoxRate estimate. The estimate can undershoot the actual
+  // frame count for long logs and silently truncate the FFT input (see issue #922).
+  let frameCount = 0;
+  for (const chunk of allChunks) {
+    frameCount += chunk.frames.length;
+  }
+
+  // The FFT input size is power 2 to get maximal performance
+  // Limit fft input count for simple spectrum chart to get normal charts plot quality
+  let fftBufferSize;
+  if (scaled && frameCount < MIN_SPECTRUM_SAMPLES_COUNT) {
+    fftBufferSize = MIN_SPECTRUM_SAMPLES_COUNT;
+  } else {
+    fftBufferSize = this.getNearPower2Value(frameCount);
+  }
+
+  // Allocate at least fftBufferSize: slice() clamps without zero-padding, so the buffer
+  // must cover the (possibly larger, power-of-2) FFT window for short logs.
+  const samples = new Float64Array(Math.max(frameCount, fftBufferSize));
 
   // Loop through all the samples in the chunks and assign them to a sample array ready to pass to the FFT.
   let samplesCount = 0;
@@ -476,15 +532,6 @@ GraphSpectrumCalc._getFlightSamplesFreq = function (scaled = true) {
       }
       samplesCount++;
     }
-  }
-
-  // The FFT input size is power 2 to get maximal performance
-  // Limit fft input count for simple spectrum chart to get normal charts plot quality
-  let fftBufferSize;
-  if (scaled && samplesCount < MIN_SPECTRUM_SAMPLES_COUNT) {
-    fftBufferSize = MIN_SPECTRUM_SAMPLES_COUNT;
-  } else {
-    fftBufferSize = this.getNearPower2Value(samplesCount);
   }
 
   return {
@@ -512,17 +559,19 @@ GraphSpectrumCalc._getFlightSamplesFreqVsX = function (
   const allChunks = this._getFlightChunks();
   const vsIndexes = this._getVsIndexes(vsFieldNames);
 
-  const samples = new Float64Array(
-    (MAX_ANALYSER_LENGTH / (1000 * 1000)) * this._blackBoxRate,
-  );
+  // Size the buffers from the real number of logged frames in the selected chunks.
+  // A _blackBoxRate estimate can undershoot the actual frame count for long logs,
+  // overflowing the buffers; the out-of-range reads then poisoned minValue/maxValue
+  // with NaN and crashed the binning in _dataLoadFrequencyVsX (issue #922).
+  let frameCount = 0;
+  for (const chunk of allChunks) {
+    frameCount += chunk.frames.length;
+  }
+
+  const samples = new Float64Array(frameCount);
   const vsValues = new Array(vsIndexes.length)
     .fill(null)
-    .map(
-      () =>
-        new Float64Array(
-          (MAX_ANALYSER_LENGTH / (1000 * 1000)) * this._blackBoxRate,
-        ),
-    );
+    .map(() => new Float64Array(frameCount));
 
   let samplesCount = 0;
   for (const chunk of allChunks) {
@@ -586,21 +635,27 @@ GraphSpectrumCalc._getFlightSamplesFreqVsX = function (
     maxValue += ((maxValue - minValue) * RPM_AXIS_TOP_MARGIN_PERCENT) / 100;
   }
 
-  if (minValue > maxValue) {
+  // Reject any non-usable range: non-finite bounds (empty/too-short window leaves the
+  // Infinity/-Infinity defaults, or a buffer overflow would leave NaN) and the
+  // degenerate equal-bounds case (constant VS value → maxValue - minValue === 0 →
+  // divide-by-zero in the bin index). Fall back to a safe 0..100 range.
+  if (
+    !Number.isFinite(minValue) ||
+    !Number.isFinite(maxValue) ||
+    minValue >= maxValue
+  ) {
     if (minValue === Infinity) {
       // this should never happen
-      minValue = 0;
-      maxValue = 100;
       console.warn("Invalid minimum value");
     } else {
       console.warn(
-        "Maximum value %f smaller than minimum value %d",
-        maxValue,
+        "Invalid value range for spectrum binning (min %s, max %s)",
         minValue,
+        maxValue,
       );
-      minValue = 0;
-      maxValue = 100;
     }
+    minValue = 0;
+    maxValue = 100;
   }
 
   const slicedVsValues = [];


### PR DESCRIPTION
# fix: spectrum analysis crash on long logs (Freq/PSD vs Throttle/RPM)

## Summary

Fixes #922 — "Freq. vs Throttle" / "Freq. vs RPM" (and the PSD variants) threw
`TypeError: Cannot read properties of undefined (reading '0')` and failed to open for
long (e.g. 15-minute) logs, while plain Frequency and v3.6.0 worked.

**Root cause:** the spectrum sample buffers in `graph_spectrum_calc.js` were sized from a
`_blackBoxRate` *estimate* (`(MAX_ANALYSER_LENGTH / 1e6) * _blackBoxRate`), but the real
frame count comes from an index-based chunk range that is decoupled from that rate. On a
long log the actual frame count exceeds the estimate, so the per-field `vsValues` buffers
overflow. The out-of-range reads in the min/max pass returned `undefined` → `NaN`, which
poisoned `minValue`/`maxValue`; the existing `minValue > maxValue` guard does not catch
`NaN`, so the bin index became `Math.round(NaN) = NaN` and `matrixFftOutput[NaN][0]` threw.

## Changes (`src/graph_spectrum_calc.js`)

- **Size buffers from the real frame count** (sum of `chunk.frames.length`) instead of the
  rate estimate, in `_getFlightSamplesFreqVsX` and `_getFlightSamplesFreq`. This removes
  the overflow at its source. `_getFlightSamplesFreq` uses `Math.max(frameCount, fftBufferSize)`
  so the `MIN_SPECTRUM_SAMPLES_COUNT` (2048) FFT floor and zero-padding are preserved for
  short logs.
- **NaN-aware range guard:** the degenerate-range fallback now also rejects non-finite
  bounds and the equal-bounds case (`!Number.isFinite(...) || minValue >= maxValue`),
  falling back to a safe `0..100` range. This also covers a constant-VS log
  (`maxValue === minValue`) that would otherwise divide by zero.
- **Clamp the VS bin index** to `[0, NUM_VS_BINS - 1]` in `_dataLoadFrequencyVsX` and
  `_dataLoadPowerSpectralDensityVsX` as a second line of defense against an out-of-range
  matrix-row dereference.
- **Empty-window guards:** early return in `dataLoadPSD` when there are no samples
  (`getNearPower2Value(0)` → `FFTComplex(0)` would throw), and an empty-matrix fallback in
  `_dataLoadPowerSpectralDensityVsX` so `fftOutput` is never `undefined`.

## Test plan

No automated test suite exists for this module (manual testing per the project setup).

- [x] Open the log attached to #922 (`30-05-first-long-flight.zip`); confirm Freq vs
      Throttle, Freq vs RPM, PSD vs Throttle and PSD vs RPM all render with no console error.
- [x] Confirm plain Frequency and Power Spectral Density still render (no regression).
- [x] Confirm short logs (< 5 min) render all spectrum types unchanged.
- [ ] Confirm a constant-throttle window falls back to a `0..100` axis without crashing.
- [ ] Confirm an empty/near-empty selected analyser range does not throw.
- [x] `npm run lint` passes; `prettier --check` clean.

## Notes

- No MSP / protocol / logged-field-definition changes — single-repo, client-side calculation fix.
- Out of scope (follow-up): `_getFlightSamplesPidErrorVsSetpoint` still uses the same
  rate-estimate sizing. It writes by index and slices to the sample count, so it cannot
  crash like the heat-map paths, but it shares the latent undersize and is worth a separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed graph calculation errors preventing crashes when analyzing flight data with edge-case sample ranges.
  * Improved handling of invalid range bounds in frequency analysis with automatic fallback to safe defaults.
  * Enhanced data buffer management to prevent data corruption and calculation errors in spectral analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->