### PR TITLE
Grant deploy jobs the permissions their reusable workflow requires

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -98,6 +98,10 @@ jobs:
   modern_deploy:
     name: Deploy to Maintenance Branch
     needs: [modern_build, prepare_environment]
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: ${{ needs.prepare_environment.outputs.env_name }}
@@ -111,6 +115,10 @@ jobs:
     name: Deploy Latest to Production
     needs: [modern_build, check_latest]
     if: needs.check_latest.outputs.is_latest == 'true'
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: "release"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,10 @@ jobs:
   deploy:
     name: Deploy
     needs: [build, prepare_branch]
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: ${{ needs.prepare_branch.outputs.branch_name }}


### PR DESCRIPTION
After #929 pinned the untrusted `build` job token to `contents: read`, the run's token ceiling became effectively read-only, causing any job that calls `deploy_cloudflare.yml` without its own `permissions` block to fail validation at startup (`startup_failure`):

> The nested job 'deploy' is requesting 'actions: read, deployments: write', but is only allowed 'actions: none, deployments: none'.

`deploy_cloudflare.yml` declares `actions: read` + `deployments: write`, more than the inherited default allows. The build jobs were unaffected because `contents: read` fits under the ceiling.

This grants each affected job its own explicit least-privilege permissions matching what the reusable workflow requires, keeping #929's read-only pin on the untrusted build job intact.

Affected jobs:
- `deploy.yml`: `deploy` (broke the master push in run 29389736379)
- `build_release.yml`: `modern_deploy` and `modern_deploy_latest` (same defect, would fail on the next published release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow permissions to explicitly grant only the minimum required access for build and deployment actions.
  * Limited workflow access to actions/repository contents read permissions and deployments write permission for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->