### PR TITLE
Update debugs after Position Estimate changes in 15584

### DIFF
--- a/src/flightlog_fielddefs.js
+++ b/src/flightlog_fielddefs.js
@@ -550,9 +550,11 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
       MAG_HARDWARE.splice(MAG_HARDWARE.indexOf("LIS3MDL"), 0, "LIS2MDL");
       MAG_HARDWARE.push("IST8310");
     }
+
     if (semver.lt(firmwareVersion, "2025.12.0")) {
       DEBUG_MODE.splice(DEBUG_MODE.indexOf("D_MAX"), 1, "D_MIN");
     }
+
     if (semver.gte(firmwareVersion, "2025.12.0")) {
       ACC_HARDWARE.splice(ACC_HARDWARE.indexOf("ADXL345"), 1);
       ACC_HARDWARE.splice(ACC_HARDWARE.indexOf("MMA8452"), 1);
@@ -588,8 +590,9 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
         "MAVLINK_TELEMETRY",
       );
     }
+
     if (semver.gte(firmwareVersion, "2025.12.0")) {
-      //rename DUAL_GYRO_ to MULTI_GYRO
+      // rename DUAL_GYRO_ to MULTI_GYRO
       DEBUG_MODE.splice(
         DEBUG_MODE.indexOf("DUAL_GYRO_RAW"),
         1,
@@ -606,10 +609,23 @@ export function adjustFieldDefsList(firmwareType, firmwareVersion) {
         "MULTI_GYRO_SCALED",
       );
     }
+
     if (semver.gte(firmwareVersion, "2026.6.0")) {
-      DEBUG_MODE.push("AUTOPILOT_PID");
+      DEBUG_MODE.splice(DEBUG_MODE.indexOf("AUTOPILOT_POSITION"), 1);
+
+      DEBUG_MODE.push(
+        "AUTOPILOT_PID",
+        "POSITION_NAV",
+        "AUTOPILOT_STOP",
+      );
     }
 
+    if (semver.gte(semver.coerce(firmwareVersion), "2026.12.0")) {
+      DEBUG_MODE.push(
+        "PITOT",
+        "POSITION_EST",
+      );
+    }
     ACC_HARDWARE = makeReadOnly(ACC_HARDWARE);
     MAG_HARDWARE = makeReadOnly(MAG_HARDWARE);
     DEBUG_MODE = makeReadOnly(DEBUG_MODE);

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -2901,19 +2901,15 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
         return value; // " °C";
       case "ALTITUDE":
         if (semver.gte(flightLog.getSysConfig().firmwareVersion, "2026.6.0")) {
-          switch (fieldName) {
-            case "debug[0]": // RangeFinder Altitude cm
-            case "debug[1]": // Baro Altitude cm
-            case "debug[2]": // GPS Altitude cm
-            case "debug[3]": // Kalman Altitude cm
-            case "debug[4]": // GPS Velocity
-            case "debug[5]": // Kalman Velocity
-            case "debug[6]": // Accelerometer
-            case "debug[7]": // Kalman Acceleration
-              return toFriendly ? value / 100 : value * 100;
-            default:
-              return value;
-          }
+          // debug[0] = RangeFinder Altitude cm
+          // debug[1] = Baro Altitude cm
+          // debug[2] = GPS Altitude cm
+          // debug[3] = Kalman Altitude cm
+          // debug[4] = GPS Velocity
+          // debug[5] = Kalman Velocity
+          // debug[6] = Accelerometer
+          // debug[7] = Kalman Acceleration
+          return toFriendly ? value / 100 : value * 100;
         } else {
           switch (fieldName) {
             case "debug[0]": // GPS Trust * 100
@@ -2935,39 +2931,42 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
           case "debug[4]": // Vel North
           case "debug[5]": // Raw Acceleration
             return toFriendly ? value / 100 : value * 100;
-          case "debug[6]": // GPS R Pos
-          case "debug[7]": // GPS R Vel
+          // debug[6] = GPS R Pos
+          // debug[7] = GPS R Vel
           default:
             return value;
         }
+
       case "AUTOPILOT_PID":
         switch (fieldName) {
           case "debug[0]": // Velocity
           case "debug[1]": // DistanceError
             return toFriendly ? value / 100 : value * 100;
-          case "debug[2]": // P
-          case "debug[3]": // I
-          case "debug[4]": // D
-          case "debug[5]": // A
-          case "debug[6]": // F
-          case "debug[7]": // Status
+          // debug[2] = P
+          // debug[3] = I
+          // debug[4] = D
+          // debug[5] = A
+          // debug[6] = F
+          // debug[7] = Status
           default:
             return value;
         }
+
       case "AUTOPILOT_ALTITUDE":
         switch (fieldName) {
           case "debug[1]": // Target Altitude
           case "debug[2]": // Current Altitude
             return toFriendly ? value / 100 : value * 100;
-          case "debug[3]": // P
-          case "debug[4]": // I
-          case "debug[5]": // D
-          case "debug[6]": // A
-          case "debug[7]": // F
-          case "debug[0]": // NewThrottle
+          // debug[0] = NewThrottle
+          // debug[3] = P
+          // debug[4] = I
+          // debug[5] = D
+          // debug[6] = A
+          // debug[7] = F
           default:
             return value;
         }
+
       case "AUTOPILOT_STOP":
         switch (fieldName) {
           case "debug[0]": // VelocityErrorEast
@@ -2976,10 +2975,10 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
           case "debug[4]": // AngleRoll
           case "debug[5]": // AnglePitch
             return toFriendly ? value / 10 : value * 10;
-          case "debug[2]": // PidSumEast
-          case "debug[3]": // PidSumNorth
-          case "debug[6]": // Status
-          case "debug[7]": // Status
+          // debug[2] = PidSumEast
+          // debug[3] = PidSumNorth
+          // debug[6] = Status
+          // debug[7] = Status
           default:
             return value;
         }
@@ -3242,27 +3241,21 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
             return value;
         }
       case "ATTITUDE":
-        switch (fieldName) {
-          case "debug[0]": // Roll Angle
-          case "debug[1]": // Pitch Angle
-          case "debug[2]": // Ground speed factor
-          case "debug[3]": // Heading error
-          case "debug[4]": // Velocity to home
-          case "debug[5]": // Ground speed error ratio
-          case "debug[6]": // Pitch forward angle
-          case "debug[7]": // dcmKp gain
-          default:
-            return value;
-        }
+        // debug[0] = Roll Angle
+        // debug[1] = Pitch Angle
+        // debug[2] = Ground speed factor
+        // debug[3] = Heading error
+        // debug[4] = Velocity to home
+        // debug[5] = Ground speed error ratio
+        // debug[6] = Pitch forward angle
+        // debug[7] = dcmKp gain
+        return value;
       case "VTX_MSP":
-        switch (fieldName) {
-          case "debug[0]": // packetCounter
-          case "debug[1]": // isCrsfPortConfig
-          case "debug[2]": // isLowPowerDisarmed
-          case "debug[3]": // mspTelemetryDescriptor
-          default:
-            return value;
-        }
+        // debug[0] = packetCounter
+        // debug[1] = isCrsfPortConfig
+        // debug[2] = isLowPowerDisarmed
+        // debug[3] = mspTelemetryDescriptor
+        return value;
       case "GPS_DOP":
         switch (fieldName) {
           case "debug[0]": // Number of Satellites

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1550,7 +1550,7 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[all]": "Autopilot Nav",
         "debug[0]": "Target Velocity",
         "debug[1]": "Velocity",
-        "debug[2]": "VelocityError",
+        "debug[2]": "Velocity Error",
         "debug[3]": "P",
         "debug[4]": "I",
         "debug[5]": "D",
@@ -1566,7 +1566,7 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[4]": "Roll Angle",
         "debug[5]": "Pitch Angle",
         "debug[6]": "Status",
-        "debug[7]": "Status", // unused
+        "debug[7]": "-", // unused
       };
     DEBUG_FRIENDLY_FIELD_NAMES.PITOT = {
         "debug[all]": "Pitot",

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1533,13 +1533,13 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[4]": "Alt I",
         "debug[5]": "Alt D",
         "debug[6]": "Alt A",
-        "debug[7]": "AltF",
+        "debug[7]": "Alt F",
       };
     DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_PID = {
         "debug[all]": "Autopilot PID",
         "debug[0]": "XY Velocity",
         "debug[1]": "XY Distance Error",
-        "debug[2]": " P",
+        "debug[2]": "P",
         "debug[3]": "I",
         "debug[4]": "D",
         "debug[5]": "A",
@@ -1550,7 +1550,7 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[all]": "Autopilot Nav",
         "debug[0]": "Target Velocity",
         "debug[1]": "Velocity",
-        "debug[2]": " VelocityError",
+        "debug[2]": "VelocityError",
         "debug[3]": "P",
         "debug[4]": "I",
         "debug[5]": "D",
@@ -1558,10 +1558,10 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "Status",
       };
     DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_STOP = {
-        "debug[all]": " Autopilot Stop",
+        "debug[all]": "Autopilot Stop",
         "debug[0]": "East Vel Error",
         "debug[1]": "North Vel Error",
-        "debug[2]": " East PIDsum",
+        "debug[2]": "East PIDsum",
         "debug[3]": "North PIDsum",
         "debug[4]": "Roll Angle",
         "debug[5]": "Pitch Angle",
@@ -1569,10 +1569,10 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "Status", // unused
       };
     DEBUG_FRIENDLY_FIELD_NAMES.PITOT = {
-        "debug[all]": " Pitot",
+        "debug[all]": "Pitot",
         "debug[0]": "Airspeed",
         "debug[1]": "Diff Pressure",
-        "debug[2]": " Pressure Pa",
+        "debug[2]": "Pressure Pa",
         "debug[3]": "Temperature",
         "debug[4]": "-", // unused
         "debug[5]": "-", // unused
@@ -1580,10 +1580,10 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[7]": "-", // unused
       };
     DEBUG_FRIENDLY_FIELD_NAMES.POSITION_EST = {
-        "debug[all]": " Position Estimate",
+        "debug[all]": "Position Estimate",
         "debug[0]": "Position",
         "debug[1]": "Velocity",
-        "debug[2]": " Acceleration",
+        "debug[2]": "Acceleration",
         "debug[3]": "velEast", // temporary
         "debug[4]": "velNorth", // temporary
         "debug[5]": "AccelRaw", // temporary
@@ -2066,6 +2066,12 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
             case "debug[2]": // GPS Altitude cm
             case "debug[3]": // Kalman Altitude cm
               return `${(value / 100).toFixed(2)} m`;
+            case "debug[4]": // GPS Velocity
+            case "debug[5]": // Kalman Velocity
+              return `${(value / 100).toFixed(2)} m/s`;
+            case "debug[6]": // Accelerometer
+            case "debug[7]": // Kalman Acceleration
+              return `${(value / 100).toFixed(2)} m/s/s`;
             default:
               return value.toFixed(0);
           }
@@ -2080,6 +2086,7 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
             default:
               return value.toFixed(0);
           }
+        }
 
       case "POSITION_EST":
         switch (fieldName) {
@@ -2899,11 +2906,11 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
             case "debug[1]": // Baro Altitude cm
             case "debug[2]": // GPS Altitude cm
             case "debug[3]": // Kalman Altitude cm
-              return toFriendly ? value / 100 : value * 100;
             case "debug[4]": // GPS Velocity
             case "debug[5]": // Kalman Velocity
             case "debug[6]": // Accelerometer
             case "debug[7]": // Kalman Acceleration
+              return toFriendly ? value / 100 : value * 100;
             default:
               return value;
           }

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -3195,37 +3195,34 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
         switch (fieldName) {
           case "debug[0]": // Pitch P degrees * 100
           case "debug[1]": // Pitch D degrees * 100
-            return toFriendly ? value / 100 : value * 100; // °
           case "debug[2]": // velocity to home cm/s
           case "debug[3]": // velocity target cm/s
-            return toFriendly ? value / 100 : value * 100; // m/s
+            return toFriendly ? value / 100 : value * 100;
           default:
             return value;
         }
       case "GPS_RESCUE_HEADING":
         switch (fieldName) {
           case "debug[0]": // Ground speed cm/s
+          case "debug[6]": // Roll Added deg * 100
             return toFriendly ? value / 100 : value * 100; // m/s
           case "debug[1]": // GPS Ground course degrees * 10
           case "debug[2]": // Attitude in degrees * 10
           case "debug[3]": // Angle to home in degrees * 10
           case "debug[4]": // magYaw in degrees * 10
             return toFriendly ? value / 10 : value * 10; //°
-          case "debug[6]": // Roll Added deg * 100
-            return toFriendly ? value / 100 : value * 100; // °
           case "debug[5]": // Roll Mix Att
           case "debug[7]": // Rescue Yaw Rate
           default:
             return value;
         }
-      case "GPS_RESCUE_TRACKING":
+      case "    ":
         switch (fieldName) {
           case "debug[0]": // velocity to home cm/s
           case "debug[1]": // velocity target cm/s
-            return toFriendly ? value / 100 : value * 100; // m/s
           case "debug[2]": // altitude cm
           case "debug[3]": // altitude target cm
-            return toFriendly ? value / 100 : value * 100;
+            return toFriendly ? value / 100 : value * 100; // m/s
           default:
             return value;
         }

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1512,6 +1512,85 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         ...DEBUG_FRIENDLY_FIELD_NAMES.GYRO_SAMPLE,
         "debug[4]": "Avg System Load %",
       };
+
+      DEBUG_FRIENDLY_FIELD_NAMES.ALTITUDE = {
+        "debug[all]": "Altitude",
+        "debug[0]": "RangeFinder Altitude",
+        "debug[1]": "Baro Altitude",
+        "debug[2]": "GPS Altitude",
+        "debug[3]": "Kalman Altitude",
+        "debug[4]": "GPS Velocity",
+        "debug[5]": "Kalman Velocity",
+        "debug[6]": "Accelerometer",
+        "debug[7]": "Kalman Acceleration",
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_ALTITUDE = {
+        "debug[all]": "Autopilot Altitude",
+        "debug[0]": "newThrottle",
+        "debug[1]": "Target Altitude",
+        "debug[2]": "Current Altitude",
+        "debug[3]": "Alt P",
+        "debug[4]": "Alt I",
+        "debug[5]": "Alt D",
+        "debug[6]": "Alt A",
+        "debug[7]": "AltF",
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_PID = {
+        "debug[all]": "Autopilot PID",
+        "debug[0]": "XY Velocity",
+        "debug[1]": "XY Distance Error",
+        "debug[2]": " P",
+        "debug[3]": "I",
+        "debug[4]": "D",
+        "debug[5]": "A",
+        "debug[6]": "F",
+        "debug[7]": "Status",
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_NAV = {
+        "debug[all]": "Autopilot Nav",
+        "debug[0]": "Target Velocity",
+        "debug[1]": "Velocity",
+        "debug[2]": " VelocityError",
+        "debug[3]": "P",
+        "debug[4]": "I",
+        "debug[5]": "D",
+        "debug[6]": "A",
+        "debug[7]": "Status",
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_STOP = {
+        "debug[all]": " Autopilot Stop",
+        "debug[0]": "East Vel Error",
+        "debug[1]": "North Vel Error",
+        "debug[2]": " East PIDsum",
+        "debug[3]": "North PIDsum",
+        "debug[4]": "Roll Angle",
+        "debug[5]": "Pitch Angle",
+        "debug[6]": "Status",
+        "debug[7]": "Status", // unused
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.PITOT = {
+        "debug[all]": " Pitot",
+        "debug[0]": "Airspeed",
+        "debug[1]": "Diff Pressure",
+        "debug[2]": " Pressure Pa",
+        "debug[3]": "Temperature",
+        "debug[4]": "-", // unused
+        "debug[5]": "-", // unused
+        "debug[6]": "-", // unused
+        "debug[7]": "-", // unused
+      };
+    DEBUG_FRIENDLY_FIELD_NAMES.POSITION_EST = {
+        "debug[all]": " Position Estimate",
+        "debug[0]": "Position",
+        "debug[1]": "Velocity",
+        "debug[2]": " Acceleration",
+        "debug[3]": "velEast", // temporary
+        "debug[4]": "velNorth", // temporary
+        "debug[5]": "AccelRaw", // temporary
+        "debug[6]": "RGpsPos", // temporary
+        "debug[7]": "RGpsVel", // temporary
+      };
+
     }
   }
 };
@@ -1980,13 +2059,85 @@ FlightLogFieldPresenter.decodeDebugFieldToFriendly = function (
       case "ESC_SENSOR_TMP":
         return `${value.toFixed(0)} °C`;
       case "ALTITUDE":
+        if (semver.gte(flightLog.getSysConfig().firmwareVersion, "2026.6.0")) {
+          switch (fieldName) {
+            case "debug[0]": // RangeFinder Altitude cm
+            case "debug[1]": // Baro Altitude cm
+            case "debug[2]": // GPS Altitude cm
+            case "debug[3]": // Kalman Altitude cm
+              return `${(value / 100).toFixed(2)} m`;
+            default:
+              return value.toFixed(0);
+          }
+        } else {
+          switch (fieldName) {
+            case "debug[0]": // GPS Trust * 100
+              return value.toFixed(0);
+            case "debug[1]": // GPS Altitude cm
+            case "debug[2]": // OSD Altitude cm
+            case "debug[3]": // Control Altitude cm
+              return `${(value / 100).toFixed(2)} m`;
+            default:
+              return value.toFixed(0);
+          }
+
+      case "POSITION_EST":
         switch (fieldName) {
-          case "debug[0]": // GPS Trust * 100
-            return value.toFixed(0);
-          case "debug[1]": // GPS Altitude cm
-          case "debug[2]": // OSD Altitude cm
-          case "debug[3]": // Control Altitude
+          case "debug[0]": // Position (dist to home)
             return `${(value / 100).toFixed(2)} m`;
+          case "debug[1]": // Velocity
+          case "debug[3]": // Vel East
+          case "debug[4]": // Vel North
+            return `${(value / 100).toFixed(2)} m/s`;
+          case "debug[2]": // Kal Acceleration
+          case "debug[5]": // Raw Acceleration
+            return `${(value / 100).toFixed(2)} m/s/s`;
+          case "debug[6]": // GPS R Pos
+          case "debug[7]": // GPS R Vel
+          default:
+            return value.toFixed(0);
+        }
+      case "AUTOPILOT_PID":
+        switch (fieldName) {
+          case "debug[0]": // Velocity
+            return `${(value / 100).toFixed(2)} m/s`;
+          case "debug[1]": // DistanceError
+            return `${(value / 100).toFixed(2)} m`;
+          case "debug[2]": // P
+          case "debug[3]": // I
+          case "debug[4]": // D
+          case "debug[5]": // A
+          case "debug[6]": // F
+          case "debug[7]": // Status
+          default:
+            return value.toFixed(0);
+        }
+      case "AUTOPILOT_ALTITUDE":
+        switch (fieldName) {
+          case "debug[1]": // Target Altitude
+          case "debug[2]": // Current Altitude
+            return `${(value / 100).toFixed(2)} m`;
+          case "debug[3]": // P
+          case "debug[4]": // I
+          case "debug[5]": // D
+          case "debug[6]": // A
+          case "debug[7]": // F
+          case "debug[0]": // NewThrottle
+          default:
+            return value.toFixed(0);
+        }
+    case "AUTOPILOT_STOP":
+        switch (fieldName) {
+          case "debug[0]": // VelocityErrorEast
+          case "debug[1]": // VelocityErrorNorth
+            return `${(value / 100).toFixed(2)} m/s`;
+          case "debug[4]": // AngleRoll
+          case "debug[5]": // AnglePitch
+            return `${(value / 10).toFixed(1)} deg`;
+          case "debug[2]": // PidSumEast
+          case "debug[3]": // PidSumNorth
+          case "debug[6]": // Status
+          case "debug[7]": // Status
           default:
             return value.toFixed(0);
         }
@@ -2742,13 +2893,86 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
       case "ESC_SENSOR_TMP":
         return value; // " °C";
       case "ALTITUDE":
+        if (semver.gte(flightLog.getSysConfig().firmwareVersion, "2026.6.0")) {
+          switch (fieldName) {
+            case "debug[0]": // RangeFinder Altitude cm
+            case "debug[1]": // Baro Altitude cm
+            case "debug[2]": // GPS Altitude cm
+            case "debug[3]": // Kalman Altitude cm
+              return toFriendly ? value / 100 : value * 100;
+            case "debug[4]": // GPS Velocity
+            case "debug[5]": // Kalman Velocity
+            case "debug[6]": // Accelerometer
+            case "debug[7]": // Kalman Acceleration
+            default:
+              return value;
+          }
+        } else {
+          switch (fieldName) {
+            case "debug[0]": // GPS Trust * 100
+              return value;
+            case "debug[1]": // GPS Altitude cm
+            case "debug[2]": // OSD Altitude cm
+            case "debug[3]": // Control Altitude
+              return toFriendly ? value / 100 : value * 100;
+            default:
+              return value;
+          }
+        }
+      case "POSITION_EST":
         switch (fieldName) {
-          case "debug[0]": // GPS Trust * 100
+          case "debug[0]": // Position (dist to home)
+          case "debug[1]": // Velocity
+          case "debug[2]": // Kal Acceleration
+          case "debug[3]": // Vel East
+          case "debug[4]": // Vel North
+          case "debug[5]": // Raw Acceleration
+            return toFriendly ? value / 100 : value * 100;
+          case "debug[6]": // GPS R Pos
+          case "debug[7]": // GPS R Vel
+          default:
             return value;
-          case "debug[1]": // GPS Altitude cm
-          case "debug[2]": // OSD Altitude cm
-          case "debug[3]": // Control Altitude
-            return toFriendly ? value / 100 : value * 100; //  m
+        }
+      case "AUTOPILOT_PID":
+        switch (fieldName) {
+          case "debug[0]": // Velocity
+          case "debug[1]": // DistanceError
+            return toFriendly ? value / 100 : value * 100;
+          case "debug[2]": // P
+          case "debug[3]": // I
+          case "debug[4]": // D
+          case "debug[5]": // A
+          case "debug[6]": // F
+          case "debug[7]": // Status
+          default:
+            return value;
+        }
+      case "AUTOPILOT_ALTITUDE":
+        switch (fieldName) {
+          case "debug[1]": // Target Altitude
+          case "debug[2]": // Current Altitude
+            return toFriendly ? value / 100 : value * 100;
+          case "debug[3]": // P
+          case "debug[4]": // I
+          case "debug[5]": // D
+          case "debug[6]": // A
+          case "debug[7]": // F
+          case "debug[0]": // NewThrottle
+          default:
+            return value;
+        }
+      case "AUTOPILOT_STOP":
+        switch (fieldName) {
+          case "debug[0]": // VelocityErrorEast
+          case "debug[1]": // VelocityErrorNorth
+            return toFriendly ? value / 100 : value * 100;
+          case "debug[4]": // AngleRoll
+          case "debug[5]": // AnglePitch
+            return toFriendly ? value / 10 : value * 10;
+          case "debug[2]": // PidSumEast
+          case "debug[3]": // PidSumNorth
+          case "debug[6]": // Status
+          case "debug[7]": // Status
           default:
             return value;
         }

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -1539,11 +1539,11 @@ FlightLogFieldPresenter.adjustDebugDefsList = function (
         "debug[all]": "Autopilot PID",
         "debug[0]": "XY Velocity",
         "debug[1]": "XY Distance Error",
-        "debug[2]": "P",
-        "debug[3]": "I",
-        "debug[4]": "D",
-        "debug[5]": "A",
-        "debug[6]": "F",
+        "debug[2]": "XY P",
+        "debug[3]": "XY I",
+        "debug[4]": "XY D",
+        "debug[5]": "XY A",
+        "debug[6]": "XY F",
         "debug[7]": "Status",
       };
     DEBUG_FRIENDLY_FIELD_NAMES.AUTOPILOT_NAV = {

--- a/src/flightlog_fields_presenter.js
+++ b/src/flightlog_fields_presenter.js
@@ -3215,7 +3215,7 @@ FlightLogFieldPresenter.ConvertDebugFieldValue = function (
           default:
             return value;
         }
-      case "    ":
+      case "GPS_RESCUE_TRACKING":
         switch (fieldName) {
           case "debug[0]": // velocity to home cm/s
           case "debug[1]": // velocity target cm/s

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1103,12 +1103,12 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           }
         case "GPS_RESCUE_HEADING":
           switch (fieldName) {
-            case "debug[0]": // Groundspeed cm/s
+            case "debug[0]": // Groundspeed
               return {
                 power: 1,
                 MinMax: {
-                  min: -100,
-                  max: 100,
+                  min: -20, // 20 m/s range
+                  max: 20,
                 },
               };
             case "debug[1]": // GPS GroundCourse
@@ -1119,31 +1119,23 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                 power: 1,
                 MinMax: {
                   min: 0,
-                  max: 360,
+                  max: 360, // degrees
                 },
               };
-            case "debug[7]": // RescueYawRate
+            case "debug[6]": // roll angle deg
               return {
                 power: 1,
                 MinMax: {
-                  min: -20,
-                  max: 20,
-                },
-              };
-            case "debug[6]": // roll angle *100
-              return {
-                power: 1,
-                MinMax: {
-                  min: 0,
-                  max: 180,
+                  min: -5,
+                  max: 5,
                 },
               };
             case "debug[7]": // yaw rate deg/s
               return {
                 power: 1,
                 MinMax: {
-                  min: 0,
-                  max: 200,
+                  min: -100, // just the value sent
+                  max: 100,
                 },
               };
             default:

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1,3 +1,4 @@
+import semver from "semver";
 import { FlightLogFieldPresenter } from "./flightlog_fields_presenter";
 import { RATES_TYPE, DEBUG_MODE } from "./flightlog_fielddefs";
 import { escapeRegExp } from "./tools";

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -571,29 +571,35 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           };
         case "ALTITUDE":
           switch (fieldName) {
-            case "debug[0]": // GPS Trust
-              return {
-                power: 1,
-                MinMax: {
-                  min: -200,
-                  max: 200,
-                },
-              };
+            case "debug[0]": // GPS Trust / RangeFinderAlt
             case "debug[1]": // Baro Alt
             case "debug[2]": // GPS Alt
+            case "debug[3]": // Kalman Alt
+
               return {
                 power: 1,
                 MinMax: {
-                  min: -50,
-                  max: 50,
+                  min: -100,
+                  max: 100,
                 },
               };
-            case "debug[3]": // vario
+ 
+            case "debug[4]": // GPS Vel Up
+            case "debug[5]": // Kalman Vel Up
               return {
                 power: 1,
                 MinMax: {
-                  min: -5,
-                  max: 5,
+                  min: -500,
+                  max: 500,
+                },
+              };
+            case "debug[6]": // AccelerometerUp
+            case "debug7]": // Kalman Accel Up
+              return {
+                power: 1,
+                MinMax: {
+                  min: -500,
+                  max: 500,
                 },
               };
             default:
@@ -809,7 +815,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                 power: 1,
                 MinMax: {
                   min: 0,
-                  max: 1200,
+                  max: 1000,
                 },
               };
             default:
@@ -1062,24 +1068,19 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           }
         case "GPS_RESCUE_VELOCITY":
           switch (fieldName) {
-            case "debug[0]": // Pitch P deg * 100
-            case "debug[1]": // Pitch D deg * 100
+            case "debug[0]": // TargetVelocity
+            case "debug[1]": // Velocity
+            case "debug[2]": // Step East *100
+            case "debug[3]": // Step North*100
               return {
                 power: 1,
                 MinMax: {
-                  min: -20,
-                  max: 20,
+                  min: -1000,
+                  max: 1000,
                 },
               };
-            case "debug[2]": // Velocity in cm/s
-            case "debug[3]": // Velocity to home in cm/s
-              return {
-                power: 1,
-                MinMax: {
-                  min: -5,
-                  max: 5,
-                },
-              };
+              case "debug[4]": // Phase
+              case "debug[5]": // Distance to home cm
             default:
               return getCurveForMinMaxFields(fieldName);
           }
@@ -1104,11 +1105,11 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                   max: 360,
                 },
               };
-            case "debug[5]": // magYaw * 10
+            case "debug[7]": // RescueYawRate
               return {
                 power: 1,
                 MinMax: {
-                  min: 0,
+                  min: -20,
                   max: 20,
                 },
               };
@@ -1165,20 +1166,22 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           switch (fieldName) {
             case "debug[0]": // velocity to home cm/s
             case "debug[1]": // target velocity cm/s
+            case "debug[2]": // altitude cm
+            case "debug[3]": // Target altitude cm
               return {
                 power: 1,
                 MinMax: {
-                  min: -10,
-                  max: 10,
+                  min: -1000,
+                  max: 10000,
                 },
               };
-            case "debug[2]": // altitude m
-            case "debug[3]": // Target altitude m
+            case "debug[4]": // Heading
+            case "debug[5]": // Bearing
               return {
                 power: 1,
                 MinMax: {
-                  min: -50,
-                  max: 50,
+                  min: 0,
+                  max: 360,
                 },
               };
             default:
@@ -1428,6 +1431,104 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                 MinMax: {
                   min: 0,
                   max: 100,
+                },
+              };
+            default:
+              return getCurveForMinMaxFields(fieldName);
+          }
+
+        case "AUTOPILOT_ALTITUDE":
+          switch (fieldName) {
+            case "debug[0]": // new throttle
+            case "debug[1]": // TargetAltitude
+            case "debug[2]": // CurrentAltitude
+            case "debug[3]": // P
+            case "debug[4]": // I
+            case "debug[5]": // D
+            case "debug[6]": // A
+            case "debug[7]": // F
+              return {
+                power: 1,
+                MinMax: {
+                  min: -500,
+                  max: 500,
+                },
+              };
+            default:
+              return getCurveForMinMaxFields(fieldName);
+          }
+
+        case "POSITION_EST":
+          switch (fieldName) {
+            case "debug[0]": // Position
+            case "debug[1]": // Velocity
+            case "debug[2]": // Acceleration
+            case "debug[3]": // Vel East
+            case "debug[4]": // Vel North
+            case "debug[5]": // Raw Accelerometer
+            case "debug[6]": // R GPSPos
+            case "debug[7]": // R GPSVel
+              return {
+                power: 1,
+                MinMax: {
+                  min: -500,
+                  max: 500,
+                },
+              };
+            default:
+              return getCurveForMinMaxFields(fieldName);
+          }
+
+        case "AUTOPILOT_STOP":
+          switch (fieldName) {
+            case "debug[0]": // VelErr East
+            case "debug[1]": // VelErr North
+            case "debug[2]": // PidSum East
+            case "debug[3]": // PidSum North
+            case "debug[4]": // Angle Roll
+            case "debug[5]": // Angle Pitch
+              return {
+                power: 1,
+                MinMax: {
+                  min: -500,
+                  max: 500,
+                },
+              };
+            case "debug[6]": // Status, one sided 0-250
+            case "debug[7]": // Status, one sided 0-250
+              return {
+                power: 1,
+                MinMax: {
+                  min: 0,
+                  max: 500,
+                },
+              };
+            default:
+              return getCurveForMinMaxFields(fieldName);
+          }
+
+        case "AUTOPILOT_PID":
+          switch (fieldName) {
+            case "debug[0]": // XY Velocity
+            case "debug[1]": // Distance Error
+            case "debug[2]": // P
+            case "debug[3]": // I
+            case "debug[4]": // D
+            case "debug[5]": // A
+            case "debug[6]": // F
+              return {
+                power: 1,
+                MinMax: {
+                  min: -500,
+                  max: 500,
+                },
+              };
+            case "debug[7]": // Status, one sided 0-250
+              return {
+                power: 1,
+                MinMax: {
+                  min: 0,
+                  max: 500,
                 },
               };
             default:

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -570,24 +570,56 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
             },
           };
         case "ALTITUDE":
-          switch (fieldName) {
-            case "debug[0]": // GPS Trust / RangeFinderAlt
-            case "debug[1]": // Baro Alt
-            case "debug[2]": // GPS Alt
-            case "debug[3]": // Kalman Alt
-            case "debug[4]": // GPS Vel Up
-            case "debug[5]": // Kalman Vel Up
-            case "debug[6]": // AccelerometerUp
-            case "debug[7]": // Kalman Accel Up
-              return {
-                power: 1,
-                MinMax: {
-                  min: -5,
-                  max: 5,
-                },
-              };
-            default:
-              return getCurveForMinMaxFields(fieldName);
+          if (semver.gte(flightLog.getSysConfig().firmwareVersion, "2026.6.0")) {
+            switch (fieldName) {
+              case "debug[0]": // RangeFinder Alt
+              case "debug[1]": // Baro Alt
+              case "debug[2]": // GPS Alt
+              case "debug[3]": // Kalman Alt
+              case "debug[4]": // GPS Vel Up
+              case "debug[5]": // Kalman Vel Up
+              case "debug[6]": // Accelerometer Up
+              case "debug[7]": // Kalman Accel Up
+                return {
+                  power: 1,
+                  MinMax: {
+                    min: -5,
+                    max: 5,
+                  },
+                };
+              default:
+                return getCurveForMinMaxFields(fieldName);
+            }
+          } else {
+            switch (fieldName) {
+              case "debug[0]": // GPS Trust
+                return {
+                  power: 1,
+                  MinMax: {
+                    min: -200,
+                    max: 200,
+                  },
+                };
+              case "debug[1]": // Baro Alt
+              case "debug[2]": // GPS Alt
+                return {
+                  power: 1,
+                  MinMax: {
+                    min: -50,
+                    max: 50,
+                  },
+                };
+              case "debug[3]": // Vario
+                return {
+                  power: 1,
+                  MinMax: {
+                    min: -5,
+                    max: 5,
+                  },
+                };
+              default:
+                return getCurveForMinMaxFields(fieldName);
+            }
           }
         case "FFT":
           switch (fieldName) {

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -575,31 +575,15 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
             case "debug[1]": // Baro Alt
             case "debug[2]": // GPS Alt
             case "debug[3]": // Kalman Alt
-
-              return {
-                power: 1,
-                MinMax: {
-                  min: -100,
-                  max: 100,
-                },
-              };
- 
             case "debug[4]": // GPS Vel Up
             case "debug[5]": // Kalman Vel Up
-              return {
-                power: 1,
-                MinMax: {
-                  min: -500,
-                  max: 500,
-                },
-              };
             case "debug[6]": // AccelerometerUp
-            case "debug7]": // Kalman Accel Up
+            case "debug[7]": // Kalman Accel Up
               return {
                 power: 1,
                 MinMax: {
-                  min: -500,
-                  max: 500,
+                  min: -5,
+                  max: 5,
                 },
               };
             default:
@@ -1171,8 +1155,8 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
               return {
                 power: 1,
                 MinMax: {
-                  min: -1000,
-                  max: 10000,
+                  min: -10,
+                  max: 10,
                 },
               };
             case "debug[4]": // Heading
@@ -1439,9 +1423,23 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
 
         case "AUTOPILOT_ALTITUDE":
           switch (fieldName) {
-            case "debug[0]": // new throttle
             case "debug[1]": // TargetAltitude
             case "debug[2]": // CurrentAltitude
+              return {
+                power: 1,
+                MinMax: {
+                  min: -10,
+                  max: 10,
+                },
+              };
+            case "debug[0]": // new throttle
+              return {
+                power: 1,
+                MinMax: {
+                  min: 1000,
+                  max: 2000,
+                },
+              };
             case "debug[3]": // P
             case "debug[4]": // I
             case "debug[5]": // D
@@ -1466,13 +1464,20 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
             case "debug[3]": // Vel East
             case "debug[4]": // Vel North
             case "debug[5]": // Raw Accelerometer
+              return {
+                power: 1,
+                MinMax: {
+                  min: -10,
+                  max: 10,
+                },
+              };
             case "debug[6]": // R GPSPos
             case "debug[7]": // R GPSVel
               return {
                 power: 1,
                 MinMax: {
-                  min: -500,
-                  max: 500,
+                  min:0,
+                  max: 1000,
                 },
               };
             default:
@@ -1483,6 +1488,12 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           switch (fieldName) {
             case "debug[0]": // VelErr East
             case "debug[1]": // VelErr North
+                power: 1,
+                MinMax: {
+                  min: -5,
+                  max: 5,
+                },
+              };
             case "debug[2]": // PidSum East
             case "debug[3]": // PidSum North
             case "debug[4]": // Angle Roll
@@ -1511,6 +1522,13 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           switch (fieldName) {
             case "debug[0]": // XY Velocity
             case "debug[1]": // Distance Error
+              return {
+                power: 1,
+                MinMax: {
+                  min: -10,
+                  max: 10,
+                },
+              };
             case "debug[2]": // P
             case "debug[3]": // I
             case "debug[4]": // D

--- a/src/graph_config.js
+++ b/src/graph_config.js
@@ -1488,6 +1488,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
           switch (fieldName) {
             case "debug[0]": // VelErr East
             case "debug[1]": // VelErr North
+              return {
                 power: 1,
                 MinMax: {
                   min: -5,


### PR DESCRIPTION
Synchonises labels and graphs for the debugs associated with Kalman update  #15584

Makes it much easier to interpret those logs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for BetaFlight 2026.6+ debug fields, including altitude, autopilot, pitot, position estimation, navigation, and GPS rescue telemetry.
  * Added firmware-specific formatting, unit conversions, labels, and graph scaling for newly supported fields.
  * Added support for additional pitot and position-estimation fields in BetaFlight 2026.12+.

* **Bug Fixes**
  * Corrected debug labels, altitude layouts, velocity and acceleration conversions, and graph ranges.
  * Preserved compatibility with legacy firmware mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->